### PR TITLE
Don't convert editor input string if the cell type is text.

### DIFF
--- a/src/BlazorDatasheet.Core/Edit/Editor.cs
+++ b/src/BlazorDatasheet.Core/Edit/Editor.cs
@@ -85,6 +85,7 @@ public class Editor
     /// <param name="col"></param>
     /// <param name="isSoftEdit">If true, the editor should hold on to the edit when arrow keys are pressed.</param>
     /// <param name="mode">Details on the method that was used to begin the edit.</param>
+    /// <param name="mode">Details on the method that was used to begin the edit.</param>
     /// <param name="key">The key that was used to begin the edit, if the entry mode was using the keyboard</param>
     public void BeginEdit(int row, int col, bool isSoftEdit = true, EditEntryMode mode = EditEntryMode.None,
         string? key = null)
@@ -155,7 +156,7 @@ public class Editor
         }
 
         var formulaResult = isFormula ? Sheet.FormulaEngine.Evaluate(parsedFormula) : CellValue.Empty;
-        var editValue = isFormula ? formulaResult : new CellValue(this.EditValue);
+        var editValue = isFormula ? formulaResult : GetValueAsCellValue(EditCell.Row, EditCell.Col, EditValue);
 
         var beforeAcceptEdit = new BeforeAcceptEditEventArgs(EditCell, editValue, parsedFormula, formulaString);
         BeforeEditAccepted?.Invoke(this, beforeAcceptEdit);
@@ -194,6 +195,18 @@ public class Editor
         }
 
         return false;
+    }
+
+    private CellValue GetValueAsCellValue(int row, int col, string editValue)
+    {
+        var type = Sheet.Cells.GetCellType(row, col);
+        switch (type)
+        {
+            case "text":
+                return CellValue.Text(editValue);
+        }
+
+        return new CellValue(editValue);
     }
 
     private void ClearEdit()

--- a/src/BlazorDatasheet/DatasheetRow.razor
+++ b/src/BlazorDatasheet/DatasheetRow.razor
@@ -73,6 +73,7 @@
             @switch (visualCell.CellType)
             {
                 case "default":
+                case "text":
                 case "datetime":
                     <div style="width: 100%;">
                         @visualCell.FormattedString
@@ -146,4 +147,3 @@
 
 
 }
-

--- a/test/BlazorDatasheet.Test/Edit/EditTests.cs
+++ b/test/BlazorDatasheet.Test/Edit/EditTests.cs
@@ -1,4 +1,5 @@
 using BlazorDatasheet.Core.Data;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace BlazorDatasheet.Test.Edit;
@@ -69,5 +70,16 @@ public class EditTests
         sheet.Editor.AcceptEdit();
         sheet.Commands.Undo();
         Assert.AreEqual(null, sheet.Cells.GetValue(0, 0));
+    }
+
+    [Test]
+    public void Do_Not_Do_Conversion_If_Cell_Type_Is_Set_To_Text()
+    {
+        var sheet = new Sheet(10, 10);
+        sheet.Cells[0, 0].Type = "text";
+        sheet.Editor.BeginEdit(0, 0);
+        sheet.Editor.EditValue = "04-10-1";
+        sheet.Editor.AcceptEdit();
+        sheet.Cells[0,0].Value.Should().Be("04-10-1");
     }
 }


### PR DESCRIPTION
Fixes #96/#97. If the cell type is set by the user to "text", conversions from the editor string are not attempted.