### PR TITLE
Restrict acitons that require multiple cells to be selected (e.g. merge and sort) to not be visible unless the prerequisites for the actions are met

### DIFF
--- a/src/BlazorDatasheet/SelectionMenu.razor
+++ b/src/BlazorDatasheet/SelectionMenu.razor
@@ -22,7 +22,7 @@
             {
                 <SheetMenuItem OnClick="() => sheet.Cells.ClearCells(sheet.Selection.Regions)">Clear</SheetMenuItem>
             }
-            @if (MenuOptions.MergeEnabled)
+            @if (MenuOptions.MergeEnabled && !sheet.Selection.ActiveRegion.IsSingleCell())
             {
                 <SheetMenuItem OnClick="() => sheet.Cells.Merge(sheet.Selection.Regions)">Merge</SheetMenuItem>
             }
@@ -112,7 +112,7 @@
             }
         }
 
-        @if (MenuOptions.SortRangeEnabled)
+        @if (MenuOptions.SortRangeEnabled && sheet.Selection.ActiveRegion!.Height > 1)
         {
             <SheetMenuDivider/>
             <SheetSubMenu Label="Sort">


### PR DESCRIPTION
Merge and Sort don't make sense when only one cell is selected.  This PR hides those options if the prerequisites are not met.