### PR TITLE
Fix overflow error in RegionDataStore when rows/columns were removed.

### DIFF
--- a/src/BlazorDatasheet.DataStructures/Geometry/Region.cs
+++ b/src/BlazorDatasheet.DataStructures/Geometry/Region.cs
@@ -28,7 +28,16 @@ public class Region : IRegion
 
     public int Height => Bottom >= int.MaxValue ? int.MaxValue : Bottom - Top + 1;
     public int Width => Right >= int.MaxValue ? int.MaxValue : Right - Left + 1;
-    public int Area => Height * Width;
+    public int Area
+    {
+        get
+        {
+            if (Height == int.MaxValue || Width == int.MaxValue)
+                return int.MaxValue;
+            
+            return Height * Width;
+        }
+    }
 
 
     /// <summary>

--- a/src/BlazorDatasheet.DataStructures/Store/RegionDataStore.cs
+++ b/src/BlazorDatasheet.DataStructures/Store/RegionDataStore.cs
@@ -220,14 +220,6 @@ public class RegionDataStore<T> : IStore<T, RegionRestoreData<T>> where T : IEqu
 
             // if the region is partially overlapping (it must be because we know it is overlapping and it doesn't fully
             // overlap) then shift the overlap left and contract the left edge
-            // First check if it will result in the area being smaller than the minArea, in which case it should be 
-            // removed instead
-            if (overlap.Region.Break(region).Sum(x => x.Area) <= MinArea)
-            {
-                Tree.Delete(overlap);
-                removed.Add(overlap);
-                continue;
-            }
 
             var intersection = overlap.Region.GetIntersection(region)!;
             // contraction amount in row direction
@@ -246,7 +238,12 @@ public class RegionDataStore<T> : IStore<T, RegionRestoreData<T>> where T : IEqu
 
             var newRegion = new DataRegion<T>(overlap.Data, overlap.Region.Clone());
             newRegion.Region.Contract(cEdge, Math.Max(cRow, cCol));
-            newRegion.Region.Shift(sRow,sCol);
+            newRegion.Region.Shift(sRow, sCol);
+            
+            // if the region is less than the minimum area, don't add it back
+            if(newRegion.Region.Area <= MinArea)
+                continue;
+            
             newRegion.UpdateEnvelope();
             dataAdded.Add(newRegion);
             newDataToAdd.Add(newRegion);

--- a/test/BlazorDatasheet.Test/Store/RegionStoreTests.cs
+++ b/test/BlazorDatasheet.Test/Store/RegionStoreTests.cs
@@ -185,7 +185,7 @@ public class RegionStoreTests
             .Select(x => x.Region)
             .Should().BeEquivalentTo([r]);
     }
-    
+
     [Test]
     public void Delete_First_Cols_From_Behind_region_Restores()
     {
@@ -252,5 +252,14 @@ public class RegionStoreTests
         var subStore = store.GetSubStore(new RowRegion(3, 4), newStoreResetsOffsets: true);
         subStore.GetData(0, 1).Should().BeEquivalentTo(new int[] { 1 });
         subStore.GetData(1, 2).Should().BeEquivalentTo(new int[] { 2 });
+    }
+
+    [Test]
+    public void Removing_Across_Column_Region_Doesnt_Overflow()
+    {
+        var store = new ConsolidatedDataStore<int>();
+        store.Add(new ColumnRegion(10, 20), 1);
+
+        store.RemoveRows(10, 10);
     }
 }


### PR DESCRIPTION
Fix bug #82. When removing rows/columns from a region restore we would remove any remaining area if the total area remaining was less than the MinArea. This PR does it without causing an arithmetic overflow error.