### PR TITLE
throw on blazor server due to null

### DIFF
--- a/src/BlazorDatasheet/Data/Cell.cs
+++ b/src/BlazorDatasheet/Data/Cell.cs
@@ -119,7 +119,7 @@ public class Cell : IReadOnlyCell, IWriteableCell
             // Use the Key!
 
             var val = Data?.GetType().GetProperty(Key)?.GetValue(Data, null);
-            if (val.GetType() == type || System.Nullable.GetUnderlyingType(type) == val.GetType())
+            if (val==null || val.GetType() == type || System.Nullable.GetUnderlyingType(type) == val.GetType())
                 return val;
             else
             {


### PR DESCRIPTION
if you add a new row on blazor server (main example), it will crash at this line because val is null.

blazor wasm's runtime seems to not consider it actually null so it doesn't throw.

ps: I have been tracking your project for a couple mths now, finally I learned blazor enough to try it out today!