### PR TITLE
Re-render rows if the column indices change.

### DIFF
--- a/src/BlazorDatasheet/DatasheetGridRow.razor
+++ b/src/BlazorDatasheet/DatasheetGridRow.razor
@@ -5,7 +5,7 @@
 @{
     var colOffset = 1;
 }
-@foreach (var col in VisibleColIndices)
+@foreach (var col in _visibleColIndices)
 {
     var dataCol = col;
     var dataRow = Row;
@@ -32,37 +32,7 @@
             data-col="@dataCol"
             class="sheet-cell"
             style="@visualCell.FormatStyleString;">
-            <div style="display: flex;">
-                @if (visualCell.Icon != null)
-                {
-                    <div
-                        style="margin-right:2px; float:left; color: @(visualCell.Format?.IconColor ?? "var(--icon-color)");">
-                        @GetIconRenderFragment(visualCell.Icon)
-                    </div>
-                }
-                @switch (visualCell.CellType)
-                {
-                    case "default":
-                    case "text":
-                    case "datetime":
-                        <div style="width: 100%;">
-                            @visualCell.FormattedString
-                        </div>
-                        break;
-                    case "boolean":
-                        <BoolRenderer Cell="visualCell" Sheet="Sheet"/>
-                        break;
-                    case "select":
-                        <SelectRenderer Cell="visualCell" Sheet="Sheet"/>
-                        break;
-
-                    default:
-                        <DynamicComponent
-                            Parameters="@GetCellRendererParameters(visualCell)"
-                            Type="@GetCellRendererType(visualCell.CellType)"/>
-                        break;
-                }
-            </div>
+            <div>@Row, @col</div>
         </div>
     </div>
     colOffset++;
@@ -76,6 +46,7 @@
 
     [Parameter] public Sheet Sheet { get; set; } = null!;
 
+    private List<int> _visibleColIndices = new();
     [Parameter] public List<int> VisibleColIndices { get; set; } = new();
 
     [Parameter, EditorRequired] public Dictionary<CellPosition, VisualCell> Cache { get; set; } = null!;
@@ -85,7 +56,35 @@
     [CascadingParameter(Name = "CustomCellTypeDefinitions")]
     public Dictionary<string, CellTypeDefinition> CustomCellTypeDefinitions { get; set; } = default!;
 
-    protected override bool ShouldRender() => IsDirty;
+    protected override bool ShouldRender() => IsDirty || _colIndicesChanged;
+    private bool _colIndicesChanged = false;
+
+    protected override void OnParametersSet()
+    {
+        if (VisibleColIndices != _visibleColIndices)
+        {
+            if (!IsDirty)
+            {
+                _colIndicesChanged = CompareIndices(_visibleColIndices, VisibleColIndices);
+            }
+            _visibleColIndices = VisibleColIndices;
+        }
+
+        base.OnParametersSet();
+    }
+
+    private bool CompareIndices(List<int> oldIndices, List<int> newIndices)
+    {
+        // for the purpose of this comparison we just want to know whether
+        // we need to re-render, so we do not need to compare all elements
+        if (oldIndices.Count != newIndices.Count)
+            return true;
+        if (oldIndices.FirstOrDefault() != newIndices.FirstOrDefault())
+            return true;
+        if (oldIndices.LastOrDefault() != newIndices.LastOrDefault())
+            return true;
+        return false;
+    }
 
     private Type GetCellRendererType(string type)
     {

--- a/src/BlazorDatasheet/Virtualise/Virtualise2D.razor
+++ b/src/BlazorDatasheet/Virtualise/Virtualise2D.razor
@@ -157,10 +157,6 @@
         _requiresRender = false;
     }
 
-    protected override void OnParametersSet()
-    {
-    }
-
     protected override async Task OnParametersSetAsync()
     {
         if (!_viewRegion.Equals(ViewRegion))


### PR DESCRIPTION
Fixes the last issue in #139.

Previously, scrolling issues could occur when:
1. The user scrolls all the way to the right
2. The user scrolls down.

When the user scrolls down the column indices rendered are likely to have changed because they would have scrolled one or two cells past the edge of the current view. When scrolling down, the column indices changed but the rows in the centre of the view weren't re-rendered because the datasheet didn't consider them dirty. This PR adds a check to each datasheet row to see whether the column indices change.