### PR TITLE
Formula circular references fix

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
@@ -55,6 +55,8 @@ public class SetCellValuesCommand : IUndoableCommand
 
     public bool Execute(Sheet sheet)
     {
+        sheet.ScreenUpdating = false;
+        sheet.BatchUpdates();
         if (_values != null)
             ExecuteSetObjectArrayData(sheet);
         else if (_cellValues != null)
@@ -65,13 +67,14 @@ public class SetCellValuesCommand : IUndoableCommand
             ExecuteSetRegionData(sheet);
         else
             return false;
+        sheet.EndBatchUpdates();
+        sheet.ScreenUpdating = true;
 
         return true;
     }
 
     private void ExecuteSetObjectArrayData(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
         var rowEnd = _row + _values!.Length;
         var colEnd = _col;
 
@@ -85,12 +88,10 @@ public class SetCellValuesCommand : IUndoableCommand
         }
 
         sheet.MarkDirty(new Region(_row, rowEnd, _col, colEnd));
-        sheet.ScreenUpdating = true;
     }
 
     private void ExecuteSetCellValueData(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
         var rowEnd = _row + _cellValues!.Length;
         var colEnd = _col;
 
@@ -104,14 +105,11 @@ public class SetCellValuesCommand : IUndoableCommand
         }
 
         sheet.MarkDirty(new Region(_row, rowEnd, _col, colEnd));
-        sheet.ScreenUpdating = true;
     }
 
 
     private void ExecuteSetRegionData(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
-
         for (int row = _region!.Top; row <= _region!.Bottom; row++)
         {
             for (int col = _region.Left; col <= _region.Right; col++)
@@ -121,7 +119,6 @@ public class SetCellValuesCommand : IUndoableCommand
         }
 
         sheet.MarkDirty(_region);
-        sheet.ScreenUpdating = true;
     }
 
     private void ExecuteSetRegionDataAsCellValue(Sheet sheet)
@@ -137,13 +134,14 @@ public class SetCellValuesCommand : IUndoableCommand
         }
 
         sheet.MarkDirty(_region);
-        sheet.ScreenUpdating = true;
     }
 
     public bool Undo(Sheet sheet)
     {
         sheet.ScreenUpdating = false;
+        sheet.BatchUpdates();
         sheet.Cells.Restore(_restoreData);
+        sheet.EndBatchUpdates();
         sheet.ScreenUpdating = true;
         return true;
     }

--- a/src/BlazorDatasheet.Core/FormulaEngine/SheetEnvironment.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/SheetEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.References;
 
 namespace BlazorDatasheet.Core.FormulaEngine;
@@ -62,6 +63,11 @@ public class SheetEnvironment : IEnvironment
     }
 
     public CellValue GetCellValue(int row, int col) => _sheet.Cells.GetCellValue(row, col);
+
+    public CellFormula? GetFormula(int row, int col)
+    {
+        return _sheet.Cells.GetFormula(row, col);
+    }
 
     public CellValue[][] GetRangeValues(Reference reference)
     {

--- a/src/BlazorDatasheet.DataStructures/Graph/SCCSort.cs
+++ b/src/BlazorDatasheet.DataStructures/Graph/SCCSort.cs
@@ -1,0 +1,76 @@
+﻿namespace BlazorDatasheet.DataStructures.Graph;
+
+/// <summary>
+/// Implements Tarjan's strongly connected components algorithm
+/// https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public class SccSort<T> where T : Vertex
+{
+    private readonly DependencyGraph<T> _graph;
+    private Dictionary<string, int> _indices = null!;
+    private Dictionary<string, int> _low = null!;
+    private List<IList<T>> _results = null!;
+    private Stack<T> _stack = null!;
+    private int _index;
+
+    public SccSort(DependencyGraph<T> graph)
+    {
+        _graph = graph;
+    }
+
+    public IList<IList<T>> Sort()
+    {
+        _indices = new();
+        _low = new();
+        _results = new();
+        _stack = new();
+        _index = 0;
+        
+        foreach (var v in _graph.GetAll())
+        {
+            if (!_indices.ContainsKey(v.Key))
+                StrongConnect(v);
+        }
+
+        // Result of this algo is reverse topological sort of a DAG
+        _results.Reverse();
+
+        return _results;
+    }
+
+    private void StrongConnect(T v)
+    {
+        // set depth index for v to smallest unused index
+        _indices[v.Key] = _index;
+        _low[v.Key] = _index;
+        _index++;
+        _stack.Push(v);
+
+        foreach (var w in _graph.Adj(v))
+        {
+            if (!_indices.ContainsKey(w.Key))
+            {
+                // have not yet visited w
+                StrongConnect(w);
+                _low[v.Key] = Math.Min(_low[v.Key], _low[w.Key]);
+            }
+            else if (_stack.Contains(w))
+                _low[v.Key] = Math.Min(_low[v.Key], _indices[w.Key]);
+        }
+
+        if (_low[v.Key] == _indices[v.Key])
+        {
+            // start a new strongly connected component
+            var g = new List<T>();
+            T w;
+            do
+            {
+                w = _stack.Pop();
+                g.Add(w);
+            } while (v.Key != w.Key);
+
+            _results.Add(g);
+        }
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
+++ b/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
@@ -262,10 +262,14 @@ public class DependencyManager
         return restoreData;
     }
 
-    public IEnumerable<FormulaVertex> GetCalculationOrder()
+    /// <summary>
+    /// Returns the topological sort of the vertices. Each group of vertices is a strongly connected group.
+    /// </summary>
+    /// <returns></returns>
+    public IList<IList<FormulaVertex>> GetCalculationOrder()
     {
-        var sort = new TopologicalSort<FormulaVertex>();
-        return sort.Sort(_dependencyGraph);
+        var sort = new SccSort<FormulaVertex>(_dependencyGraph);
+        return sort.Sort();
     }
 
     public IEnumerable<DependencyInfo> GetDependencies()

--- a/src/BlazorDatasheet.Formula.Core/ErrorType.cs
+++ b/src/BlazorDatasheet.Formula.Core/ErrorType.cs
@@ -8,5 +8,6 @@ public enum ErrorType
     Null,
     Num,
     Ref,
-    Value
+    Value,
+    Circular
 }

--- a/src/BlazorDatasheet.Formula.Core/IEnvironment.cs
+++ b/src/BlazorDatasheet.Formula.Core/IEnvironment.cs
@@ -1,10 +1,20 @@
-﻿using BlazorDatasheet.Formula.Core.Interpreter.References;
+﻿using BlazorDatasheet.Formula.Core.Interpreter;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
 
 namespace BlazorDatasheet.Formula.Core;
 
 public interface IEnvironment
 {
     CellValue GetCellValue(int row, int col);
+
+    /// <summary>
+    /// Return a cell formula at <paramref name="row"/>, <paramref name="col"/> if it exists.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <param name="col"></param>
+    /// <returns></returns>
+    CellFormula? GetFormula(int row, int col);
+
     public CellValue[][] GetRangeValues(Reference reference);
     bool FunctionExists(string functionIdentifier);
     ISheetFunction GetFunctionDefinition(string identifierText);

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
@@ -10,6 +10,8 @@ public class Evaluator
     private readonly BinaryOpEvaluator _bOp;
     private readonly UnaryOpEvaluator _uOp;
     private readonly IEnvironment _environment;
+    private FormulaEvaluationOptions _options = FormulaEvaluationOptions.Default;
+    private FormulaExecutionContext _formulaExecutionContext = default!;
 
     public Evaluator(IEnvironment environment)
     {
@@ -20,45 +22,40 @@ public class Evaluator
         _uOp = new UnaryOpEvaluator(cellValueCoercer);
     }
 
-    public CellValue Evaluate(CellFormula cellFormula, bool resolveReferences = true)
+    public CellValue Evaluate(CellFormula cellFormula, FormulaExecutionContext? executionContext = null,
+        FormulaEvaluationOptions? options = null)
     {
-        return Evaluate(cellFormula.ExpressionTree, resolveReferences);
+        _options = options ?? FormulaEvaluationOptions.Default;
+        _formulaExecutionContext = executionContext ?? new FormulaExecutionContext();
+        var evaluatedValue = DoEvaluate(cellFormula);
+        return evaluatedValue;
+    }
+
+    private CellValue DoEvaluate(CellFormula formula)
+    {
+        if (_formulaExecutionContext.IsExecuting(formula))
+        {
+            return CellValue.Error(ErrorType.Circular);
+        }
+
+        _formulaExecutionContext.SetExecuting(formula);
+        return Evaluate(formula.ExpressionTree);
     }
 
     /// <summary>
     /// Evaluates a syntax tree
     /// </summary>
     /// <param name="tree"></param>
-    /// <param name="resolveReferences">Whether or not to resolve any CellValues that are references. If set to false,
-    /// a CellValue will be returned with a ValueType Reference, otherwise the value will be looked up in the sheet.</param>
     /// <returns></returns>
-    public CellValue Evaluate(SyntaxTree tree, bool resolveReferences = true)
+    internal CellValue Evaluate(SyntaxTree tree)
     {
-        if (tree.Errors.Any())
+        if (tree.Errors.Count > 0)
             return CellValue.Error(ErrorType.Na);
-        var result = EvaluateExpression(tree.Root);
 
-        // If we haven't resolved references yet, do that.
-        if (resolveReferences && result.ValueType == CellValueType.Reference)
-        {
-            var r = (Reference)result.Data!;
-            if (r.Kind == ReferenceKind.Cell)
-            {
-                var c = (CellReference)r;
-                return _environment.GetCellValue(c.RowIndex, c.ColIndex);
-            }
-            else if (r.Kind == ReferenceKind.Range)
-            {
-                return CellValue.Array(_environment
-                    .GetRangeValues(r));
-            }
-        }
-
-        // otherwise return the calculated result.
-        return result;
+        return EvaluateExpression(tree.Root);
     }
 
-    public CellValue EvaluateExpression(Expression expression)
+    private CellValue EvaluateExpression(Expression expression)
     {
         switch (expression.Kind)
         {
@@ -118,7 +115,36 @@ public class Evaluator
         //TODO check it's valid (inside sheet)
         if (expression.Reference.IsInvalid)
             return CellValue.Error(ErrorType.Ref);
+
+        if (expression.Reference.Kind == ReferenceKind.Cell)
+            return EvaluateCellReference((CellReference)expression.Reference);
+
+        if (expression.Reference.Kind == ReferenceKind.Range)
+            return EvaluateRangeReference((RangeReference)expression.Reference);
+
+        // we currently don't handle array values...
         return CellValue.Reference(expression.Reference);
+    }
+
+    private CellValue EvaluateCellReference(CellReference cellReference)
+    {
+        if (_options.DoNotResolveDependencies)
+            return CellValue.Reference(cellReference);
+
+        var formula = _environment.GetFormula(cellReference.RowIndex, cellReference.ColIndex);
+        if (formula == null)
+            return _environment.GetCellValue(cellReference.RowIndex, cellReference.ColIndex);
+
+        return DoEvaluate(formula);
+    }
+
+    private CellValue EvaluateRangeReference(RangeReference reference)
+    {
+        if (_options.DoNotResolveDependencies)
+            return CellValue.Reference(reference);
+
+        return CellValue.Array(_environment
+            .GetRangeValues(reference));
     }
 
     private CellValue EvaluateFunctionCall(FunctionExpression node)

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaEvaluationOptions.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaEvaluationOptions.cs
@@ -1,0 +1,21 @@
+﻿namespace BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
+
+public class FormulaEvaluationOptions
+{
+    /// <summary>
+    /// When true, the formula evaluator should not resolve dependencies. Instead,
+    /// references are CellValue.References. Default is false.
+    /// </summary>
+    public bool DoNotResolveDependencies { get; }
+
+    /// <summary>
+    /// Provides options for the formula <see cref="Evaluator"/>
+    /// </summary>
+    /// <param name="doNotResolveDependencies"> When true, the formula evaluator should not resolve dependencies. Instead,references are CellValue.References. Default is false.</param>
+    public FormulaEvaluationOptions(bool doNotResolveDependencies)
+    {
+        DoNotResolveDependencies = doNotResolveDependencies;
+    }
+
+    public static FormulaEvaluationOptions Default => new(false);
+}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
@@ -1,0 +1,67 @@
+﻿namespace BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
+
+public class FormulaExecutionContext
+{
+    private readonly List<CellFormula> _executed = new();
+    private readonly Dictionary<CellFormula, CellValue> _executedValues = new();
+    public IReadOnlyCollection<CellFormula> ExecutionOrder => _executed;
+    private readonly Stack<CellFormula> _executing = new();
+
+    internal bool IsExecuting(CellFormula formula)
+    {
+        return _executing.Contains(formula);
+    }
+
+    /// <summary>
+    /// If the formula has been executed, returns true and sets <paramref name="value"/> to the executed value.
+    /// </summary>
+    /// <param name="formula"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public bool TryGetExecutedValue(CellFormula formula, out CellValue value)
+    {
+        value = CellValue.Empty;
+        if (_executedValues.TryGetValue(formula, out var cellValue))
+        {
+            value = cellValue;
+            return true;
+        }
+
+        return false;
+    }
+
+    internal void SetExecuting(CellFormula formula)
+    {
+        _executing.Push(formula);
+    }
+
+    /// <summary>
+    /// Marks the currently executing <see cref="CellFormula"/> as executed
+    /// </summary>
+    public void FinishCurrentExecuting(CellValue value)
+    {
+        if (_executing.TryPop(out var formula))
+        {
+            _executed.Add(formula);
+            _executedValues.Add(formula, value);
+        }
+    }
+
+    /// <summary>
+    /// Clears the record of executing <see cref="CellFormula"/>
+    /// </summary>
+    public void ClearExecuting()
+    {
+        _executing.Clear();
+    }
+
+    /// <summary>
+    /// Clears the execution context
+    /// </summary>
+    public void Clear()
+    {
+        _executed.Clear();
+        _executing.Clear();
+        _executedValues.Clear();
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/ParameterConverter.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/ParameterConverter.cs
@@ -14,13 +14,13 @@ public class ParameterConverter
     }
 
     /// <summary>
-    /// Performs an implicit conversion of a value into another type, specified by <paramref name="definition"/>
+    /// Performs an implicit conversion of a value into another type, specified by <paramref name="type"/>
     /// See the below link as we try to follow this standard.
     /// http://docs.oasis-open.org/office/v1.2/os/OpenDocument-v1.2-os-part2.html
     /// If the conversion cannot be performed, an error is usually the result.
     /// </summary>
     /// <param name="value"></param>
-    /// <param name="definition"></param>
+    /// <param name="type"></param>
     /// <returns></returns>
     public CellValue ConvertVal(CellValue value, ParameterType type)
     {

--- a/src/BlazorDatasheet.Formula.Functions/Logical/IfFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Logical/IfFunction.cs
@@ -43,5 +43,5 @@ public class IfFunction : ISheetFunction
         return CellValue.Logical(isTrue);
     }
 
-    public bool AcceptsErrors => false;
+    public bool AcceptsErrors => true;
 }

--- a/test/BlazorDatasheet.Test/Formula/DependencyManagerTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/DependencyManagerTests.cs
@@ -35,6 +35,7 @@ public class DependencyManagerTests
         dm.SetFormula(0, 0, GetFormula("=A2")); // A1
         dm.SetFormula(1, 0, GetFormula("=A3")); // A2
         dm.GetCalculationOrder()
+            .SelectMany(x => x)
             .Select(x => new CellPosition(x.Region!.Top, x.Region!.Left))
             .Should()
             .BeEquivalentTo([
@@ -51,7 +52,7 @@ public class DependencyManagerTests
         dm.SetFormula(0, 1, GetFormula("=A2")); // B1
         dm.SetFormula(0, 2, GetFormula("=A3")); // C1
 
-        var sorted = dm.GetCalculationOrder()
+        var sorted = dm.GetCalculationOrder().SelectMany(x => x)
             .Where(x => x.Formula != null)
             .Select(x => x.Region!.Left)
             .ToList();
@@ -79,6 +80,7 @@ public class DependencyManagerTests
         dm.SetFormula(1, 0, f);
         dm.InsertRowColAt(0, 2, Axis.Row);
         dm.GetCalculationOrder()
+            .SelectMany(x => x)
             .Should().BeEquivalentTo([new FormulaVertex(3, 0, GetFormula("=A7"))]);
     }
 
@@ -106,7 +108,7 @@ public class DependencyManagerTests
         dm.HasDependents(1, 0).Should().BeFalse();
         dm.Restore(rest);
         dm.HasDependents(1, 0).Should().BeTrue();
-        dm.GetCalculationOrder().Select(x => x.Region)
+        dm.GetCalculationOrder().SelectMany(x => x).Select(x => x.Region)
             .Should()
             .BeEquivalentTo([new Region(0, 0)]);
     }

--- a/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
+++ b/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Util;
 using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.References;
 
 namespace BlazorDatasheet.Test.Formula;
@@ -13,6 +14,7 @@ public class TestEnvironment : IEnvironment
     private Dictionary<CellPosition, CellValue> _cellValues = new();
     private Dictionary<string, ISheetFunction> _functions = new();
     private Dictionary<string, CellValue> _variables = new();
+    private Dictionary<CellPosition, CellFormula> _formulas = new();
 
     public void SetCellValue(int row, int col, object val)
     {
@@ -23,6 +25,13 @@ public class TestEnvironment : IEnvironment
     {
         _cellValues.TryAdd(position, new CellValue(val));
         _cellValues[position] = new CellValue(val);
+    }
+
+    public void SetCellFormula(int row, int col, CellFormula formula)
+    {
+        var position = new CellPosition(row, col);
+        if (_formulas.TryAdd(position, formula))
+            _formulas[position] = formula;
     }
 
     public void RegisterFunction(string name, ISheetFunction functionDefinition)
@@ -59,6 +68,14 @@ public class TestEnvironment : IEnvironment
         if (hasVal)
             return val;
         return CellValue.Empty;
+    }
+
+    public CellFormula? GetFormula(int row, int col)
+    {
+        var hasVal = _formulas.TryGetValue(new CellPosition(row, col), out var val);
+        if (hasVal)
+            return val;
+        return null;
     }
 
     public CellValue[][] GetRangeValues(Reference reference)

--- a/test/BlazorDatasheet.Test/Functions/LogicalFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/LogicalFunctionTests.cs
@@ -24,7 +24,7 @@ public class LogicalFunctionTests
     {
         var eval = new Evaluator(_env);
         var parser = new Parser();
-        return eval.Evaluate(parser.Parse(formulaString), resolveReferences).Data;
+        return eval.Evaluate(parser.FromString(formulaString), null, new FormulaEvaluationOptions(!resolveReferences)).Data;
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Functions/LookupFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/LookupFunctionTests.cs
@@ -22,8 +22,8 @@ public class LookupFunctionTests
     {
         var eval = new Evaluator(_env);
         var parser = new Parser();
-        var formula = parser.Parse(formulaString);
-        return eval.Evaluate(formula, resolveReferences).Data;
+        var formula = parser.FromString(formulaString);
+        return eval.Evaluate(formula, null, new FormulaEvaluationOptions(!resolveReferences)).Data;
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
@@ -62,14 +62,25 @@ public class MathFunctionTests
 
         Eval("=sum(A1:A2,C1:C2)").Should().Be(nums.Sum());
 
-        _env.SetCellValue(0, 0, true);
-        Eval("=sum(A1)").Should().Be(0);
-
-        _env.SetCellValue(0, 0, "abc");
-        Eval("=sum(A1)").Should().Be(0);
-
         _env.SetCellValue(2, 1, 123);
         Eval("=sum(B3)").Should().Be(123);
+    }
+
+    [Test]
+    public void Sum_With_True_Cell_Value_Should_Return_0()
+    {
+        _env.RegisterFunction("sum", new SumFunction());
+        _env.SetCellValue(0, 0, true);
+        Eval("=sum(A1)").Should().Be(0);
+    }
+
+    [Test]
+    public void Sum_With_Text_Cell_Value_Should_Return_0()
+    {
+        // correct behaviour from excel - if sum range contains text it should be valuated as 0
+        _env.RegisterFunction("sum", new SumFunction());
+        _env.SetCellValue(0, 0, "abc");
+        Eval("=sum(A1)").Should().Be(0);
     }
 
     [Test]


### PR DESCRIPTION
Adds handling of circular dependencies and fixes #126.

Issues:
- Conversion of formula arguments to the relevant values is not working 100%. For example, set A1 = "abc" and evaluate Sum(A1), this should return 0 but it's returning #value because the reference isn't converted to a number sequence correctly.
- Evaluating SCCs is not efficient - recalculation may occur if they have already been evaluated. Attempting to set their value if they have been already calculated is causing tests to break.