### PR TITLE
Ensure that MainView is assigned prior to attempting to refresh the view

### DIFF
--- a/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
+++ b/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
@@ -76,7 +76,10 @@ public partial class HeadingRenderer : SheetComponentBase
 
     public async void RefreshView()
     {
-        await MainView.RefreshView();
+        if (MainView is not null)
+        {
+            await MainView.RefreshView();
+        }
     }
 
     protected string GetSelectedClass(int index)


### PR DESCRIPTION
In a blazor wasm app, I am setting the column size in a SetParameters method and I've run into the situation where sometimes my assignment of the column size appears to trigger events before the Virtualize2d object is populated resulting in an NRE.

This change simply adds a check to see if it is not null (indicating assignment) and skips it if it is, with the understanding no refresh is necessary since it will be picked up when the object is constructed.

The actual exception
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at BlazorDatasheet.Render.Headings.HeadingRenderer.RefreshView() in C:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet\Render\Headings\HeadingRenderer.razor.cs:line 79
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.ThreadPool.BackgroundJobHandler()
```

The stack when setting a breakpoint and observing MainView being null
```
>	BlazorDatasheet.Render.Headings.HeadingRenderer.RefreshView [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet\Render\Headings\HeadingRenderer.razor.cs] Line 79	JavaScript
 	BlazorDatasheet.Render.Headings.HeadingRenderer.HandleSizeModified [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet\Render\Headings\HeadingRenderer.razor.cs] Line 74	JavaScript
 	BlazorDatasheet.Core.Data.RowColInfoStore.EmitSizeModified [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet.Core\Data\RowColInfoStore.cs] Line 100	JavaScript
 	BlazorDatasheet.Core.Data.RowColInfoStore.SetSizesImpl [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet.Core\Data\RowColInfoStore.cs] Line 94	JavaScript
 	BlazorDatasheet.Core.Commands.RowCols.SetSizeCommand.Execute [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet.Core\Commands\RowCols\SetSizeCommand.cs] Line 26	JavaScript
 	BlazorDatasheet.Core.Commands.CommandManager.ExecuteCommand [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet.Core\Commands\CommandManager.cs] Line 68	JavaScript
 	BlazorDatasheet.Core.Data.RowColInfoStore.SetSize [c:\Users\brend_i38wkf1\source\repos\BlazorDatasheet\src\BlazorDatasheet.Core\Data\RowColInfoStore.cs] Line 491	JavaScript

```