### PR TITLE
Fix bug where current edit was removed when editor component moved ou…

### DIFF
--- a/src/BlazorDatasheet.Server/Pages/Index.razor
+++ b/src/BlazorDatasheet.Server/Pages/Index.razor
@@ -29,12 +29,22 @@ Welcome to your new app.
             new Person() { Id = 1, Age = 49, FirstName = "Albert", LastName = "Rogers" },
             new Person() { Id = 2, Age = 106, FirstName = "Wendall", LastName = "Palmer" },
         };
-        
+
         var random = new Random();
-        for (int i = 0; i < 10000; i++)
+        for (int i = 0; i < 100; i++)
         {
             People.Add(new Person() { Id = i, Age = random.NextInt64(100), FirstName = "Person", LastName = "Person" });
         }
+
+        var checkCf = new ConditionalFormat((cell, cells) => { return ((Person)cell.Data).Checked == true; }, new Format()
+        {
+            BackgroundColor = "#D9F8C4"
+        });
+
+        var ageCf = new ConditionalFormat((cell, cells) => { return ((Person)cell.Data).Age > 50; }, new Format()
+        {
+            ForegroundColor = "#F37878"
+        });
 
         var builder1 = new ObjectEditorBuilder<Person>(People, GridDirection.PropertiesAcrossColumns);
         builder1.AutogenerateProperties(true)
@@ -46,11 +56,16 @@ Welcome to your new app.
                     {
                         FontWeight = "bold",
                         ForegroundColor = "#006600",
-                        BackgroundColor = "#fafafa"
+                        BackgroundColor = "#fafafa",
                     };
+                    pd.UseConditionalFormat("ageCf");
+                    pd.UseConditionalFormat("check");
                 })
-                .WithProperty(x => x.Id, pd => { pd.Heading = "Person ID"; });
-        
+                .WithProperty(x => x.Id, pd => { pd.Heading = "Person ID"; })
+                .WithConditionalFormat("check", checkCf)
+                .WithConditionalFormat("ageCf", ageCf)
+                .WithProperty(x => x.Checked, pd => { pd.UseConditionalFormat("check"); });
+
         var editor1 = builder1.Build();
 
 

--- a/src/BlazorDatasheet.Wasm/Pages/Index.razor
+++ b/src/BlazorDatasheet.Wasm/Pages/Index.razor
@@ -31,7 +31,7 @@ Welcome to your new app.
         };
         
         var random = new Random();
-        for (int i = 0; i < 10000; i++)
+        for (int i = 0; i < 200; i++)
         {
             People.Add(new Person() { Id = i, Age = random.NextInt64(100), FirstName = "Person", LastName = "Person" });
         }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -30,7 +30,7 @@
     </tr>
 
     <Virtualize Items="@Sheet?.Rows" Context="sheetRow">
-        <tr>
+        <tr @key="sheetRow.RowNumber">
             <td
                 class="sheet-cell row-head @(IsDataSheetActive && Sheet.IsRowActive(sheetRow.RowNumber) ? "row-active" : "")"
                 @onmousedown="e => HandleRowHeaderMouseDown(sheetRow.RowNumber, e)"
@@ -54,7 +54,14 @@
                     @onmouseup="e => HandleCellMouseUp(row, col, e)">
                     @if (EditPosition?.Col == col && EditPosition?.Row == row)
                     {
-                        @RenderEditor(cell.Type)
+                        // @RenderEditor(cell.Type)
+                        //<DynamicComponent
+                        //    Type="getEditorComponentType(cell.Type)"
+                        //    @ref="_activeEditorRefernce"/>
+                        <DynamicComponent
+                            Type="getEditorComponentType(cell.Type)"
+                            Parameters="@getEditorParameters()"
+                            @ref="_activeEditorRefernce"/>
                     }
                     else
                     {
@@ -82,16 +89,3 @@
         </tr>
     </Virtualize>
 </table>
-
-@code{
-
-    private RenderFragment RenderEditor(string type) => builder =>
-    {
-        var componentType = getEditorComponentType(type);
-        builder.OpenComponent(0, componentType);
-        builder.AddComponentReferenceCapture(1, componentRef => 
-                                                    ActiveEditorReference = (ICellEditor)componentRef);
-        builder.CloseComponent();
-    };
-
-}

--- a/src/BlazorDatasheet/Edit/BaseEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/BaseEditorComponent.razor
@@ -3,21 +3,21 @@
 
 @code {
 
-    public string EditString { get; protected set; }
-    protected Cell Cell { get; set; }
-    public virtual bool CanCancelEdit => true;
-    public virtual bool CanAcceptEdit => true;
-    public virtual bool IsSoftEdit { get; protected set; }
+    [Parameter]
+    public EditState EditState { get; set; }
 
     public virtual void BeginEdit(EditEntryMode entryMode, Cell cell, string key)
     {
-        Cell = cell;
-        EditString = Cell.Value;
+        EditState.Cell = cell;
+        EditState.EditString = cell.Value;
         if (entryMode == EditEntryMode.Key)
         {
-            EditString = key;
-            IsSoftEdit = true;
+            EditState.EditString = key;
+            EditState.IsSoftEdit = true;
         }
+
+        EditState.CanAcceptEdit = true;
+        EditState.CanCancelEdit = true;
 
         StateHasChanged();
     }

--- a/src/BlazorDatasheet/Edit/BoolEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/BoolEditorComponent.razor
@@ -3,37 +3,43 @@
 
 @code {
 
+    [Parameter]
+    public EditState EditState { get; set; }
+
     public void BeginEdit(EditEntryMode entryMode, Cell cell, string key)
     {
+        EditState.CanAcceptEdit = true;
+        EditState.CanCancelEdit = true;
+
         var canPass = bool.TryParse(cell.Value, out bool parsedValue);
         if (!canPass)
-            this.OnCancelEdit.Invoke();
+            EditState.OnCancelEdit.Invoke();
 
-        EditString = cell.Value;
+        EditState.EditString = cell.Value;
 
         if (entryMode == EditEntryMode.Mouse)
         {
             var newValue = !parsedValue;
-            EditString = newValue.ToString();
+            EditState.EditString = newValue.ToString();
         }
 
         if (entryMode == EditEntryMode.Key)
         {
             if (key.ToLower() == "y")
             {
-                EditString = true.ToString();
+                EditState.EditString = true.ToString();
             }
             else if (key.ToLower() == "n")
             {
-                EditString = false.ToString();
+                EditState.EditString = false.ToString();
             }
             else if (key == "Space")
             {
-                EditString = (!parsedValue).ToString();
+                EditState.EditString = (!parsedValue).ToString();
             }
         }
 
-        this.OnAcceptEdit.Invoke();
+        EditState.OnAcceptEdit.Invoke();
     }
 
     public bool HandleKey(string key)
@@ -41,10 +47,4 @@
         return false;
     }
 
-    public Func<bool> OnAcceptEdit { get; set; }
-    public Func<bool> OnCancelEdit { get; set; }
-    public bool CanCancelEdit => true;
-    public bool CanAcceptEdit => true;
-    public bool IsSoftEdit => true;
-    public string EditString { get; protected set; }
 }

--- a/src/BlazorDatasheet/Edit/DateTimeEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DateTimeEditorComponent.razor
@@ -5,7 +5,7 @@
     type="date"
     class="date-input"
     @bind="EditDate"
-    @onclick="() => IsSoftEdit = false"
+    @onclick="() => EditState.IsSoftEdit = false"
     @bind:event="oninput"
     @ref="InputRef"/>
 
@@ -13,31 +13,31 @@
 
     public override void BeginEdit(EditEntryMode entryMode, Cell cell, string key)
     {
-        Cell = cell;
+        EditState.Cell = cell;
 
         var canParse = DateTime.TryParse(cell.Value, out DateTime parsedDateTime);
         if (!canParse)
-            EditString = DateTime.Now.ToString();
+            EditState.EditString = DateTime.Now.ToString();
         else
-            EditString = Cell.Value;
+            EditState.EditString = cell.Value;
 
         if (entryMode == EditEntryMode.Key)
         {
     // If we are typing a number, set it to the first char in the date string, (e.g first part of day or month)
             if (char.IsNumber((char)key.First()))
             {
-                var newDateString = key + EditString?.Substring(1, EditString.Length - 1);
+                var newDateString = key + EditState.EditString?.Substring(1, EditState.EditString.Length - 1);
                 if (DateTime.TryParse(newDateString, out var newDate))
-                    EditString = newDateString;
+                    EditState.EditString = newDateString;
                 else
-                    EditString = DateTime.Now.ToString();
+                    EditState.EditString = DateTime.Now.ToString();
             }
             else
             {
-                EditString = DateTime.Now.ToString();
+                EditState.EditString = DateTime.Now.ToString();
             }
 
-            IsSoftEdit = true;
+            EditState.IsSoftEdit = true;
         }
 
         StateHasChanged();
@@ -47,8 +47,8 @@
 
     private DateTime? EditDate
     {
-        set { EditString = value.ToString(); }
-        get { return String.IsNullOrEmpty(EditString) ? null : DateTime.Parse(EditString); }
+        set { EditState.EditString = value.ToString(); }
+        get { return String.IsNullOrEmpty(EditState.EditString) ? null : DateTime.Parse(EditState.EditString); }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/BlazorDatasheet/Edit/ICellEditor.cs
+++ b/src/BlazorDatasheet/Edit/ICellEditor.cs
@@ -1,4 +1,5 @@
 using BlazorDatasheet.Model;
+using Microsoft.AspNetCore.Components;
 
 namespace BlazorDatasheet.Edit;
 
@@ -13,10 +14,6 @@ public interface ICellEditor
     /// <returns>Whether the event should be cancelled</returns>
     public bool HandleKey(string key);
 
-    public Func<bool> OnAcceptEdit { get; set; }
-    public Func<bool> OnCancelEdit { get; set; }
-    public bool CanCancelEdit { get; }
-    public bool CanAcceptEdit { get; }
-    public bool IsSoftEdit { get; }
-    public string EditString { get; }
+    [Parameter]
+    public EditState EditState { get; set; }
 }

--- a/src/BlazorDatasheet/Edit/SelectEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/SelectEditorComponent.razor
@@ -1,10 +1,10 @@
 @inherits BaseEditorComponent
 
-<input @bind="EditString" class="text-input" @ref="InputTextComponent"/>
+<input @bind="EditState.EditString" class="text-input" @ref="InputTextComponent"/>
 <div class="select-list">
     @foreach (var val in values)
     {
-        <div class="select-item" @onmousedown="() => { EditString = val; OnAcceptEdit.Invoke(); }">@val</div>
+        <div class="select-item" @onmousedown="() => { EditState.EditString = val; OnAcceptEdit.Invoke(); }">@val</div>
     }
 </div>
 

--- a/src/BlazorDatasheet/Edit/TextEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/TextEditorComponent.razor
@@ -5,8 +5,8 @@
 <input
     type="text"
     class="text-input"
-    @bind="EditString"
-    @onclick="() => IsSoftEdit = false"
+    @bind="EditState.EditString"
+    @onclick="() => EditState.IsSoftEdit = false"
     @bind:event="oninput"
     @ref="InputRef"/>
 

--- a/src/BlazorDatasheet/Model/EditState.cs
+++ b/src/BlazorDatasheet/Model/EditState.cs
@@ -1,0 +1,16 @@
+namespace BlazorDatasheet.Model;
+
+/// <summary>
+/// Stores the current edit state
+/// Required because if the control is virtualised we lose info when it moves out of scope
+/// </summary>
+public class EditState
+{
+    public Func<bool>? OnAcceptEdit { get; set; }
+    public Func<bool>? OnCancelEdit { get; set; }
+    public bool CanCancelEdit { get; set; }
+    public bool CanAcceptEdit { get; set; }
+    public bool IsSoftEdit { get; set; }
+    public string? EditString { get; set; }
+    public Cell Cell { get; set; }
+}


### PR DESCRIPTION
Fixes a bug where the current edit was removed when the editor component moved out of view.

This was caused by the virtualization - when the dynamic component was removed it lost its internal state. To fix this we move the internal state (EditState) into the Datasheet component.