### PR TITLE
InsertDelimitedText : Fixed line break characters

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -343,14 +343,14 @@ public class Sheet
     /// <param name="inputPosition">The position where the insertion starts</param>
     /// <param name="newLineDelim">The delimiter that specifies a new-line</param>
     /// <returns>The region of cells that were affected</returns>
-    public Region? InsertDelimitedText(string text, CellPosition inputPosition, string newLineDelim = "\n")
+    public Region? InsertDelimitedText(string text, CellPosition inputPosition)
     {
         if (!Region.Contains(inputPosition))
             return null;
 
-        if (text.EndsWith('\n'))
-            text = text.Substring(0, text.Length - 1);
-        var lines = text.Split(newLineDelim);
+        ReadOnlySpan<string> lines = text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+        if (lines[^1] is [])
+            lines = lines[..^1];
 
         // We may reach the end of the sheet, so we only need to paste the rows up until the end.
         var endRow = Math.Min(inputPosition.row + lines.Length - 1, NumRows - 1);


### PR DESCRIPTION
![GIF 2024-01-11 오후 6-33-23](https://github.com/anmcgrath/BlazorDatasheet/assets/10435867/a2105f56-fa2f-4024-a56c-5207b43806d6)

I've fixed an issue where line breaks were not properly handled when copying and pasting, as shown in the GIF.
The testing environment was a Blazor Server project running on Windows 10 and Edge browser.