### PR TITLE
Only render visible rows and cols

### DIFF
--- a/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
+++ b/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
@@ -270,6 +270,9 @@ public abstract class RowColInfoStore
     /// <returns></returns>
     public List<int> GetVisibleIndices(int start, int end)
     {
+        if (Sheet.GetSize(_axis) == 0)
+            return new List<int>();
+
         start = Math.Max(start, 0);
         end = Math.Min(end, Sheet.GetSize(_axis) - 1);
         var hidden = _visible.GetOverlapping(start, end);

--- a/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
+++ b/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
@@ -219,6 +219,8 @@ public abstract class RowColInfoStore
     /// <returns></returns>
     public bool IsVisible(int index)
     {
+        if (index < 0 || index >= Sheet.GetSize(_axis))
+            return false;
         return _visible.Get(index);
     }
 
@@ -258,6 +260,41 @@ public abstract class RowColInfoStore
 
         var cmd = new UnhideCommand(start, start + count - 1, _axis);
         Sheet.Commands.ExecuteCommand(cmd);
+    }
+
+    /// <summary>
+    /// Returns the visible rows or columns between <paramref name="start"/> and <paramref name="end"/> inclusive.
+    /// </summary>
+    /// <param name="start"></param>
+    /// <param name="end"></param>
+    /// <returns></returns>
+    public List<int> GetVisibleIndices(int start, int end)
+    {
+        start = Math.Max(start, 0);
+        end = Math.Min(end, Sheet.GetSize(_axis) - 1);
+        var hidden = _visible.GetOverlapping(start, end);
+
+        if (!hidden.Any())
+            return Enumerable.Range(start, end - start + 1).ToList();
+
+        var visibleRows = new List<int>();
+
+        int n = hidden.First().start - start;
+        if (n > 0)
+            visibleRows.AddRange(Enumerable.Range(start, n));
+
+        for (int i = 0; i < hidden.Count - 1; ++i)
+        {
+            n = hidden[i + 1].start - (hidden[i].end + 1);
+            if (n > 0)
+                visibleRows.AddRange(Enumerable.Range(hidden[i].end + 1, n));
+        }
+
+        n = end - hidden.Last().end;
+        if (n > 0)
+            visibleRows.AddRange(Enumerable.Range(hidden.Last().end + 1, n));
+
+        return visibleRows;
     }
 
     /// <summary>
@@ -301,7 +338,7 @@ public abstract class RowColInfoStore
         return nextIndex;
     }
 
-    public IEnumerable<Interval> GetVisibleRows()
+    public IEnumerable<Interval> GetVisible()
     {
         return _visible.GetAllIntervals();
     }

--- a/src/BlazorDatasheet.Core/Layout/CellLayoutProvider.cs
+++ b/src/BlazorDatasheet.Core/Layout/CellLayoutProvider.cs
@@ -165,10 +165,6 @@ public class CellLayoutProvider : IGridLayoutProvider
     public Viewport GetViewPort(double left, double top, double containerWidth, double containerHeight, int overflowX,
         int overflowY)
     {
-        // if top > total height of sheet we must have an issue...
-        // if left > total width of sheet we must have an issue...
-        // even if top > total height of sheet - container height we have an issue
-        // even if left > total width of sheet - container width we have an issue
         var totalWidth = _sheet.Columns.GetVisualWidthBetween(0, _sheet.NumCols);
         var totalHeight = _sheet.Rows.GetVisualHeightBetween(0, _sheet.NumRows);
         if (top > totalHeight - containerHeight)
@@ -194,7 +190,14 @@ public class CellLayoutProvider : IGridLayoutProvider
         var startCol = Math.Max(visibleColStart - overflowX, 0);
         var endCol = Math.Min(Math.Max(_sheet.NumCols - 1, 0), visibleColEnd + overflowX);
 
-        var region = new Region(startRow, endRow, startCol, endCol);
+        var rowIndices = _sheet.Rows.GetVisibleIndices(startRow, endRow);
+        var colIndices = _sheet.Columns.GetVisibleIndices(startCol, endCol);
+
+        var region = new Region(
+            rowIndices.FirstOrDefault(),
+            rowIndices.LastOrDefault(),
+            colIndices.FirstOrDefault(),
+            colIndices.LastOrDefault());
 
         var leftPos = _sheet.Columns.GetVisualTop(startCol);
         var topPos = _sheet.Rows.GetVisualTop(startRow);
@@ -212,8 +215,10 @@ public class CellLayoutProvider : IGridLayoutProvider
             DistanceRight = distRight,
             VisibleWidth = visibleWidth,
             VisibleHeight = visibleHeight,
-            NumberVisibleCols = _sheet.Columns.CountVisible(startCol, endCol),
-            NumberVisibleRows = _sheet.Rows.CountVisible(startRow, endRow)
+            NumberVisibleCols = colIndices.Count,
+            NumberVisibleRows = rowIndices.Count,
+            VisibleRowIndices = rowIndices,
+            VisibleColIndices = colIndices
         };
     }
 }

--- a/src/BlazorDatasheet.Core/Layout/Viewport.cs
+++ b/src/BlazorDatasheet.Core/Layout/Viewport.cs
@@ -44,4 +44,8 @@ public class Viewport
     
     public int NumberVisibleRows { get; internal init; }
     public int NumberVisibleCols { get; internal init; }
+
+    public List<int> VisibleRowIndices { get; internal init; } = new();
+    public List<int> VisibleColIndices { get; internal init; } = new();
+
 }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -182,7 +182,7 @@
                             <td colspan="1" rowspan="@(_visualSheet.Viewport.NumberVisibleRows + 1)"
                                 style="padding: 0; border: 0;height: 0;">
                                 <div @ref="_fillerLeft" id="filler-left"
-                                     style="display: block; min-width: @(_visualSheet.Viewport.Left)px; height: @(RenderedInnerSheetHeight)px;">
+                                     style="display: block; min-width: @(_visualSheet.Viewport.Left)px; height: @(Math.Max(RenderedInnerSheetHeight, 1))px;">
                                 </div>
                             </td>
                             <td colspan="@_visualSheet.Viewport.NumberVisibleCols" style="max-height: 0;"></td>
@@ -228,7 +228,9 @@
                             <tr>
                                 @if (ShowRowHeadings)
                                 {
+                                    <!-- Heading -->
                                     <td></td>
+                                    <!-- for virtualiser -->
                                     <td></td>
                                 }
                                 <td colspan="@_visualSheet.Viewport.VisibleRegion.Width">

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -68,7 +68,7 @@
                             <!-- virtualisation column -->
                             <col style="width: @(_visualSheet.Viewport.Left)px;"/>
 
-                            @if (Sheet.NumCols > 0)
+                            @if (_visualSheet.Viewport.NumberVisibleCols > 0)
                             {
                                 @for (int i = _visualSheet.Viewport.VisibleRegion.Left; i <= _visualSheet.Viewport.VisibleRegion.Right; i++)
                                 {
@@ -85,7 +85,7 @@
                         <!-- col headings -->
                         @if (ShowColHeadings)
                         {
-                            if (Sheet.NumCols > 0)
+                            if (_visualSheet.Viewport.NumberVisibleCols > 0)
                             {
                                 <thead class="sheet-left @(StickyHeadings ? "col-sticky" : "")">
                                 <tr style="height: @(_cellLayoutProvider.ColHeadingHeight)px;" class="sheet-top">
@@ -188,7 +188,7 @@
                             <td colspan="@_visualSheet.Viewport.NumberVisibleCols" style="max-height: 0;"></td>
                         </tr>
 
-                        @if (Sheet.NumRows > 0 && _visualSheet.Viewport.NumberVisibleRows > 0)
+                        @if (_visualSheet.Viewport.NumberVisibleRows > 0)
                         {
                             @for (int i = 0; i < _visualSheet.Viewport.VisibleRowIndices.Count; i++)
                             {

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -29,8 +29,7 @@
             CanUserRemoveRows="@CanUserRemoveRows"
             CanUserHideCols="@CanUserHideCols"
             CanUserHideRows="@CanUserHideRows"
-            DefaultFilterTypes="@DefaultFilterTypes"
-            />
+            DefaultFilterTypes="@DefaultFilterTypes"/>
 
 
         <SheetMenuTarget
@@ -189,15 +188,13 @@
                             <td colspan="@_visualSheet.Viewport.NumberVisibleCols" style="max-height: 0;"></td>
                         </tr>
 
-                        @if (Sheet.NumRows > 0)
+                        @if (Sheet.NumRows > 0 && _visualSheet.Viewport.NumberVisibleRows > 0)
                         {
-                            @for (int rowIndex = _visualSheet.Viewport.VisibleRegion.Top; rowIndex <= _visualSheet.Viewport.VisibleRegion.Bottom; rowIndex++)
+                            @for (int i = 0; i < _visualSheet.Viewport.VisibleRowIndices.Count; i++)
                             {
-                                var row = rowIndex;
+                                var rowOffset = i;
+                                var row = _visualSheet.Viewport.VisibleRowIndices[rowOffset];
                                 var rowHeight = @_cellLayoutProvider.ComputeHeight(row, 1);
-
-                                if (rowHeight == 0)
-                                    continue;
 
                                 <tr @key="row"
                                     style="max-height:@(rowHeight)px;height:@(rowHeight)px;"

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -124,6 +124,11 @@
                             {
                                 <thead>
                                 <tr>
+                                    @if (ShowRowHeadings)
+                                    {
+                                        <td></td>
+                                        <td></td>
+                                    }
                                     <td colspan="1">
                                         @if (EmptyColumnsTemplate == null)
                                         {
@@ -233,7 +238,7 @@
                                     <!-- for virtualiser -->
                                     <td></td>
                                 }
-                                <td colspan="@_visualSheet.Viewport.VisibleRegion.Width">
+                                <td colspan="@(_visualSheet.Viewport.VisibleRegion.Width + 1)">
                                     @if (EmptyRowsTemplate == null)
                                     {
                                         <div>No rows</div>

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -85,21 +85,21 @@
                         <!-- col headings -->
                         @if (ShowColHeadings)
                         {
-                            if (_visualSheet.Viewport.NumberVisibleCols > 0)
-                            {
-                                <thead class="sheet-left @(StickyHeadings ? "col-sticky" : "")">
-                                <tr style="height: @(_cellLayoutProvider.ColHeadingHeight)px;" class="sheet-top">
-                                    @if (ShowRowHeadings) // the bit to the left of col headings
-                                    {
-                                        <th></th>
-                                        <th style="z-index: 4;" class="col-head row-head sheet-left @(StickyHeadings ? "row-sticky col-sticky" : "")"></th>
-                                    }
+                            <thead class="sheet-left @(StickyHeadings ? "col-sticky" : "")">
+                            <tr style="height: @(_cellLayoutProvider.ColHeadingHeight)px;" class="sheet-top">
+                                @if (ShowRowHeadings) // the bit to the left of col headings
+                                {
+                                    <th></th>
+                                    <th style="z-index: 4;" class="col-head row-head sheet-left @(StickyHeadings ? "row-sticky col-sticky" : "")"></th>
+                                }
 
-                                    <!-- Virtualisation column -->
-                                    <th style="position: relative;">
-                                        <PortalTarget TargetId="Col" DatasheetId="@Id"/>
-                                    </th>
+                                <th style="position: relative;">
+                                    <!-- portal target for rendering column selection highlights -->
+                                    <PortalTarget TargetId="Col" DatasheetId="@Id"/>
+                                </th>
 
+                                @if (_visualSheet.Viewport.NumberVisibleCols > 0)
+                                {
                                     <ColumnHeadingsRenderer
                                         NCols="@_visualSheet.Viewport.VisibleRegion.Width"
                                         ColStart="@_visualSheet.Viewport.VisibleRegion.Left"
@@ -117,18 +117,9 @@
                                             }
                                         </HeadingRenderer>
                                     </ColumnHeadingsRenderer>
-                                </tr>
-                                </thead>
-                            }
-                            else
-                            {
-                                <thead>
-                                <tr>
-                                    @if (ShowRowHeadings)
-                                    {
-                                        <td></td>
-                                        <td></td>
-                                    }
+                                }
+                                else
+                                {
                                     <td colspan="1">
                                         @if (EmptyColumnsTemplate == null)
                                         {
@@ -139,9 +130,9 @@
                                             <div>@EmptyColumnsTemplate</div>
                                         }
                                     </td>
-                                </tr>
-                                </thead>
-                            }
+                                }
+                            </tr>
+                            </thead>
                         }
 
                         <tbody>

--- a/src/BlazorDatasheet/DatasheetRow.razor
+++ b/src/BlazorDatasheet/DatasheetRow.razor
@@ -2,9 +2,10 @@
 @using BlazorDatasheet.Render
 @using BlazorDatasheet.Render.DefaultComponents
 
-@for (int j = VisualSheet.Viewport.VisibleRegion.Left; j <= VisualSheet.Viewport.VisibleRegion.Right; j++)
+@for (int j = 0; j < VisualSheet.Viewport.VisibleColIndices.Count; j++)
 {
-    var col = j;
+    var colOffset = j;
+    var col = VisualSheet.Viewport.VisibleColIndices[colOffset];
     var visualCell = VisualSheet.GetVisualCell(Row, col);
 
     if (!visualCell.IsVisible)

--- a/test/BlazorDatasheet.Test/Commands/FilterCommandsTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/FilterCommandsTests.cs
@@ -24,10 +24,10 @@ public class FilterCommandsTests
         var cmd = new SetColumnFilterCommand(0, new TestFilter("Test"));
         cmd.Execute(sheet);
 
-        sheet.Rows.GetVisibleRows().Should().BeEquivalentTo<Interval>([new(1, 1)]);
+        sheet.Rows.GetVisible().Should().BeEquivalentTo<Interval>([new(1, 1)]);
 
         cmd.Undo(sheet);
-        sheet.Rows.GetVisibleRows().Should().BeNullOrEmpty();
+        sheet.Rows.GetVisible().Should().BeNullOrEmpty();
     }
 
     [Test]
@@ -57,7 +57,7 @@ public class FilterCommandsTests
         filter.Filters.First().Should().BeOfType<TestFilter>();
         filter.Filters.Cast<TestFilter>().First().MatchValue.Should().Be("Test");
 
-        sheet.Rows.GetVisibleRows().Should().BeEquivalentTo<Interval>([new(1, 1)]);
+        sheet.Rows.GetVisible().Should().BeEquivalentTo<Interval>([new(1, 1)]);
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Layout/CellLayoutProviderTests.cs
+++ b/test/BlazorDatasheet.Test/Layout/CellLayoutProviderTests.cs
@@ -113,4 +113,30 @@ public class CellLayoutProviderTests
         sheet.Columns.GetColumnIndex(0).Should().Be(0);
         sheet.Columns.GetColumnIndex(41).Should().Be(1);
     }
+    
+    [Test]
+    public void Compute_Visible_Rows_Correctly()
+    {
+        var sheet = new Sheet(10, 12, 10, 10);
+        var cp = new CellLayoutProvider(sheet);
+        sheet.Rows.Hide(0, 2);
+        sheet.Rows.Hide(5, 2);
+        cp.TotalHeight.Should().Be(60);
+        var vp = cp.GetViewPort(0, 0, 100, 100, 0, 0);
+        vp.NumberVisibleRows.Should().Be(6);
+        vp.VisibleRegion.Top.Should().Be(2);
+        vp.VisibleRegion.Bottom.Should().Be(9);
+        vp.VisibleHeight.Should().Be(60);
+        vp.Top.Should().Be(0);
+        vp.DistanceBottom.Should().Be(0);
+    }
+
+    [Test]
+    public void Hide_First_Row_Calculates_Viewport_Top_Correctly()
+    {
+        var sheet = new Sheet(10, 12, 10, 10);
+        sheet.Rows.Hide(0, 1);
+        var cp = new CellLayoutProvider(sheet);
+        cp.GetViewPort(0,0,100,100,0,0).VisibleRegion.Top.Should().Be(1);
+    }
 }

--- a/test/BlazorDatasheet.Test/SheetTests/RowColVisibility.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/RowColVisibility.cs
@@ -55,4 +55,78 @@ public class RowColVisibility
         sheet.Rows.Hide(13, 2);
         sheet.Rows.GetNextVisible(12).Should().Be(15);
     }
+
+    [Test]
+    public void Get_Visible_Row_Indices_Tests_Start_Row_Hidden()
+    {
+        /*
+         * 0 H
+         * 1 V
+         * 2 V
+         * 3 H
+         * 4 H
+         * 5 V
+         */
+        var sheet = new Sheet(6, 5);
+        sheet.Rows.Hide(0, 1);
+        sheet.Rows.Hide(3, 2);
+        sheet.Rows.GetVisibleIndices(0, 5)
+            .Should()
+            .BeEquivalentTo([1, 2, 5]);
+    }
+
+    [Test]
+    public void Get_Visible_Row_Indices_Tests_End_Row_Hidden()
+    {
+        /*
+         * 0 V
+         * 1 V
+         * 2 V
+         * 3 H
+         * 4 V
+         * 5 H
+         */
+        var sheet = new Sheet(6, 5);
+        sheet.Rows.Hide(3, 1);
+        sheet.Rows.Hide(5, 1);
+        sheet.Rows.GetVisibleIndices(0, 5)
+            .Should()
+            .BeEquivalentTo([0, 1, 2, 4]);
+    }
+
+    [Test]
+    public void Get_Visible_Row_Indices_One_Row_Hidden_Returns_Correct()
+    {
+        /*
+         * 0 V
+         * 1 V
+         * 2 V
+         * 3 V
+         * 4 V
+         * 5 H
+         */
+        var sheet = new Sheet(6, 5);
+        sheet.Rows.Hide(5, 1);
+        sheet.Rows.GetVisibleIndices(0, 5)
+            .Should()
+            .BeEquivalentTo([0, 1, 2, 3, 4]);
+    }
+
+    [Test]
+    public void Get_Visible_Row_Indices_All_Rows_Hidden_Returns_Correct()
+    {
+        /*
+         * 0 V
+         * 1 V
+         * 2 V
+         * 3 V
+         * 4 V
+         * 5 H
+         */
+        var sheet = new Sheet(6, 5);
+        sheet.Rows.Hide(0, 6);
+        sheet.Rows.GetVisibleIndices(0, 5)
+            .Should()
+            .BeEmpty();
+    }
 }


### PR DESCRIPTION
Previously the render process consisted of looping through all rows and columns in the view-port. Any hidden rows or columns inside the view-port would have their height calculated and skipped if height was zero. Big sheets with lots of hidden rows were slow to render i.e #108.

This update skips these by storing visible row and column indices in the view-port. The renderer then only considers those in the render loop.

- [x] Fix some issues with cell layout provider with visible row calculations
- [x] Don't consider hidden rows or columns in the render loop
- [x] Better handle the sheet when there are no visible rows or columns - virtualisation can break in these cases.