### PR TITLE
Improve selection of scrollable ancestor.

### DIFF
--- a/src/BlazorDatasheet/wwwroot/js/virtualise-2d.js
+++ b/src/BlazorDatasheet/wwwroot/js/virtualise-2d.js
@@ -13,7 +13,7 @@
         let overflowX = window.getComputedStyle(parent).overflowX
         let overflow = window.getComputedStyle(parent).overflow
 
-        if (overflowY === 'scroll' || overflowX === 'scroll' || overflow === 'scroll')
+        if (overflowY !== 'visible' || overflowX !== 'visible' || overflow !== 'visible')
             return parent
 
         return this.findScrollableAncestor(parent)
@@ -106,7 +106,7 @@
 
     isScrollable(el) {
         let style = window.getComputedStyle(el)
-        return style.overflow === 'scroll' || style.overflowX === 'scroll' || style.overflowY === 'scroll'
+        return style.overflow !== 'visible' || style.overflowX !== 'visible' || style.overflowY !== 'visible'
     }
 
     isInsideSticky(el) {


### PR DESCRIPTION
Previously the scrollable ancestor was being selected by looking for 'scroll' in the overflow style. Now the scrollable ancestor is found by looking for any value other than 'hidden'.