### PR TITLE
Merged cells impovement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple datasheet component for editing tabular data.
 
 #### Features
 - Data editing
-  - Built in editors including text, date, select, boolean, texarea, enum
+  - Built in editors including text, date, select, boolean, text area, enum
   - Add custom editors for any data type
 - Conditional formatting
 - Data validation

--- a/src/BlazorDatasheet/Commands/InsertColAfterCommand.cs
+++ b/src/BlazorDatasheet/Commands/InsertColAfterCommand.cs
@@ -8,6 +8,8 @@ namespace BlazorDatasheet.Commands;
 public class InsertColAfterCommand : IUndoableCommand
 {
     private readonly int _colIndex;
+    private IReadOnlyList<CellMerge> _mergesPerformed = default!;
+    private IReadOnlyList<CellMerge> _overridenMergedRegions = default!;
 
     /// <summary>
     /// Command for inserting a column into the sheet.
@@ -21,12 +23,15 @@ public class InsertColAfterCommand : IUndoableCommand
     public bool Execute(Sheet sheet)
     {
         sheet.InsertColAfterImpl(_colIndex);
+
+        (_mergesPerformed, _overridenMergedRegions) = sheet.RerangeMergedCells(Axis.Col, _colIndex, 1);
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
         sheet.RemoveColImpl(_colIndex + 1);
+        sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
         return true;
     }
 }

--- a/src/BlazorDatasheet/Commands/InsertRowAfterCommand.cs
+++ b/src/BlazorDatasheet/Commands/InsertRowAfterCommand.cs
@@ -8,6 +8,8 @@ namespace BlazorDatasheet.Commands;
 internal class InsertRowAfterCommand : IUndoableCommand
 {
     private readonly int _index;
+    private IReadOnlyList<CellMerge> _mergesPerformed = default!;
+    private IReadOnlyList<CellMerge> _overridenMergedRegions = default!;
 
     /// <summary>
     /// Command for inserting a row into the sheet.
@@ -21,12 +23,14 @@ internal class InsertRowAfterCommand : IUndoableCommand
     public bool Execute(Sheet sheet)
     {
         sheet.InsertRowAfterImpl(_index);
+        (_mergesPerformed, _overridenMergedRegions) = sheet.RerangeMergedCells(Axis.Row, _index, 1);
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
         sheet.RemoveRowAtImpl(_index + 1);
+        sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
         return true;
     }
 }

--- a/src/BlazorDatasheet/Commands/RemoveColumnCommand.cs
+++ b/src/BlazorDatasheet/Commands/RemoveColumnCommand.cs
@@ -42,7 +42,6 @@ public class RemoveColumnCommand : IUndoableCommand
             sheet.ColumnHeadings[_columnIndex] = _removedHeading;
         sheet.SetCellValuesImpl(_removedValues);
         sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
-
         return true;
     }
 }

--- a/src/BlazorDatasheet/Commands/RemoveColumnCommand.cs
+++ b/src/BlazorDatasheet/Commands/RemoveColumnCommand.cs
@@ -7,6 +7,8 @@ public class RemoveColumnCommand : IUndoableCommand
     private int _columnIndex;
     private Heading _removedHeading;
     private List<CellChange> _removedValues;
+    private IReadOnlyList<CellMerge> _mergesPerformed = default!;
+    private IReadOnlyList<CellMerge> _overridenMergedRegions = default!;
 
     /// <summary>
     /// Command for removing a column at the index given.
@@ -27,6 +29,8 @@ public class RemoveColumnCommand : IUndoableCommand
             _removedHeading = sheet.ColumnHeadings[_columnIndex];
 
         var res = sheet.RemoveColImpl(_columnIndex);
+
+        (_mergesPerformed, _overridenMergedRegions) = sheet.RerangeMergedCells(Axis.Col, _columnIndex, -1);
         return res;
     }
 
@@ -37,6 +41,8 @@ public class RemoveColumnCommand : IUndoableCommand
         if (_columnIndex >= 0 && _columnIndex < sheet.ColumnHeadings.Count)
             sheet.ColumnHeadings[_columnIndex] = _removedHeading;
         sheet.SetCellValuesImpl(_removedValues);
+        sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
+
         return true;
     }
 }

--- a/src/BlazorDatasheet/Commands/RemoveRowCommand.cs
+++ b/src/BlazorDatasheet/Commands/RemoveRowCommand.cs
@@ -34,7 +34,6 @@ public class RemoveRowCommand : IUndoableCommand
         sheet.InsertRowAfterImpl(_rowIndex - 1);
         sheet.SetCellValuesImpl(_valuesRemoved);
         sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
-
         return true;
     }
 }

--- a/src/BlazorDatasheet/Commands/RemoveRowCommand.cs
+++ b/src/BlazorDatasheet/Commands/RemoveRowCommand.cs
@@ -6,6 +6,8 @@ public class RemoveRowCommand : IUndoableCommand
 {
     private readonly int _rowIndex;
     private List<CellChange> _valuesRemoved;
+    private IReadOnlyList<CellMerge> _mergesPerformed = default!;
+    private IReadOnlyList<CellMerge> _overridenMergedRegions = default!;
 
     /// <summary>
     /// Command to remove the row at the index given.
@@ -23,6 +25,7 @@ public class RemoveRowCommand : IUndoableCommand
         var nonEmptyPosns = sheet.GetNonEmptyCellPositions(new RowRegion(_rowIndex));
         _valuesRemoved = nonEmptyPosns.Select(x => new CellChange(x.row, x.col, sheet.GetValue(x.row, x.col)))
                                       .ToList();
+        (_mergesPerformed, _overridenMergedRegions) = sheet.RerangeMergedCells(Axis.Row, _rowIndex, -1);
         return sheet.RemoveRowAtImpl(_rowIndex);
     }
 
@@ -30,6 +33,8 @@ public class RemoveRowCommand : IUndoableCommand
     {
         sheet.InsertRowAfterImpl(_rowIndex - 1);
         sheet.SetCellValuesImpl(_valuesRemoved);
+        sheet.UndoRerangeMergedCells(_mergesPerformed, _overridenMergedRegions);
+
         return true;
     }
 }

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -337,13 +337,15 @@ public class Sheet
             }
 
             MergedCells.Delete(item);
-            var merge = new CellMerge(region);
+           
             if (region.Top != region.Bottom && region.Left != region.Right)
             {
+                var merge = new CellMerge(region);
                 MergedCells.Insert(merge);
                 overridenMergedRegions.Add(merge);
             }
         }
+
         return (mergesPerformed, overridenMergedRegions.AsReadOnly());
     }
     /// <summary>

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -212,8 +212,6 @@ public class Sheet
             ColumnHeadings.Insert(colIndex + 1, new Heading());
         NumCols++;
         ColumnInserted?.Invoke(this, new ColumnInsertedEventArgs(colIndex));
-
-
     }
 
     /// <summary>
@@ -241,7 +239,6 @@ public class Sheet
                 ColumnHeadings.RemoveAt(colIndex);
             NumCols--;
             ColumnRemoved?.Invoke(this, new ColumnRemovedEventArgs(colIndex));
-
             return true;
         }
 

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -311,6 +311,11 @@ public class Sheet
         var overridenMergedRegions = new List<CellMerge>();
         foreach (var item in mergesPerformed)
         {
+            // Ignore row or column regions because
+            // they do not have a fixed end position
+            if(item.Region is RowRegion or ColumnRegion)
+                continue;
+            
             var region = item.Region.Clone();
 
             if (axis == Axis.Row)

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -313,7 +313,7 @@ public class Sheet
         {
             // Ignore row or column regions because
             // they do not have a fixed end position
-            if(item.Region is RowRegion or ColumnRegion)
+            if((item.Region is RowRegion && axis == Axis.Col) || (item.Region is ColumnRegion && axis == Axis.Row))
                 continue;
             
             var region = item.Region.Clone();

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -313,9 +313,9 @@ public class Sheet
         {
             // Ignore row or column regions because
             // they do not have a fixed end position
-            if((item.Region is RowRegion && axis == Axis.Col) || (item.Region is ColumnRegion && axis == Axis.Row))
+            if ((item.Region is RowRegion && axis == Axis.Col) || (item.Region is ColumnRegion && axis == Axis.Row))
                 continue;
-            
+
             var region = item.Region.Clone();
 
             if (axis == Axis.Row)
@@ -342,8 +342,8 @@ public class Sheet
             }
 
             MergedCells.Delete(item);
-           
-            if (region.Top != region.Bottom && region.Left != region.Right)
+
+            if ((region.Top != region.Bottom && region.Left != region.Right) || region is RowRegion || region is ColumnRegion)
             {
                 var merge = new CellMerge(region);
                 MergedCells.Insert(merge);

--- a/src/BlazorDatasheet/Data/Sheet.cs
+++ b/src/BlazorDatasheet/Data/Sheet.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using BlazorDatasheet.Commands;
 using BlazorDatasheet.DataStructures.Intervals;
@@ -211,6 +212,8 @@ public class Sheet
             ColumnHeadings.Insert(colIndex + 1, new Heading());
         NumCols++;
         ColumnInserted?.Invoke(this, new ColumnInsertedEventArgs(colIndex));
+
+
     }
 
     /// <summary>
@@ -238,6 +241,7 @@ public class Sheet
                 ColumnHeadings.RemoveAt(colIndex);
             NumCols--;
             ColumnRemoved?.Invoke(this, new ColumnRemovedEventArgs(colIndex));
+
             return true;
         }
 
@@ -280,13 +284,13 @@ public class Sheet
         return Commands.ExecuteCommand(cmd);
     }
 
-    internal bool RemoveRowAtImpl(int index)
+    internal bool RemoveRowAtImpl(int rowIndex)
     {
-        if (index >= 0 && index < NumRows)
+        if (rowIndex >= 0 && rowIndex < NumRows)
         {
-            _cellDataStore.RemoveRowAt(index);
+            _cellDataStore.RemoveRowAt(rowIndex);
             NumRows--;
-            RowRemoved?.Invoke(this, new RowRemovedEventArgs(index));
+            RowRemoved?.Invoke(this, new RowRemovedEventArgs(rowIndex));
             return true;
         }
 
@@ -294,6 +298,73 @@ public class Sheet
     }
 
     #endregion
+
+    /// <summary>
+    /// Updates a merged regions after insert or remove rows or columns
+    /// </summary>
+    /// <param name="axis"></param>
+    /// <param name="index">index of inserted row\column</param>
+    /// <param name="count">count of inserted or removed rows\columns. count > 0 when inserted, count < 0 when reomved</param>
+    /// <returns>list of affected regions (before operation state) and list of new regions (state after operation)</returns>
+    internal (IReadOnlyList<CellMerge> mergesPerformed, IReadOnlyList<CellMerge> overridenMergedRegions) RerangeMergedCells(Axis axis, int index, int count)
+    {
+        var afterInserted = axis == Axis.Row ? new Region(index, NumRows, 0, NumCols) : new Region(0, NumRows, index, NumCols);
+        var envelope = afterInserted.ToEnvelope();
+        var mergesPerformed = MergedCells.Search(envelope);
+        var overridenMergedRegions = new List<CellMerge>();
+        foreach (var item in mergesPerformed)
+        {
+            var region = item.Region.Clone();
+
+            if (axis == Axis.Row)
+            {
+                if (index < region.Top)
+                {
+                    region.Shift(count, 0);
+                }
+                else
+                {
+                    region.Expand(Edge.Bottom, count);
+                }
+            }
+            else if (axis == Axis.Col)
+            {
+                if (index < region.Left)
+                {
+                    region.Shift(0, count);
+                }
+                else
+                {
+                    region.Expand(Edge.Right, count);
+                }
+            }
+
+            MergedCells.Delete(item);
+            var merge = new CellMerge(region);
+            if (region.Top != region.Bottom && region.Left != region.Right)
+            {
+                MergedCells.Insert(merge);
+                overridenMergedRegions.Add(merge);
+            }
+        }
+        return (mergesPerformed, overridenMergedRegions.AsReadOnly());
+    }
+    /// <summary>
+    /// Undo rerange operation to restore state before Insert\Remove rows\columns commands
+    /// </summary>
+    /// <param name="_mergesPerformed">state to return on</param>
+    /// <param name="_overridenMergedRegions">state to undo</param>
+    internal void UndoRerangeMergedCells(IReadOnlyList<CellMerge> _mergesPerformed, IReadOnlyList<CellMerge> _overridenMergedRegions)
+    {
+        foreach (var item in _overridenMergedRegions)
+        {
+            MergedCells.Delete(item);
+        }
+        foreach (var item in _mergesPerformed)
+        {
+            MergedCells.Insert(item);
+        }
+    }
 
     /// <summary>
     /// Returns a single cell range at the position row, col

--- a/src/BlazorDatasheet/Edit/DefaultComponents/EnumEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/EnumEditorComponent.razor
@@ -14,21 +14,21 @@
        @ref="InputRef" />
 
 <div class="select-list">
-    @foreach (TEnum val in Enum.GetValues(typeof(TEnum)))
+    @foreach (TEnum val in Items)
     {
-        <div class="select-item"
-         @onmouseup="() => { EditedValue = val; this.AcceptEdit(); }">
+        <div class="select-item @(val.Equals(currentSelected) ? "active": "")"
+         @onmouseup="() => selectItem(val)">
             @val
         </div>
     }
 </div>
 
 
-
-
 @code {
 
     private IReadOnlyCell Cell;
+    TEnum? currentSelected;
+    IList<TEnum> Items = Enum.GetValues(typeof(TEnum)).Cast<TEnum>().ToList();
 
     public override void BeforeEdit(IReadOnlyCell cell)
     {
@@ -45,9 +45,7 @@
             if (entryMode == EditEntryMode.Key && !String.IsNullOrEmpty(key) && key.Length == 1)
             {
                 var stringValue = key.ToUpperInvariant();
-                EditedValue = Enum.GetValues(typeof(TEnum))
-                                .OfType<TEnum>()
-                                .FirstOrDefault(x => x.ToString().ToUpperInvariant().StartsWith(stringValue), EditedValue);
+                EditedValue = Items.FirstOrDefault(x => x.ToString().ToUpperInvariant().StartsWith(stringValue), EditedValue);
             }
 
         }
@@ -59,12 +57,47 @@
 
     public override bool HandleKey(string key, bool ctrlKey, bool shiftKey, bool altKey, bool metaKey)
     {
-
-        if (KeyUtil.IsKeyDown(key) || KeyUtil.IsKeyUp(key))
+        if (KeyUtil.IsEnter(key))
         {
+            if (currentSelected is not null)
+            {
+                selectItem(currentSelected);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        if (KeyUtil.IsKeyDown(key))
+        {
+            hoverItem(1);
+            return true;
+        }
+
+        if (KeyUtil.IsKeyUp(key))
+        {
+            hoverItem(-1);
             return true;
         }
 
         return base.HandleKey(key, ctrlKey, shiftKey, altKey, metaKey);
+    }
+
+    void hoverItem(int direction)
+    {
+        var index = currentSelected is not null ? Items.IndexOf(currentSelected) : 0;
+
+        index = direction > 0 ? Math.Min(index + 1, Items.Count - 1) : Math.Max(index - 1, 0);
+
+        currentSelected = Items[index];
+
+        StateHasChanged();
+    }
+
+    void selectItem(TEnum item)
+    {
+        EditedValue = item;
+        AcceptEdit();
     }
 }

--- a/src/BlazorDatasheet/Edit/DefaultComponents/EnumEditorComponent.razor.css
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/EnumEditorComponent.razor.css
@@ -29,6 +29,7 @@
     padding-left: 0.2rem;
 }
 
-.select-item:hover {
-    background: var(--selection-bg-color)
-}
+    .select-item:hover,
+    .select-item.active {
+        background: var(--selection-bg-color)
+    }

--- a/src/BlazorDatasheet/Edit/DefaultComponents/SelectEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/SelectEditorComponent.razor
@@ -3,17 +3,16 @@
 @using BlazorDatasheet.Validation
 @inherits BaseEditor<string>
 
-<input
-    @bind="EditedValue"
-    @bind:event="oninput"
-    class="text-input"
-    style="@CssUtil.GetStyledInput(Cell)"
-    @ref="InputRef"/>
+<input @bind="EditedValue"
+       @bind:event="oninput"
+       class="text-input"
+       style="@CssUtil.GetStyledInput(Cell)"
+       @ref="InputRef" />
 <div class="select-list">
     @foreach (var val in values)
     {
-        <div class="select-item"
-             @onmouseup="() => { EditedValue = val; this.AcceptEdit(); }">
+        <div class="select-item @(val.Equals(currentSelected) ? "active": "")"
+         @onmouseup="() => selectItem(val)">
             @val
         </div>
     }
@@ -24,6 +23,8 @@
     private string[] values = Array.Empty<string>();
 
     private IReadOnlyCell Cell;
+
+    string? currentSelected;
 
     public override void BeforeEdit(IReadOnlyCell cell)
     {
@@ -45,11 +46,83 @@
         }
         else if (entryMode == EditEntryMode.Key)
         {
-            EditedValue = key;
+            if (values.Any())
+            {
+                var keyUpped = key.ToUpperInvariant();
+                currentSelected = values.FirstOrDefault(v => v.ToUpperInvariant().StartsWith(keyUpped));
+            }
+
+            if (!string.IsNullOrWhiteSpace(currentSelected))
+            {
+                EditedValue = currentSelected;
+            }
+            else
+            {
+                EditedValue = key;
+            }
+
         }
 
         if (EditedValue == null)
             EditedValue = string.Empty;
+    }
+
+    public override bool HandleKey(string key, bool ctrlKey, bool shiftKey, bool altKey, bool metaKey)
+    {
+        if (KeyUtil.IsEnter(key))
+        {
+            if (!string.IsNullOrWhiteSpace(currentSelected))
+            {
+                selectItem(currentSelected);
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        if (KeyUtil.IsKeyDown(key))
+        {
+            hoverItem(1);
+            return true;
+        }
+
+        if (KeyUtil.IsKeyUp(key))
+        {
+            hoverItem(-1);
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(EditedValue))
+        {
+            var keyUpped = EditedValue.ToUpperInvariant();
+            currentSelected = values.FirstOrDefault(v => v.ToUpperInvariant().StartsWith(keyUpped));
+
+            if (!string.IsNullOrWhiteSpace(currentSelected))
+            {
+                StateHasChanged();
+                return true;
+            }
+        }
+
+        return base.HandleKey(key, ctrlKey, shiftKey, altKey, metaKey);
+    }
+
+    void hoverItem(int direction)
+    {
+        var index = !string.IsNullOrWhiteSpace(currentSelected) ? Array.IndexOf(values, currentSelected) : 0;
+
+        index = direction > 0 ? Math.Min(index + 1, values.Length - 1) : Math.Max(index - 1, 0);
+
+        currentSelected = values[index];
+
+        StateHasChanged();
+    }
+
+    void selectItem(string item)
+    {
+        EditedValue = item;
+        AcceptEdit();
     }
 
 }

--- a/src/BlazorDatasheet/Edit/DefaultComponents/SelectEditorComponent.razor.css
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/SelectEditorComponent.razor.css
@@ -6,9 +6,9 @@
     box-sizing: border-box;
 }
 
-.text-input:focus {
-    outline: none;
-}
+    .text-input:focus {
+        outline: none;
+    }
 
 .select-list {
     min-width: 10rem;
@@ -29,6 +29,7 @@
     padding-left: 0.2rem;
 }
 
-.select-item:hover {
-    background: var(--selection-bg-color)
-}
+    .select-item:hover,
+    .select-item.active {
+        background: var(--selection-bg-color)
+    }

--- a/src/BlazorDatasheet/Util/KeyUtil.cs
+++ b/src/BlazorDatasheet/Util/KeyUtil.cs
@@ -27,6 +27,11 @@ public class KeyUtil
         return key == "ArrowDown";
     }
 
+    public static bool IsEnter(string key)
+    {
+        return key == "Enter";
+    }
+
     public static Tuple<int, int> GetKeyMovementDirection(string key)
     {
         if (IsKeyDown(key)) return new Tuple<int, int>(1, 0);

--- a/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
@@ -76,7 +76,6 @@ public class MergeCellsAndInsertColRowTests
 
         Assert.False(sheet.IsPositionMerged(0, 0));
         Assert.False(sheet.IsPositionMerged(4, 4));
-
     }
 
     [Test]
@@ -502,5 +501,39 @@ public class MergeCellsAndInsertColRowTests
 
         Assert.False(sheet.IsPositionMerged(2, 2));
         Assert.False(sheet.IsPositionMerged(3, 2));
+    }
+
+    [Test]
+    public void Insert_Row_Inside_Merged_Column_Expands_Merge()
+    {
+        // This case tests when an entire column is merged
+        // and a row is inserted inside the merge. The behaviour
+        // should be the same as when inserting inside a smaller range
+        var sheet = new Sheet(3, 3);
+        sheet.TrySetCellValue(0, 1, "M");
+        sheet.MergeCells(new ColumnRegion(1));
+        Assert.AreEqual(sheet.GetValue(0, 1), "M");
+
+        sheet.InsertRowAfter(0);
+        var mergeRegion = sheet.GetMergedRegionAtPosition(0, 1);
+        Assert.NotNull(mergeRegion);
+        Assert.AreEqual(mergeRegion.GetType(), typeof(ColumnRegion));
+    }
+
+    [Test]
+    public void Insert_Col_Inside_Merged_Row_Expands_Merge()
+    {
+        // This case tests when an entire row is merged
+        // and a col is inserted inside the merge. The behaviour
+        // should be the same as when inserting inside a smaller range
+        var sheet = new Sheet(3, 3);
+        sheet.TrySetCellValue(0, 1, "M");
+        sheet.MergeCells(new RowRegion(1));
+        Assert.AreEqual(sheet.GetValue(0, 1), "M");
+
+        sheet.InsertColAfter(0);
+        var mergeRegion = sheet.GetMergedRegionAtPosition(1, 0);
+        Assert.NotNull(mergeRegion);
+        Assert.AreEqual(mergeRegion.GetType(), typeof(RowRegion));
     }
 }

--- a/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
@@ -1,0 +1,506 @@
+﻿using BlazorDatasheet.Commands;
+using BlazorDatasheet.Data;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Commands;
+
+public class MergeCellsAndInsertColRowTests
+{
+    /*
+     We need to test correct behaviour on inserting columns and rows into sheet with merged cells.
+     After insert merged region should shift if inserted row is above it or inserted column is before 
+     or inserted into merged region.
+     
+     Initial data
+
+           0  1  2  3  4
+       0 |  |  |  |  |  |
+       1 |  |U |  |  |  |
+       2 |  |  |M    |  |
+       3 |  |  |     |  |
+       4 |  |  |  |  |  |
+     
+     */
+    [Test]
+    public void Insert_Row_Above_Then_Undo_Correct()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 3));
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.InsertRowAfter(0);
+        /*
+               0  1  2  3  4
+           0 |  |  |  |  |  |
+           1 |  |  |  |  |  |
+           2 |  |U |  |  |  |
+           3 |  |  |M    |  |
+           4 |  |  |     |  |
+           5 |  |  |  |  |  |
+         
+         */
+
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(4, 2));
+        Assert.True(sheet.IsPositionMerged(4, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(2, 2));
+        Assert.False(sheet.IsPositionMerged(5, 2));
+
+        Assert.AreEqual("M", sheet.GetValue(3, 2));
+        Assert.AreEqual(null, sheet.GetValue(4, 3));
+        Assert.AreEqual("U", sheet.GetValue(2, 1));
+
+        sheet.Commands.Undo();
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+    }
+
+    [Test]
+    public void Insert_Row_Into_Then_Undo_Correct()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 3));
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.InsertRowAfter(2);
+        /*
+               0  1  2  3  4
+           0 |  |  |  |  |  |
+           1 |  |U |  |  |  |
+           2 |  |  |M    |  |
+           3 |  |  |     |  |
+           4 |  |  |     |  |
+           5 |  |  |  |  |  |
+         
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(4, 2));
+        Assert.True(sheet.IsPositionMerged(4, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 2));
+        Assert.False(sheet.IsPositionMerged(5, 2));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(4, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+    }
+
+    [Test]
+    public void Insert_Column_Before_Then_Undo_Correct()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 3));
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.InsertColAfter(0);
+
+        /*
+               0  1  2  3  4  5
+           0 |  |  |  |  |  |  |
+           1 |  |U |  |  |  |  |
+           2 |  |  |  |M    |  |
+           3 |  |  |  |     |  |
+           4 |  |  |  |  |  |  |
+     
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 4));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(3, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(2, 2));
+        Assert.False(sheet.IsPositionMerged(1, 2));
+        Assert.False(sheet.IsPositionMerged(4, 5));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 3));
+        Assert.AreEqual(null, sheet.GetValue(2, 4));
+        Assert.AreEqual("U", sheet.GetValue(1, 2));
+
+        sheet.Commands.Undo();
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+    }
+
+    [Test]
+    public void Insert_Column_Into_Then_Undo_Correct()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 3));
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.InsertColAfter(2);
+
+        /*
+               0  1  2  3  4  5
+           0 |  |  |  |  |  |  |
+           1 |  |U |  |  |  |  |
+           2 |  |  |M       |  |
+           3 |  |  |        |  |
+           4 |  |  |  |  |  |  |
+     
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 4));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(3, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 1));
+        Assert.False(sheet.IsPositionMerged(4, 5));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(2, 4));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+    }
+
+    [Test]
+    public void Remove_Column()
+    {
+        /*
+               0  1  2  3  4  5
+           0 |  |  |  |  |  |  |
+           1 |  |U |  |  |  |  |
+           2 |  |  |M       |  |
+           3 |  |  |        |  |
+           4 |  |  |  |  |  |  |
+     
+         */
+
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 4));
+
+        sheet.RemoveCol(3);
+
+        /*
+               0  1  2  3  4 
+           0 |  |  |  |  |  |
+           1 |  |U |  |  |  |
+           2 |  |  |M    |  |
+           3 |  |  |     |  |
+           4 |  |  |  |  |  |
+    
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 4));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(2, 4));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.Commands.Undo();
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 4));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(3, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 1));
+        Assert.False(sheet.IsPositionMerged(4, 5));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(2, 4));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.RemoveCol(0);
+
+        /*
+               0  1  2  3  4 
+           0 |  |  |  |  |  |
+           1 |U |  |  |  |  |
+           2 |  |M       |  |
+           3 |  |        |  |
+           4 |  |  |  |  |  |
+     
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 1));
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(3, 1));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 4));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 1));
+        Assert.AreEqual(null, sheet.GetValue(2, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 0));
+    }
+
+    [Test]
+    public void Remove_Row()
+    {
+        /*
+               0  1  2  3  4  5
+           0 |  |  |  |  |  |  |
+           1 |  |U |  |  |  |  |
+           2 |  |  |M       |  |
+           3 |  |  |        |  |
+           4 |  |  |        |  |
+           5 |  |  |  |  |  |  |
+     
+         */
+
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 4, 2, 4));
+
+        sheet.RemoveRow(3);
+
+        /*
+               0  1  2  3  4  5
+           0 |  |  |  |  |  |  |
+           1 |  |U |  |  |  |  |
+           2 |  |  |M       |  |
+           3 |  |  |        |  |
+           4 |  |  |  |  |  |  |
+     
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 4));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(3, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 5));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(2, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.Commands.Undo();
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+        Assert.True(sheet.IsPositionMerged(2, 4));
+        Assert.True(sheet.IsPositionMerged(4, 2));
+        Assert.True(sheet.IsPositionMerged(4, 3));
+        Assert.True(sheet.IsPositionMerged(4, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(1, 1));
+        Assert.False(sheet.IsPositionMerged(2, 5));
+        Assert.False(sheet.IsPositionMerged(5, 5));
+
+        sheet.RemoveRow(0);
+
+
+        /*
+               0  1  2  3  4  5
+           0 |  |U |  |  |  |  |
+           1 |  |  |M       |  |
+           2 |  |  |        |  |
+           3 |  |  |        |  |
+           4 |  |  |  |  |  |  |
+     
+         */
+
+        Assert.True(sheet.IsPositionMerged(1, 2));
+        Assert.True(sheet.IsPositionMerged(1, 3));
+        Assert.True(sheet.IsPositionMerged(1, 4));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+        Assert.True(sheet.IsPositionMerged(3, 3));
+        Assert.True(sheet.IsPositionMerged(3, 4));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(0, 3));
+        Assert.False(sheet.IsPositionMerged(1, 5));
+        Assert.False(sheet.IsPositionMerged(3, 5));
+        Assert.False(sheet.IsPositionMerged(5, 5));
+
+        Assert.AreEqual("M", sheet.GetValue(1, 2));
+        Assert.AreEqual(null, sheet.GetValue(2, 3));
+        Assert.AreEqual("U", sheet.GetValue(0, 1));
+    }
+
+    [Test]
+    public void Unmerge_Column()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 2, 2, 3));
+
+        /*
+                0  1  2  3  4
+            0 |  |  |  |  |  |
+            1 |  |U |  |  |  |
+            2 |  |  |M    |  |
+            3 |  |  |  |  |  |
+            4 |  |  |  |  |  |
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(2, 3));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.RemoveCol(3);
+        /*
+                0  1  2  3  4
+            0 |  |  |  |  |  |
+            1 |  |U |  |  |  |
+            2 |  |  |M |  |  |
+            3 |  |  |  |  |  |
+            4 |  |  |  |  |  |
+         */
+
+        Assert.False(sheet.IsPositionMerged(2, 2));
+        Assert.False(sheet.IsPositionMerged(2, 3));
+    }
+
+    [Test]
+    public void Unmerge_Row()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.TrySetCellValue(2, 2, "M");
+        sheet.TrySetCellValue(1, 1, "U");
+
+        sheet.MergeCells(sheet.Range(2, 3, 2, 2));
+
+        /*
+                0  1  2  3  4
+            0 |  |  |  |  |  |
+            1 |  |U |  |  |  |
+            2 |  |  |M |  |  |
+            3 |  |  |M*|  |  |
+            4 |  |  |  |  |  |
+         */
+
+        Assert.True(sheet.IsPositionMerged(2, 2));
+        Assert.True(sheet.IsPositionMerged(3, 2));
+
+        Assert.False(sheet.IsPositionMerged(0, 0));
+        Assert.False(sheet.IsPositionMerged(4, 4));
+
+        Assert.AreEqual("M", sheet.GetValue(2, 2));
+        Assert.AreEqual(null, sheet.GetValue(3, 3));
+        Assert.AreEqual("U", sheet.GetValue(1, 1));
+
+        sheet.RemoveRow(3);
+        /*
+                0  1  2  3  4
+            0 |  |  |  |  |  |
+            1 |  |U |  |  |  |
+            2 |  |  |M |  |  |
+            3 |  |  |  |  |  |
+         */
+
+        Assert.False(sheet.IsPositionMerged(2, 2));
+        Assert.False(sheet.IsPositionMerged(3, 2));
+    }
+}

--- a/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/MergeCellsAndInsertColRowTests.cs
@@ -528,12 +528,58 @@ public class MergeCellsAndInsertColRowTests
         // should be the same as when inserting inside a smaller range
         var sheet = new Sheet(3, 3);
         sheet.TrySetCellValue(0, 1, "M");
+        
         sheet.MergeCells(new RowRegion(1));
+
         Assert.AreEqual(sheet.GetValue(0, 1), "M");
 
         sheet.InsertColAfter(0);
-        var mergeRegion = sheet.GetMergedRegionAtPosition(1, 0);
-        Assert.NotNull(mergeRegion);
-        Assert.AreEqual(mergeRegion.GetType(), typeof(RowRegion));
+
+        var mergeRowRegion = sheet.GetMergedRegionAtPosition(1, 0);
+        Assert.NotNull(mergeRowRegion);
+        Assert.AreEqual(mergeRowRegion.GetType(), typeof(RowRegion));
+
+    }
+
+    [Test]
+    public void Insert_Col_Inside_Merged_Column_Shift_Merge()
+    {
+        // This case tests when an entire row is merged
+        // and a col is inserted inside the merge. The behaviour
+        // should be the same as when inserting inside a smaller range
+        var sheet = new Sheet(3, 3);
+        sheet.TrySetCellValue(0, 1, "M");
+
+        sheet.MergeCells(new ColumnRegion(2));
+
+
+        Assert.AreEqual(sheet.GetValue(0, 1), "M");
+
+        sheet.InsertColAfter(0);
+
+
+        var mergeColumnRegion = sheet.GetMergedRegionAtPosition(0, 3);
+        Assert.NotNull(mergeColumnRegion);
+        Assert.AreEqual(mergeColumnRegion.GetType(), typeof(ColumnRegion));
+    }
+
+    [Test]
+    public void Insert_Col_Inside_Merged_Row_Shift_Merge()
+    {
+        // This case tests when an entire row is merged
+        // and a col is inserted inside the merge. The behaviour
+        // should be the same as when inserting inside a smaller range
+        var sheet = new Sheet(3, 3);
+        sheet.TrySetCellValue(0, 1, "M");
+
+        sheet.MergeCells(new RowRegion(1));
+
+        Assert.AreEqual(sheet.GetValue(0, 1), "M");
+
+        sheet.InsertRowAfter(0);
+
+        var mergeRowRegion = sheet.GetMergedRegionAtPosition(2, 0);
+        Assert.NotNull(mergeRowRegion);
+        Assert.AreEqual(mergeRowRegion.GetType(), typeof(RowRegion));
     }
 }


### PR DESCRIPTION
Hello @anmcgrath !

In this PR:

1. Improve key navigation in DropDown based editors
2. Updates merged cells after insert\remove rows\columns. After we insert or remove rows or columns we have to shift\expand\contact all merged cells located below, after or inside affected rows or columns.