### PR TITLE
Better handle empty rows/empty columns.

### DIFF
--- a/src/BlazorDatasheet.Core/Layout/CellLayoutProvider.cs
+++ b/src/BlazorDatasheet.Core/Layout/CellLayoutProvider.cs
@@ -185,8 +185,8 @@ public class CellLayoutProvider : IGridLayoutProvider
         var visibleRowEnd = ComputeRow(top + containerHeight);
         var visibleColEnd = ComputeColumn(left + containerWidth);
 
-        visibleRowEnd = Math.Clamp(visibleRowEnd, 0, _sheet.NumRows - 1);
-        visibleColEnd = Math.Min(_sheet.NumCols - 1, visibleColEnd);
+        visibleRowEnd = Math.Clamp(visibleRowEnd, 0, Math.Max(_sheet.NumRows - 1, 0));
+        visibleColEnd = Math.Clamp(visibleColEnd, 0, Math.Max(_sheet.NumCols - 1, 0));
 
         var startRow = Math.Max(visibleRowStart - overflowY, 0);
         var endRow = Math.Min(Math.Max(_sheet.NumRows - 1, 0), visibleRowEnd + overflowY);

--- a/src/BlazorDatasheet.Core/Selecting/Selection.cs
+++ b/src/BlazorDatasheet.Core/Selecting/Selection.cs
@@ -246,6 +246,12 @@ public class Selection
 
     public void ConstrainSelectionToSheet()
     {
+        if (_sheet.NumRows == 0 || _sheet.NumCols == 0)
+        {
+            this.ClearSelections();
+            return;
+        }
+        
         var constrainedRegions = new List<IRegion>();
         for (int i = 0; i < _regions.Count; i++)
         {
@@ -253,9 +259,10 @@ public class Selection
             if (intersection != null)
                 constrainedRegions.Add(intersection);
         }
+
+        ActiveRegion = null;
         _regions.Clear();
-        _regions.AddRange(constrainedRegions);
-        EmitSelectionChange();
+        Set(constrainedRegions);
     }
 
     /// <summary>

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -11,230 +11,265 @@
 @inherits SheetComponentBase
 
 <CascadingValue Value="Id" Name="DatasheetId" IsFixed="true">
-    <div
-        @ref="_innerSheet"
-        style="height:@(_cellLayoutProvider.TotalHeight)px; width: @(_cellLayoutProvider.TotalWidth)px;"
-        class="@GetContainerClassString()"
-        theme="@Theme"
-        @onmouseover="() => IsMouseInsideSheet = true"
-        @onmouseout="() => IsMouseInsideSheet = false">
+<div
+    @ref="_innerSheet"
+    style="height:@(_cellLayoutProvider.TotalHeight)px; width: @(_cellLayoutProvider.TotalWidth)px;"
+    class="@GetContainerClassString()"
+    theme="@Theme"
+    @onmouseover="() => IsMouseInsideSheet = true"
+    @onmouseout="() => IsMouseInsideSheet = false">
 
-        <!-- Register Menus -->
-        <SelectionMenu
-            CanUserSort="@CanUserSort"
-            CanUserMergeRange="@CanUserMergeRows"
-            CanUserInsertCols="@CanUserInsertCols"
-            CanUserInsertRows="@CanUserInsertRows"
-            CanUserRemoveCols="@CanUserRemoveCols"
-            CanUserRemoveRows="@CanUserRemoveRows"/>
+<!-- Register Menus -->
+<SelectionMenu
+    CanUserSort="@CanUserSort"
+    CanUserMergeRange="@CanUserMergeRows"
+    CanUserInsertCols="@CanUserInsertCols"
+    CanUserInsertRows="@CanUserInsertRows"
+    CanUserRemoveCols="@CanUserRemoveCols"
+    CanUserRemoveRows="@CanUserRemoveRows"/>
 
 
-        <SheetMenuTarget
-            MenuId="SelectionMenu"
-            MenuData="Sheet"
-            Margin="0"
-            Trigger="@MenuTrigger.OnContextMenu"
-            Placement="@MenuPlacement.BottomRight">
+<SheetMenuTarget
+    MenuId="SelectionMenu"
+    MenuData="Sheet"
+    Margin="0"
+    Trigger="@MenuTrigger.OnContextMenu"
+    Placement="@MenuPlacement.BottomRight">
 
-            <!-- if virtualisation is on, merges need to be rendered outside of the table to handle merged cells that span outside of the viewport -->
-            <VirtualMergesRenderer
-                Icons="Icons"
-                CustomCellTypeDefinitions="CustomCellTypeDefinitions"
-                Sheet="Sheet"
-                VisualSheet="_visualSheet"
-                CellLayoutProvider="_cellLayoutProvider"/>
+@if (Sheet.NumCols > 0)
+{
+    <!-- if virtualisation is on, merges need to be rendered outside of the table to handle merged cells that span outside of the viewport -->
+    <VirtualMergesRenderer
+        Icons="Icons"
+        CustomCellTypeDefinitions="CustomCellTypeDefinitions"
+        Sheet="Sheet"
+        VisualSheet="_visualSheet"
+        CellLayoutProvider="_cellLayoutProvider"/>
 
-            <div>
 
-                <div style="display: flex; flex-direction: column; justify-content: start;">
+    <div style="display: flex; flex-direction: column; justify-content: start;">
 
-                    <div style="display: flex; flex-direction: row; justify-content: start">
+        <div style="display: flex; flex-direction: row; justify-content: start">
 
-                        <table
-                            class="sheet-table"
-                            style="width:@(RenderedInnerSheetWidth)px;">
+            <table
+                class="sheet-table"
+                style="width:@(RenderedInnerSheetWidth)px;">
 
-                            <colgroup>
-                                @if (ShowRowHeadings)
+                <colgroup>
+                    @if (ShowRowHeadings)
+                    {
+                        <col style="width:0;"/>
+                        <col style="width:@(_cellLayoutProvider.RowHeadingWidth)px;"/>
+                    }
+
+                    <!-- virtualisation column -->
+                    <col style="width: @(_visualSheet.Viewport.Left)px;"/>
+
+                    @for (int i = _visualSheet.Viewport.VisibleRegion.Left; i <= _visualSheet.Viewport.VisibleRegion.Right; i++)
+                    {
+                        var col = i;
+                        var colWidth = _cellLayoutProvider.ComputeWidth(col, 1);
+                        <col style="width:@(colWidth)px; max-width:@(colWidth)px;"/>
+                    }
+                </colgroup>
+
+                <!-- col headings -->
+                @if (ShowColHeadings)
+                {
+                    <thead class="@(this.StickyHeadings ? "col-sticky" : "")">
+                    <tr style="height: @(_cellLayoutProvider.ColHeadingHeight)px;">
+                        @if (ShowRowHeadings)
+                        {
+                            <th></th>
+                            <th style="z-index: 4;" class="col-head @(StickyHeadings ? "row-sticky" : "")"></th>
+                        }
+
+                        <!-- Virtualisation column -->
+                        <th style="position: relative;">
+                            <PortalTarget TargetId="Col" DatasheetId="@Id"/>
+                        </th>
+
+                        <ColumnHeadingsRenderer
+                            NCols="@_visualSheet.Viewport.VisibleRegion.Width"
+                            ColStart="@_visualSheet.Viewport.VisibleRegion.Left"
+                            CellLayoutProvider="_cellLayoutProvider"
+                            Sheet="_sheetLocal">
+                            <HeadingRenderer>
+                                @if (ColumnHeaderTemplate != null)
                                 {
-                                    <col style="width:0;"/>
-                                    <col style="width:@(_cellLayoutProvider.RowHeadingWidth)px;"/>
+                                    @ColumnHeaderTemplate(context)
                                 }
-
-                                <!-- virtualisation column -->
-                                <col style="width: @(_visualSheet.Viewport.Left)px;"/>
-
-                                @for (int i = _visualSheet.Viewport.VisibleRegion.Left; i <= _visualSheet.Viewport.VisibleRegion.Right; i++)
+                                else
                                 {
-                                    var col = i;
-                                    var colWidth = _cellLayoutProvider.ComputeWidth(col, 1);
-                                    <col style="width:@(colWidth)px; max-width:@(colWidth)px;"/>
+                                    @context.Heading
                                 }
-                            </colgroup>
+                            </HeadingRenderer>
+                        </ColumnHeadingsRenderer>
+                    </tr>
+                    </thead>
+                }
 
-                            <!-- col headings -->
-                            @if (ShowColHeadings)
-                            {
-                                <thead class="@(this.StickyHeadings ? "col-sticky" : "")">
-                                <tr style="height: @(_cellLayoutProvider.ColHeadingHeight)px;">
-                                    @if (ShowRowHeadings)
-                                    {
-                                        <th></th>
-                                        <th style="z-index: 4;" class="col-head @(StickyHeadings ? "row-sticky" : "")"></th>
-                                    }
+                <tbody>
 
-                                    <!-- Virtualisation column -->
-                                    <th style="position: relative;">
-                                        <PortalTarget TargetId="Col" DatasheetId="@Id"/>
-                                    </th>
+                <tr class="collapsed-row">
+                    @if (ShowRowHeadings)
+                    {
+                        <td style="background: red; z-index: 4;"
+                            class="@(StickyHeadings ? "row-sticky" : "")">
+                            <div style="position: absolute; overflow: visible; display: block;">
+                                <PortalTarget TargetId="Row" DatasheetId="@Id"/>
+                            </div>
+                        </td>
+                        <td></td>
+                    }
+                    <td></td>
+                    <td colspan="@_visualSheet.Viewport.VisibleRegion.Width"></td>
+                </tr>
 
-                                    <ColumnHeadingsRenderer
-                                        NCols="@_visualSheet.Viewport.VisibleRegion.Width"
-                                        ColStart="@_visualSheet.Viewport.VisibleRegion.Left"
-                                        CellLayoutProvider="_cellLayoutProvider"
-                                        Sheet="_sheetLocal">
-                                        <HeadingRenderer>
-                                            @if (ColumnHeaderTemplate != null)
-                                            {
-                                                @ColumnHeaderTemplate(context)
-                                            }
-                                            else
-                                            {
-                                                @context.Heading
-                                            }
-                                        </HeadingRenderer>
-                                    </ColumnHeadingsRenderer>
-                                </tr>
-                                </thead>
-                            }
-
-                            <tbody>
-
-                            <tr class="collapsed-row">
-                                @if (ShowRowHeadings)
-                                {
-                                    <td style="background: red; z-index: 4;"
-                                        class="@(StickyHeadings ? "row-sticky" : "")">
-                                        <div style="position: absolute; overflow: visible; display: block;">
-                                            <PortalTarget TargetId="Row" DatasheetId="@Id"/>
-                                        </div>
-                                    </td>
-                                    <td></td>
-                                }
-                                <td></td>
-                                <td colspan="@_visualSheet.Viewport.VisibleRegion.Width"></td>
-                            </tr>
-
-                            <!-- filler top row -->
-                            <tr>
-                                @{
-                                    // +1 here for virtualisation column
-                                    var fillerColSpan = _visualSheet.Viewport.VisibleRegion.Width + 1;
-                                    if (ShowRowHeadings)
-                                        fillerColSpan += 2; // +1 for row headings
-                                }
-                                <td colspan="@fillerColSpan" style="padding: 0; border: 0">
-                                    <div id="filler-top" @ref="_fillerTop"
-                                         style="min-height: @(_visualSheet.Viewport.Top)px; display: block;">
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <!-- row for holding left virtualiser -->
-                            <tr class="collapsed-row">
-                                @if (ShowRowHeadings)
-                                {
-                                    <th></th>
-                                    <th></th>
-                                    <!-- row headings -->
-                                }
-                                <td colspan="1" rowspan="@(_visualSheet.Viewport.VisibleRegion.Height + 1)"
-                                    style="padding: 0; border: 0;height: 0;">
-                                    <div @ref="_fillerLeft" id="filler-left-1"
-                                         style="display: block; min-width: @(_visualSheet.Viewport.Left)px; height: @(_visualSheet.Viewport.VisibleHeight)px;">
-                                    </div>
-                                </td>
-                                <td colspan="@_visualSheet.Viewport.VisibleRegion.Width" style="max-height: 0;"></td>
-                            </tr>
-
-                            @for (int rowIndex = _visualSheet.Viewport.VisibleRegion.Top; rowIndex <= _visualSheet.Viewport.VisibleRegion.Bottom; rowIndex++)
-                            {
-                                var row = rowIndex;
-                                var rowHeight = @_cellLayoutProvider.ComputeHeight(row, 1);
-                                
-                                if(rowHeight == 0)
-                                    continue;
-
-                                <tr @key="row" style="max-height:@(rowHeight)px;height:@(rowHeight)px;">
-
-                                    @if (ShowRowHeadings)
-                                    {
-                                        <th></th>
-                                        <th class="unselectable row-head @(StickyHeadings ? "row-sticky" : "")">
-                                            <div class="sheet-cell" data-col="-1" data-row="@row">
-                                                @(_sheetLocal.Rows.GetHeading(row) ?? (row + 1).ToString())
-                                            </div>
-                                        </th>
-                                    }
-
-                                    <DatasheetRow
-                                        CustomCellTypeDefinitions="CustomCellTypeDefinitions"
-                                        Icons="Icons"
-                                        IsDirty="@DirtyRows.Contains(row)"
-                                        VisualSheet="_visualSheet"
-                                        Sheet="_sheetLocal"
-                                        Row="row"
-                                        Virtualise="Virtualise"/>
-
-                                </tr>
-                            }
-                            </tbody>
-                        </table>
-
-                        <!-- filler right -->
-                        <div id="filler-right" @ref="_fillerRight"
-                             style="min-width: @(_visualSheet.Viewport.DistanceRight)px; height:@(_cellLayoutProvider.TotalHeight - _visualSheet.Viewport.DistanceBottom)">
+                <!-- filler top row -->
+                <tr>
+                    @{
+                        // +1 here for virtualisation column
+                        var fillerColSpan = _visualSheet.Viewport.VisibleRegion.Width + 1;
+                        if (ShowRowHeadings)
+                            fillerColSpan += 2; // +1 for row headings
+                    }
+                    <td colspan="@fillerColSpan" style="padding: 0; border: 0">
+                        <div id="filler-top" @ref="_fillerTop"
+                             style="min-height: @(_visualSheet.Viewport.Top)px; display: block;">
                         </div>
+                    </td>
+                </tr>
 
-                        <EditorOverlayRenderer
-                            @ref="_editorManager"
-                            Sheet="Sheet"
-                            CustomCellTypes="CustomCellTypeDefinitions"
-                            CellLayoutProvider="_cellLayoutProvider"/>
-                    </div>
+                <!-- row for holding left virtualiser -->
+                <tr class="collapsed-row">
+                    @if (ShowRowHeadings)
+                    {
+                        <th></th>
+                        <th></th>
+                        <!-- row headings -->
+                    }
+                    <td colspan="1" rowspan="@(_visualSheet.Viewport.VisibleRegion.Height + 1)"
+                        style="padding: 0; border: 0;height: 0;">
+                        <div @ref="_fillerLeft" id="filler-left-1"
+                             style="display: block; min-width: @(_visualSheet.Viewport.Left)px; height: @(_visualSheet.Viewport.VisibleHeight)px;">
+                        </div>
+                    </td>
+                    <td colspan="@_visualSheet.Viewport.VisibleRegion.Width" style="max-height: 0;"></td>
+                </tr>
 
-                    <!-- filler bottom -->
-                    <div id="filler-bottom" @ref="_fillerBottom"
-                         style="min-height: @(_visualSheet.Viewport?.DistanceBottom)px; min-width:@(_cellLayoutProvider.TotalWidth)px;">
-                    </div>
-                </div>
+                @if (Sheet.NumRows > 0)
+                {
+                    @for (int rowIndex = _visualSheet.Viewport.VisibleRegion.Top; rowIndex <= _visualSheet.Viewport.VisibleRegion.Bottom; rowIndex++)
+                    {
+                        var row = rowIndex;
+                        var rowHeight = @_cellLayoutProvider.ComputeHeight(row, 1);
 
+                        if (rowHeight == 0)
+                            continue;
+
+                        <tr @key="row" style="max-height:@(rowHeight)px;height:@(rowHeight)px;">
+
+                            @if (ShowRowHeadings)
+                            {
+                                <th></th>
+                                <th class="unselectable row-head @(StickyHeadings ? "row-sticky" : "")">
+                                    <div class="sheet-cell" data-col="-1" data-row="@row">
+                                        @(_sheetLocal.Rows.GetHeading(row) ?? (row + 1).ToString())
+                                    </div>
+                                </th>
+                            }
+
+                            <DatasheetRow
+                                CustomCellTypeDefinitions="CustomCellTypeDefinitions"
+                                Icons="Icons"
+                                IsDirty="@DirtyRows.Contains(row)"
+                                VisualSheet="_visualSheet"
+                                Sheet="_sheetLocal"
+                                Row="row"
+                                Virtualise="Virtualise"/>
+
+                        </tr>
+                    }
+                }
+                else
+                {
+                    <tr>
+                        @if (ShowRowHeadings)
+                        {
+                            <td></td>
+                            <td></td>
+                        }
+                        <td colspan="@_visualSheet.Viewport.VisibleRegion.Width">
+                            @if (EmptyRowsTemplate == null)
+                            {
+                                <div>No rows</div>
+                            }
+                            else
+                            {
+                                @EmptyRowsTemplate
+                            }
+                        </td>
+
+                    </tr>
+                }
+                </tbody>
+            </table>
+
+            <!-- filler right -->
+            <div id="filler-right" @ref="_fillerRight"
+                 style="min-width: @(_visualSheet.Viewport.DistanceRight)px; height:@(_cellLayoutProvider.TotalHeight - _visualSheet.Viewport.DistanceBottom)">
             </div>
-        </SheetMenuTarget>
 
-        <!-- entire size of sheet to force scrollbars. Includes width of row headers/columns-->
-        <div id="sheet_whole"
-             @ref="_wholeSheetDiv"
-             style="position:absolute; top:0;
-                 left:0;
-                 min-height:@(_cellLayoutProvider.TotalHeight)px;
-                 max-height:@(_cellLayoutProvider.TotalHeight)px;
-                 min-width:@(_cellLayoutProvider.TotalWidth)px;
-                 max-width:@(_cellLayoutProvider.TotalWidth)px;
-                 pointer-events: none;
-                 z-index: 2;">
-
-            <PortalTarget TargetId="Sheet" DatasheetId="@Id"/>
-
-            <SelectionRenderer
+            <EditorOverlayRenderer
+                @ref="_editorManager"
                 Sheet="Sheet"
+                CustomCellTypes="CustomCellTypeDefinitions"
                 CellLayoutProvider="_cellLayoutProvider"/>
+        </div>
 
-            <AutofillRenderer
-                Sheet="Sheet"
-                InputService="_sheetPointerInputService"
-                CellLayoutProvider="_cellLayoutProvider"
-                SelectionExpanded="HandleSelectionExpanded"/>
+        <!-- filler bottom -->
+        <div id="filler-bottom" @ref="_fillerBottom"
+             style="min-height: @(_visualSheet.Viewport?.DistanceBottom)px; min-width:@(_cellLayoutProvider.TotalWidth)px;">
         </div>
     </div>
+}
+else
+{
+    if (EmptyColumnsTemplate == null)
+    {
+        <div>Empty sheet</div>
+    }
+    else
+    {
+        @EmptyColumnsTemplate
+    }
+}
+</SheetMenuTarget>
+
+<!-- entire size of sheet to force scrollbars. Includes width of row headers/columns-->
+<div id="sheet_whole"
+     @ref="_wholeSheetDiv"
+     style="position:absolute; top:0;
+                     left:0;
+                     min-height:@(_cellLayoutProvider.TotalHeight)px;
+                     max-height:@(_cellLayoutProvider.TotalHeight)px;
+                     min-width:@(_cellLayoutProvider.TotalWidth)px;
+                     max-width:@(_cellLayoutProvider.TotalWidth)px;
+                     pointer-events: none;
+                     z-index: 2;">
+
+    <PortalTarget TargetId="Sheet" DatasheetId="@Id"/>
+
+    <SelectionRenderer
+        Sheet="Sheet"
+        CellLayoutProvider="_cellLayoutProvider"/>
+
+    <AutofillRenderer
+        Sheet="Sheet"
+        InputService="_sheetPointerInputService"
+        CellLayoutProvider="_cellLayoutProvider"
+        SelectionExpanded="HandleSelectionExpanded"/>
+</div>
+</div>
 </CascadingValue>

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -70,31 +70,42 @@ public partial class Datasheet : SheetComponentBase
     /// </summary>
     [Parameter]
     public Dictionary<string, CellTypeDefinition> CustomCellTypeDefinitions { get; set; } = new();
-    
+
     /// <summary>
     /// If set to true, the user can remove rows using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserRemoveRows { get; set; } = true;
+    [Parameter]
+    public bool CanUserRemoveRows { get; set; } = true;
+
     /// <summary>
     /// If set to true, the user can remove columns using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserRemoveCols { get; set; } = true;
+    [Parameter]
+    public bool CanUserRemoveCols { get; set; } = true;
+
     /// <summary>
     /// If set to true, the user can insert rows using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserInsertRows { get; set; } = true;
+    [Parameter]
+    public bool CanUserInsertRows { get; set; } = true;
+
     /// <summary>
     /// If set to true, the user can insert columns using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserInsertCols { get; set; } = true;
+    [Parameter]
+    public bool CanUserInsertCols { get; set; } = true;
+
     /// <summary>
     /// If set to true, the user can sort regions using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserSort { get; set; } = true;
+    [Parameter]
+    public bool CanUserSort { get; set; } = true;
+
     /// <summary>
     /// If set to true, the user can merge regions using the context menu.
     /// </summary>
-    [Parameter] public bool CanUserMergeRows { get; set; } = true;
+    [Parameter]
+    public bool CanUserMergeRows { get; set; } = true;
 
 
     /// <summary>
@@ -114,6 +125,10 @@ public partial class Datasheet : SheetComponentBase
     [Parameter] public Dictionary<string, RenderFragment> Icons { get; set; } = new();
 
     [Parameter] public RenderFragment<HeadingContext>? ColumnHeaderTemplate { get; set; }
+
+    [Parameter] public RenderFragment? EmptyColumnsTemplate { get; set; }
+
+    [Parameter] public RenderFragment? EmptyRowsTemplate { get; set; }
 
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
@@ -594,7 +609,7 @@ public partial class Datasheet : SheetComponentBase
             return;
 
         var posn = Sheet.Selection.ActiveCellPosition;
-        
+
         Sheet.Selection.ClearSelections();
         Sheet.Selection.Set(posn.row, posn.col);
         Sheet.Selection.MoveActivePositionByRow(drow);


### PR DESCRIPTION
This PR handles better handles rendering an empty sheet (rows/cols = 0)

The visual sheet should no longer cause a crash as issue #78.

If the sheet has no columns or rows, the fallback is now to render the EmptyColumnsTemplate or EmptyRowsTemplate on the datasheet:

```csharp
    [Parameter] public RenderFragment? EmptyColumnsTemplate { get; set; }

    [Parameter] public RenderFragment? EmptyRowsTemplate { get; set; }
```

