### PR TITLE
Variables as formula and named ranges

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.Formula.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.Formula.cs
@@ -24,7 +24,7 @@ public partial class CellStore
     /// <param name="formulaString"></param>
     public void SetFormula(int row, int col, string formulaString)
     {
-        var parsed = Sheet.FormulaEngine.ParseFormula(formulaString);
+        var parsed = Sheet.FormulaEngine.ParseFormula(formulaString, Sheet.Name);
         if (parsed.IsValid())
             SetFormula(row, col, parsed);
     }
@@ -59,7 +59,7 @@ public partial class CellStore
 
     internal CellStoreRestoreData SetFormulaImpl(int row, int col, string formula)
     {
-        var parsedFormula = Sheet.FormulaEngine.ParseFormula(formula);
+        var parsedFormula = Sheet.FormulaEngine.ParseFormula(formula, Sheet.Name);
         if (parsedFormula.IsValid())
             return SetFormulaImpl(row, col, parsedFormula);
         return new CellStoreRestoreData();

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.cs
@@ -273,7 +273,7 @@ public partial class CellStore
 
             var rangeStrFormula = $"={cellAddress}";
             var evaluatedValue =
-                Sheet.FormulaEngine.Evaluate(Sheet.FormulaEngine.ParseFormula(rangeStrFormula),
+                Sheet.FormulaEngine.Evaluate(Sheet.FormulaEngine.ParseFormula(rangeStrFormula, Sheet.Name),
                     resolveReferences: false);
             if (evaluatedValue.ValueType == CellValueType.Reference)
             {

--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -14,6 +14,7 @@ using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter.References;
 using System.Text;
 using BlazorDatasheet.Core.Events.Sort;
+using BlazorDatasheet.Core.FormulaEngine;
 
 namespace BlazorDatasheet.Core.Data;
 
@@ -148,6 +149,8 @@ public class Sheet
     /// </summary>
     private bool _isBatchingChanges;
 
+    public NamedRangeManager NamedRanges { get; }
+
     /// <summary>
     /// If the sheet is batching dirty regions, they are stored here.
     /// </summary>
@@ -163,6 +166,7 @@ public class Sheet
         Columns = new ColumnInfoStore(defaultWidth, this);
         Selection = new Selection(this);
         ConditionalFormats = new ConditionalFormatManager(this, Cells);
+        NamedRanges = new NamedRangeManager(this);
     }
 
     internal Sheet(int numRows, int numCols, int defaultWidth, int defaultHeight, Workbook workbook) : this(numRows,

--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -292,8 +292,8 @@ public class Sheet
             return null;
 
         var rangeStrFormula = $"={rangeStr}";
-        var evaluatedValue =
-            FormulaEngine.Evaluate(FormulaEngine.ParseFormula(rangeStrFormula), resolveReferences: false);
+        var evaluatedValue = FormulaEngine.Evaluate(FormulaEngine.ParseFormula(rangeStrFormula, Name, true),
+            resolveReferences: false);
         if (evaluatedValue.ValueType == CellValueType.Reference)
         {
             var reference = evaluatedValue.GetValue<Reference>();

--- a/src/BlazorDatasheet.Core/Edit/Editor.cs
+++ b/src/BlazorDatasheet.Core/Edit/Editor.cs
@@ -192,7 +192,7 @@ public class Editor
 
         if (isFormula)
         {
-            parsedFormula = Sheet.FormulaEngine.ParseFormula(formulaString!);
+            parsedFormula = Sheet.FormulaEngine.ParseFormula(formulaString!, Sheet.Name);
             if (!parsedFormula.IsValid())
             {
                 var args = new InvalidEditEventArgs(EditValue, $"Invalid formula", false);

--- a/src/BlazorDatasheet.Core/Events/SelectionChangedEventArgs.cs
+++ b/src/BlazorDatasheet.Core/Events/SelectionChangedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.DataStructures.Geometry;
+﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
 
 namespace BlazorDatasheet.Core.Events;
 
@@ -6,10 +7,13 @@ public class SelectionChangedEventArgs
 {
     public IReadOnlyList<IRegion> PreviousRegions { get; }
     public IReadOnlyList<IRegion> NewRegions { get; }
+    
+    public Sheet Sheet { get; }
 
-    public SelectionChangedEventArgs(IReadOnlyList<IRegion> previousRegions, IReadOnlyList<IRegion> newRegions)
+    public SelectionChangedEventArgs(IReadOnlyList<IRegion> previousRegions, IReadOnlyList<IRegion> newRegions, Sheet sheet)
     {
         PreviousRegions = previousRegions;
         NewRegions = newRegions;
+        Sheet = sheet;
     }
 }

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -237,6 +237,7 @@ public class FormulaEngine
     public void ClearVariable(string varName)
     {
         _environment.ClearVariable(varName);
+        DependencyManager.ClearFormula(varName);
         CalculateSheet(true);
     }
 

--- a/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
@@ -40,12 +40,12 @@ public class NamedRangeManager
             Clear(name);
 
         var rangeStrFormula = $"={rangeString}";
-        var formula = _sheet.FormulaEngine.ParseFormula(rangeStrFormula);
+        var formula = _sheet.FormulaEngine.ParseFormula(rangeStrFormula, _sheet.Name, true);
 
         var evaluatedValue = _sheet.FormulaEngine.Evaluate(formula, resolveReferences: false);
         if (evaluatedValue.ValueType == CellValueType.Reference && evaluatedValue.GetValue<Reference>()?.Region != null)
         {
-            _sheet.FormulaEngine.SetVariable(name, rangeStrFormula);
+            _sheet.FormulaEngine.SetVariable(name, formula.ToFormulaString());
             _namedRanges[name] = _sheet.FormulaEngine.DependencyManager.GetVertex(name)!.Formula!;
 
             return true;

--- a/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
@@ -1,0 +1,106 @@
+﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core.Interpreter;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
+
+namespace BlazorDatasheet.Core.FormulaEngine;
+
+public class NamedRangeManager
+{
+    private readonly Sheet _sheet;
+
+    /// <summary>
+    /// Stores named ranges - we store in a computed formula rather than a range to allow for dynamic ranges
+    /// </summary>
+    private Dictionary<string, CellFormula> _namedRanges = new();
+
+    public NamedRangeManager(Sheet sheet)
+    {
+        _sheet = sheet;
+    }
+
+    /// <summary>
+    /// Set a named range.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="rangeString"></param>
+    /// <returns>Whether the name was set successfully.</returns>
+    public bool Set(string name, string rangeString)
+    {
+        if (string.IsNullOrEmpty(rangeString))
+            return false;
+
+        if (!RangeText.IsValidName(name))
+        {
+            return false;
+        }
+
+        if (_namedRanges.ContainsKey(name))
+            Clear(name);
+
+        var rangeStrFormula = $"={rangeString}";
+        var formula = _sheet.FormulaEngine.ParseFormula(rangeStrFormula);
+
+        var evaluatedValue = _sheet.FormulaEngine.Evaluate(formula, resolveReferences: false);
+        if (evaluatedValue.ValueType == CellValueType.Reference && evaluatedValue.GetValue<Reference>()?.Region != null)
+        {
+            _sheet.FormulaEngine.SetVariable(name, rangeStrFormula);
+            _namedRanges[name] = _sheet.FormulaEngine.DependencyManager.GetVertex(name)!.Formula!;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Clears a named range.
+    /// </summary>
+    /// <param name="name"></param>
+    public void Clear(string name)
+    {
+        if (_namedRanges.ContainsKey(name))
+        {
+            _namedRanges.Remove(name);
+            _sheet.FormulaEngine.ClearVariable(name);
+        }
+    }
+
+    /// <summary>
+    /// Returns the name for the region, if any. Returns null if no name is found.
+    /// </summary>
+    /// <param name="region"></param>
+    /// <returns></returns>
+    public string? GetRegionName(IRegion region)
+    {
+        foreach (var kp in _namedRanges)
+        {
+            var formula = kp.Value;
+            if (formula.References.Count() == 1)
+            {
+                if (formula.References.First().Region.Equals(region))
+                {
+                    return kp.Key;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the named range <paramref name="name"/> as  as string.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public string? GetRangeString(string name)
+    {
+        if (_namedRanges.TryGetValue(name, out var formula))
+        {
+            return formula.ToFormulaString(includeEquals: false);
+        }
+
+        return null;
+    }
+}

--- a/src/BlazorDatasheet.Core/FormulaEngine/WorkbookEnvironment.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/WorkbookEnvironment.cs
@@ -37,6 +37,11 @@ public class WorkbookEnvironment : IEnvironment
             _variables[name] = cellValue;
     }
 
+    public void ClearVariable(string name)
+    {
+        _variables.Remove(name);
+    }
+
     public bool FunctionExists(string name)
     {
         return _functions.ContainsKey(name.ToLower());

--- a/src/BlazorDatasheet.Core/Selecting/Selection.cs
+++ b/src/BlazorDatasheet.Core/Selecting/Selection.cs
@@ -145,9 +145,11 @@ public class Selection
         if (SelectingRegion == null)
             return;
         SetActiveCellPosition(SelectingStartPosition.row, SelectingStartPosition.col);
+        var oldRegions = Regions.Select(x => x.Clone()).ToList();
         this.Add(SelectingRegion);
         SelectingRegion = null;
         EmitSelectingChanged();
+        EmitSelectionChange(oldRegions);
     }
 
     private void EmitSelectingChanged()

--- a/src/BlazorDatasheet.Core/Selecting/Selection.cs
+++ b/src/BlazorDatasheet.Core/Selecting/Selection.cs
@@ -59,7 +59,7 @@ public class Selection
     /// <summary>
     /// Fired before the active cell position changes. Allows the modification of the new active cell position.
     /// </summary>
-    public event EventHandler<BeforeActiveCellPositionChangedEventArgs> BeforeActiveCellPositionChanged;
+    public event EventHandler<BeforeActiveCellPositionChangedEventArgs>? BeforeActiveCellPositionChanged;
 
     /// <summary>
     /// Fired when the cells that are selected changes.
@@ -600,7 +600,7 @@ public class Selection
 
     private void EmitSelectionChange(IReadOnlyList<IRegion> oldRegions)
     {
-        SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(oldRegions, _regions));
+        SelectionChanged?.Invoke(this, new SelectionChangedEventArgs(oldRegions, _regions, _sheet));
         CellsSelected?.Invoke(this, new CellsSelectedEventArgs(_sheet.Cells.GetCellsInRegions(_regions)));
     }
 

--- a/src/BlazorDatasheet.DataStructures/Graph/DependencyGraph.cs
+++ b/src/BlazorDatasheet.DataStructures/Graph/DependencyGraph.cs
@@ -169,8 +169,6 @@ public class DependencyGraph<T> where T : Vertex
         }
     }
 
-    private void RemoveIfNoDependents(T v) => RemoveIfNoDependents(v.Key);
-
     private void RemoveIfNoDependents(string vKey)
     {
         if (!IsDependedOn(vKey) && !IsDependentOnAny(vKey))

--- a/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
+++ b/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
@@ -180,6 +180,12 @@ public class DependencyManager
         return ClearFormula(formulaVertex);
     }
 
+    public DependencyManagerRestoreData ClearFormula(string name)
+    {
+        var formulaVertex = new FormulaVertex(name, null);
+        return ClearFormula(formulaVertex);
+    }
+
     public bool HasDependents(IRegion region, string sheetName)
     {
         return GetReferencedVertexStore(sheetName).Any(region);
@@ -448,6 +454,11 @@ public class DependencyManager
     public FormulaVertex? GetVertex(int cellRow, int cellCol, string sheetName)
     {
         return _dependencyGraph.GetVertex(new FormulaVertex(cellRow, cellCol, sheetName, null).Key);
+    }
+
+    public FormulaVertex? GetVertex(string name)
+    {
+        return _dependencyGraph.GetVertex(name);
     }
 
     public IEnumerable<FormulaVertex> GetAllVertices() => _dependencyGraph.GetAll();

--- a/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
+++ b/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using BlazorDatasheet.DataStructures.Geometry;
+﻿using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Graph;
 using BlazorDatasheet.DataStructures.Store;
 using BlazorDatasheet.Formula.Core.Interpreter;
@@ -68,6 +67,12 @@ public class DependencyManager
         return SetFormulaVertex(formulaVertex);
     }
 
+    public DependencyManagerRestoreData SetFormula(string name, CellFormula? formula)
+    {
+        var formulaVertex = new FormulaVertex(name, formula);
+        return SetFormulaVertex(formulaVertex);
+    }
+
     private DependencyManagerRestoreData SetFormulaVertex(FormulaVertex formulaVertex)
     {
         // Clear any dependency tracking for old formula if there is one
@@ -87,7 +92,7 @@ public class DependencyManager
         foreach (var formulaRef in formulaVertex.Formula.References)
         {
             // add edges to any formula that already exist
-            if (formulaRef is not NamedReference)
+            if (formulaRef is not NamedReference namedRef)
             {
                 var formulaInsideRegion = GetVerticesInRegion(formulaRef.Region, formulaRef.SheetName);
                 foreach (var f in formulaInsideRegion)
@@ -101,7 +106,11 @@ public class DependencyManager
             }
             else
             {
-                throw new NotImplementedException();
+                if (_dependencyGraph.HasVertex(namedRef.Name))
+                {
+                    var v = _dependencyGraph.GetVertex(namedRef.Name)!;
+                    _dependencyGraph.AddEdge(v, formulaVertex);
+                }
             }
         }
 
@@ -119,12 +128,12 @@ public class DependencyManager
     {
         var restoreData = new DependencyManagerRestoreData();
         _volatileVertices.Remove(formulaVertex);
-        
+
         if (!_dependencyGraph.HasVertex(formulaVertex.Key))
             return restoreData;
 
         formulaVertex = _dependencyGraph.GetVertex(formulaVertex.Key)!;
-        
+
         // remove the references that refer to this formula cell
         var formulaReferences = formulaVertex.Formula?.References;
 
@@ -142,9 +151,6 @@ public class DependencyManager
                     case RangeReference rangeReference:
                         dataToDelete = GetReferencedVertexStore(rangeReference.SheetName)
                             .GetDataRegions(rangeReference.Region, formulaVertex).ToList();
-                        break;
-                    case NamedReference namedReference:
-                        throw new NotImplementedException();
                         break;
                 }
 
@@ -205,7 +211,8 @@ public class DependencyManager
             return GetDirectDependents(vertex.Region!, vertex.SheetName);
         }
 
-        return _dependencyGraph.Adj(vertex);
+        return _dependencyGraph.GetAll()
+            .Where(x => x.Formula!.References.Any(r => r is NamedReference n && n.Name == vertex.Key));
     }
 
     public DependencyManagerRestoreData InsertRowAt(int row, int count, string sheetName) =>

--- a/src/BlazorDatasheet.Formula.Core/IEnvironment.cs
+++ b/src/BlazorDatasheet.Formula.Core/IEnvironment.cs
@@ -25,4 +25,5 @@ public interface IEnvironment
     void RegisterFunction(string name, ISheetFunction value);
     public IEnumerable<CellValue> GetNonEmptyInRange(Reference reference);
     void SetCellValue(int row, int col, string sheetName, CellValue value);
+    void ClearVariable(string varName);
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/CellFormula.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/CellFormula.cs
@@ -24,7 +24,10 @@ public class CellFormula
         return !ExpressionTree.Errors.Any();
     }
 
-    public string ToFormulaString() => "=" + ExpressionTree.Root.ToExpressionText();
+    public string ToFormulaString(bool includeEquals = true)
+    {
+        return includeEquals ? $"={ExpressionTree.Root.ToExpressionText()}" : ExpressionTree.Root.ToExpressionText();
+    }
 
     /// <summary>
     /// Shifts all references by <paramref name="offsetRow"/> rows and <paramref name="offsetCol"/> columns.

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Lexer.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Lexer.cs
@@ -192,7 +192,7 @@ public ref struct Lexer
     {
         int start = _position;
         Next(); // consume start character
-        while (char.IsLetterOrDigit(_current) || _current == '$')
+        while (RangeText.IsValidNameChar(_current) || _current == '$')
             Next();
 
         int length = _position - start;

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
@@ -1,4 +1,3 @@
-using BlazorDatasheet.DataStructures.Util;
 using BlazorDatasheet.Formula.Core.Interpreter.Addresses;
 using BlazorDatasheet.Formula.Core.Interpreter.Lexing;
 using BlazorDatasheet.Formula.Core.Interpreter.References;
@@ -14,6 +13,7 @@ public class Parser
     private List<string> _errors = null!;
     private List<Reference> _references = new();
     private bool _containsVolatiles;
+    private ParsingContext? _parsingContext;
 
     public Parser(IEnvironment environment)
     {
@@ -30,20 +30,29 @@ public class Parser
         MatchToken(Tag.EqualsToken);
         var expression = ParseExpression();
         MatchToken(Tag.Eof);
+
+        foreach (var reference in _references)
+        {
+            if (!reference.ExplicitSheetName && _parsingContext != null)
+                reference.SetSheetName(_parsingContext.CallingSheetName, _parsingContext.ExplicitSheetNameReference);
+        }
+
         return new SyntaxTree(expression, _references, _errors);
     }
 
-    public SyntaxTree Parse(string formulaString)
+    public SyntaxTree Parse(string formulaString, ParsingContext? parsingContext = null)
     {
+        _parsingContext = parsingContext;
         var lexer = new Lexer();
         var tokens = lexer.Lex(formulaString);
         _references = new();
         return Parse(tokens, lexer.Errors);
     }
 
-    public CellFormula FromString(string formulaString)
+    public CellFormula FromString(string formulaString, ParsingContext? parsingContext = null)
     {
-        return new CellFormula(Parse(formulaString), _containsVolatiles);
+        _parsingContext = parsingContext ?? _parsingContext;
+        return new CellFormula(Parse(formulaString, parsingContext), _containsVolatiles);
     }
 
     private Expression ParseExpression()

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
@@ -340,6 +340,7 @@ public class Parser
         if (Current.Tag == Tag.ColonToken && TryConvertToAddress(identifierToken, out var address))
             return ParseReferenceExpressionFromAddress(address!);
 
+        _references.Add(new NamedReference(identifierToken.Value));
         return new VariableExpression(identifierToken);
     }
 

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/ParsingContext.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/ParsingContext.cs
@@ -1,0 +1,13 @@
+﻿namespace BlazorDatasheet.Formula.Core.Interpreter.Parsing;
+
+public class ParsingContext
+{
+    public string CallingSheetName { get; }
+    public bool ExplicitSheetNameReference { get; }
+
+    public ParsingContext(string callingSheetName, bool explicitSheetNameReference)
+    {
+        CallingSheetName = callingSheetName;
+        ExplicitSheetNameReference = explicitSheetNameReference;
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/References/CellReference.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/References/CellReference.cs
@@ -20,7 +20,7 @@ public class CellReference : Reference
 
     public override string ToAddressText()
     {
-        return (ExplicitSheetName ? $"'{SheetName}'!" : "") +  RangeText.RegionToText(Region, IsColFixed, IsColFixed, IsRowFixed, IsRowFixed);
+        return GetSheetPrefix() + RangeText.RegionToText(Region, IsColFixed, IsColFixed, IsRowFixed, IsRowFixed);
     }
 
     public override bool SameAs(Reference reference)

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/References/RangeReference.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/References/RangeReference.cs
@@ -76,9 +76,10 @@ public class RangeReference : Reference
 
     public override string ToAddressText()
     {
-        return (ExplicitSheetName ? $"'{SheetName}'!" : "") +  RangeText.RegionToText(Region, IsStartColFixed, IsEndColFixed, IsStartRowFixed, IsEndRowFixed);
+        return GetSheetPrefix() + RangeText.RegionToText(Region, IsStartColFixed,
+            IsEndColFixed, IsStartRowFixed, IsEndRowFixed);
     }
-
+    
     public override bool SameAs(Reference reference)
     {
         if (reference.Kind == ReferenceKind.Range)

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/References/Reference.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/References/Reference.cs
@@ -36,7 +36,10 @@ public abstract class Reference
     public abstract IRegion Region { get; protected set; }
     internal abstract void SetRegion(IRegion region);
     public string SheetName { get; private set; } = "Sheet1";
-    internal bool ExplicitSheetName { get; private set; }
+    /// <summary>
+    /// Whether the sheet name was explicitly set.
+    /// </summary>
+    public bool ExplicitSheetName { get; private set; }
     internal void SetSheetName(string sheetName, bool explicitSheetName = true)
     {
         SheetName = sheetName;
@@ -46,4 +49,13 @@ public abstract class Reference
     {
         IsInvalid = !isValid;
     }
+    
+    protected string GetSheetPrefix()
+    {
+        var hasWhitespace = SheetName.Any(char.IsWhiteSpace);
+        if (ExplicitSheetName)
+            return $"{(hasWhitespace ? "'" : "")}{SheetName}{(hasWhitespace ? "'" : "")}!";
+        return "";
+    }
+
 }

--- a/src/BlazorDatasheet.Formula.Core/RangeText.cs
+++ b/src/BlazorDatasheet.Formula.Core/RangeText.cs
@@ -198,6 +198,23 @@ public static class RangeText
         return char.IsLetter(c) || c == '_';
     }
 
+    public static bool IsValidName(ReadOnlySpan<char> name)
+    {
+        if (name.Length == 0)
+            return false;
+
+        if (!IsValidStartOfName(name[0]))
+            return false;
+
+        for (int i = 1; i < name.Length; i++)
+        {
+            if (!IsValidNameChar(name[i]))
+                return false;
+        }
+
+        return true;
+    }
+
 
     public static int ColStrToIndex(ReadOnlySpan<char> text)
     {

--- a/src/BlazorDatasheet.Server/Shared/NavMenu.razor
+++ b/src/BlazorDatasheet.Server/Shared/NavMenu.razor
@@ -64,6 +64,11 @@
                 Workbook/Multi-sheet
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="NamedRangeExample">
+                Named ranges
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/BlazorDatasheet.SharedPages/Pages/Formula.razor
+++ b/src/BlazorDatasheet.SharedPages/Pages/Formula.razor
@@ -6,9 +6,11 @@
 
 <p>Blazor datasheet has support for an excel-like formula language.</p>
 
-<p>This example shows a 10x10 sheet with sin functions applied to each. The phase can be controlled with the formula variable "x", which is set via the range slider below.</p>
+<p>This example shows a 10x10 sheet with sin functions applied to each. The phase can be controlled with the formula
+    variable "x", which is set via the range slider below.</p>
 
-<input type="range" min="0" max="10" step="0.05" @oninput="@(e => Sheet.FormulaEngine.SetVariable("x", e.Value))"/>
+<input type="range" min="0" max="10" step="0.05"
+       @oninput="@(e => Sheet.FormulaEngine.SetVariable("x", e.Value))"/>
 
 <Datasheet Sheet="Sheet" ShowColHeadings="false" ShowRowHeadings="false"/>
 
@@ -31,6 +33,7 @@
                 Sheet.Cells.SetFormula(i, j, $"=(1+sin(({i / 10.0}+{j / 10.0})*3.14-x))/2");
             }
         }
+
         var colorCf = new NumberScaleConditionalFormat(Color.LightBlue, Color.GreenYellow);
         Sheet.ConditionalFormats.Apply(new Region(0, 10, 0, 10), colorCf);
         Sheet.FormulaEngine.SetVariable("x", 10);

--- a/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
@@ -4,13 +4,20 @@
 @using BlazorDatasheet.Formula.Core
 <h3>NamedRangeExample</h3>
 
+<p>
+    Ranges can be named and referenced by their name. Select a range and type a name in the input field, then press
+    enter, to name the range.
+</p>
+
+<h6>Sheet 1</h6>
 <input type="text" @bind-value:get="SelectedRangeValue" @bind-value:set="OnInput"/>
 
-<div style="width: 400px; height: 400px; overflow: auto">
+<div style="width: 550px; height: 300px; overflow: auto">
     <Datasheet Sheet="Sheet"/>
 </div>
 
-<div style="width: 400px; height: 400px; overflow: auto">
+<h6>Sheet 2</h6>
+<div style="width: 550px; height: 300px; overflow: auto">
     <Datasheet Sheet="Sheet2"/>
 </div>
 

--- a/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
@@ -10,9 +10,15 @@
     <Datasheet Sheet="Sheet"/>
 </div>
 
+<div style="width: 400px; height: 400px; overflow: auto">
+    <Datasheet Sheet="Sheet2"/>
+</div>
+
 @code {
 
     private string? _selectedRangeValue;
+
+    private Sheet ActiveSheet;
 
     private string? SelectedRangeValue
     {
@@ -25,6 +31,7 @@
     }
 
     private Sheet Sheet { get; set; }
+    private Sheet Sheet2 { get; set; }
 
     private void OnInput(string? value)
     {
@@ -34,22 +41,26 @@
             return;
         }
 
-        Sheet.NamedRanges.Set(newValue, SelectedRangeValue);
+        ActiveSheet.NamedRanges.Set(newValue, SelectedRangeValue);
         SelectedRangeValue = newValue;
     }
 
     protected override void OnInitialized()
     {
-        Sheet = new Sheet(100, 100);
+        var workbook = new Workbook();
+        Sheet = workbook.AddSheet(100, 100);
+        Sheet2 = workbook.AddSheet(100, 100);
         Sheet.Selection.SelectionChanged += SelectionOnSelectionChanged;
+        Sheet2.Selection.SelectionChanged += SelectionOnSelectionChanged;
     }
 
     private void SelectionOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
     {
-        if (Sheet.Selection.IsSelecting || !Sheet.Selection.Regions.Any())
+        ActiveSheet = e.Sheet;
+        if (ActiveSheet.Selection.IsSelecting || !ActiveSheet.Selection.Regions.Any())
             return;
 
-        var sheetSelection = Sheet.Selection.Regions;
+        var sheetSelection = ActiveSheet.Selection.Regions;
         if (sheetSelection.Count > 1)
         {
             SelectedRangeValue = null;
@@ -57,7 +68,7 @@
         }
 
         var selectedRegion = sheetSelection[0];
-        var namedRegion = Sheet.NamedRanges.GetRegionName(selectedRegion);
+        var namedRegion = ActiveSheet.NamedRanges.GetRegionName(selectedRegion);
         if (namedRegion != null)
         {
             SelectedRangeValue = namedRegion;

--- a/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Pages/NamedRangeExample.razor
@@ -1,0 +1,71 @@
+﻿@page "/NamedRangeExample"
+@using BlazorDatasheet.Core.Data
+@using BlazorDatasheet.Core.Events
+@using BlazorDatasheet.Formula.Core
+<h3>NamedRangeExample</h3>
+
+<input type="text" @bind-value:get="SelectedRangeValue" @bind-value:set="OnInput"/>
+
+<div style="width: 400px; height: 400px; overflow: auto">
+    <Datasheet Sheet="Sheet"/>
+</div>
+
+@code {
+
+    private string? _selectedRangeValue;
+
+    private string? SelectedRangeValue
+    {
+        get => _selectedRangeValue;
+        set
+        {
+            _selectedRangeValue = value;
+            StateHasChanged();
+        }
+    }
+
+    private Sheet Sheet { get; set; }
+
+    private void OnInput(string? value)
+    {
+        var newValue = value ?? string.Empty;
+        if (string.IsNullOrEmpty(newValue) || string.IsNullOrEmpty(SelectedRangeValue))
+        {
+            return;
+        }
+
+        Sheet.NamedRanges.Set(newValue, SelectedRangeValue);
+        SelectedRangeValue = newValue;
+    }
+
+    protected override void OnInitialized()
+    {
+        Sheet = new Sheet(100, 100);
+        Sheet.Selection.SelectionChanged += SelectionOnSelectionChanged;
+    }
+
+    private void SelectionOnSelectionChanged(object? sender, SelectionChangedEventArgs e)
+    {
+        if (Sheet.Selection.IsSelecting || !Sheet.Selection.Regions.Any())
+            return;
+
+        var sheetSelection = Sheet.Selection.Regions;
+        if (sheetSelection.Count > 1)
+        {
+            SelectedRangeValue = null;
+            return;
+        }
+
+        var selectedRegion = sheetSelection[0];
+        var namedRegion = Sheet.NamedRanges.GetRegionName(selectedRegion);
+        if (namedRegion != null)
+        {
+            SelectedRangeValue = namedRegion;
+            return;
+        }
+
+        SelectedRangeValue = RangeText.RegionToText(selectedRegion);
+    }
+
+
+}

--- a/src/BlazorDatasheet.Wasm/Shared/NavMenu.razor
+++ b/src/BlazorDatasheet.Wasm/Shared/NavMenu.razor
@@ -64,6 +64,11 @@
                 Workbook/Multi-sheet
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="NamedRangeExample">
+                Named ranges
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/BlazorDatasheet/Render/Layers/HighlightLayer.razor
+++ b/src/BlazorDatasheet/Render/Layers/HighlightLayer.razor
@@ -49,8 +49,7 @@
     {
         if (Sheet.Editor.EditValue.StartsWith("="))
         {
-            var parser = new Parser(Sheet.FormulaEngine.GetEnvironment());
-            var formula = parser.FromString(Sheet.Editor.EditValue);
+            var formula = Sheet.FormulaEngine.ParseFormula(Sheet.Editor.EditValue, Sheet.Name, false);
             if (!formula.References.Any())
             {
                 _colorRegions = new List<DataRegion<string>>();
@@ -58,7 +57,7 @@
             }
 
             _colorRegions = formula.References
-                .Where(x=>x.SheetName == Sheet.Name)
+                .Where(x => x.SheetName == Sheet.Name)
                 .Select((r, i) =>
                 {
                     var colorIndex = (i % 5) + 1;

--- a/src/BlazorDatasheet/Render/Layers/HighlightLayer.razor
+++ b/src/BlazorDatasheet/Render/Layers/HighlightLayer.razor
@@ -1,5 +1,6 @@
 ﻿@using BlazorDatasheet.Core.Data
 @using BlazorDatasheet.Core.Events.Edit
+@using BlazorDatasheet.DataStructures.Geometry
 @using BlazorDatasheet.DataStructures.Store
 @using BlazorDatasheet.Formula.Core.Interpreter.Parsing
 @inherits Layer
@@ -56,13 +57,13 @@
                 return;
             }
 
-            _colorRegions = formula.References
-                .Where(x => x.SheetName == Sheet.Name)
-                .Select((r, i) =>
-                {
-                    var colorIndex = (i % 5) + 1;
-                    return new DataRegion<string>($"var(--highlight-color-{colorIndex})", r.Region);
-                }).ToList();
+            _colorRegions = new();
+            foreach (var reference in formula.References)
+            {
+                var colorIndex = (_colorRegions.Count % 5) + 1;
+                var isValid = reference.SheetName == Sheet.Name;
+                _colorRegions.Add(new DataRegion<string>($"var(--highlight-color-{colorIndex})", isValid ? reference.Region : new EmptyRegion()));
+            }
         }
     }
 

--- a/test/BlazorDatasheet.Test/Formula/CellReferenceTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/CellReferenceTests.cs
@@ -88,7 +88,9 @@ public class CellReferenceTests
         var workbook = new Workbook();
         workbook.AddSheet(100, 100);
         var formulaEngine = workbook.GetFormulaEngine();
-        var refCellValue = formulaEngine.Evaluate(formulaEngine.ParseFormula($"={refStr}"), resolveReferences: false);
+        var refCellValue =
+            formulaEngine.Evaluate(formulaEngine.ParseFormula($"={refStr}", workbook.Sheets.First().Name),
+                resolveReferences: false);
         var isReferenceType = refCellValue.ValueType == CellValueType.Reference;
         isReferenceType.Should().Be(isValid);
 

--- a/test/BlazorDatasheet.Test/Formula/NamedRangeTest.cs
+++ b/test/BlazorDatasheet.Test/Formula/NamedRangeTest.cs
@@ -1,0 +1,88 @@
+﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Formula.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Formula;
+
+public class NamedRangeTest
+{
+    private Workbook _workbook;
+    private Sheet _sheet;
+
+    [SetUp]
+    public void Setup()
+    {
+        _workbook = new Workbook();
+        _sheet = _workbook.AddSheet(100, 100);
+    }
+
+    [Test]
+    public void Add_Named_Range_Success_When_Referenced()
+    {
+        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.Cells["A2"]!.Formula = "=x+1";
+        _sheet.Cells["A1"]!.Value = 10;
+        _sheet.Cells["A2"]!.Value.Should().Be(11);
+    }
+
+    [Test]
+    public void Add_Named_Range_Success_When_Referenced_In_Alternate_Order()
+    {
+        _sheet.Cells["A1"]!.Value = 10;
+        _sheet.Cells["A2"]!.Formula = "=x+1";
+        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.Cells["A2"]!.Value.Should().Be(11);
+    }
+
+    [Test]
+    public void Set_Named_Range_Fails_When_Invalid()
+    {
+        _sheet.NamedRanges.Set("x", "A_1");
+        _sheet.Cells["A2"]!.Formula = "=x+1";
+        _sheet.Cells["A2"]!.Value.Should().BeOfType<FormulaError>();
+    }
+
+    [Test]
+    public void Cleared_Named_Range_Clears_Named_Range()
+    {
+        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.Cells["A1"]!.Value = 10;
+        _sheet.Cells["A2"]!.Formula = "=x+1";
+        _sheet.NamedRanges.Clear("x");
+        _sheet.Cells["A2"]!.Value.Should().BeOfType<FormulaError>();
+    }
+
+    [Test]
+    public void Set_Named_Range_String_Returns_Correct_String()
+    {
+        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1");
+    }
+
+    [Test]
+    public void Named_Ranges_Changes_On_Row_Insert()
+    {
+        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.Rows.InsertAt(0);
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("A2");
+    }
+
+    [Test]
+    public void Named_Ranges_Changes_On_Row_Remove()
+    {
+        _sheet.NamedRanges.Set("x", "A1:A2");
+        _sheet.Rows.RemoveAt(0);
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1");
+        _sheet.Commands.Undo();
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1:A2");
+    }
+
+    [Test]
+    public void Named_Region_Selection_Gets_Correct_Name()
+    {
+        _sheet.NamedRanges.Set("x", "A1:A2");
+        _sheet.NamedRanges.GetRegionName(_sheet.Range("A1:A2")!.Region).Should().Be("x");
+    }
+}

--- a/test/BlazorDatasheet.Test/Formula/NamedRangeTest.cs
+++ b/test/BlazorDatasheet.Test/Formula/NamedRangeTest.cs
@@ -58,15 +58,15 @@ public class NamedRangeTest
     public void Set_Named_Range_String_Returns_Correct_String()
     {
         _sheet.NamedRanges.Set("x", "A1");
-        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1");
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("Sheet1!A1");
     }
 
     [Test]
     public void Named_Ranges_Changes_On_Row_Insert()
     {
-        _sheet.NamedRanges.Set("x", "A1");
+        _sheet.NamedRanges.Set("x", "Sheet1!A1");
         _sheet.Rows.InsertAt(0);
-        _sheet.NamedRanges.GetRangeString("x").Should().Be("A2");
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("Sheet1!A2");
     }
 
     [Test]
@@ -74,9 +74,9 @@ public class NamedRangeTest
     {
         _sheet.NamedRanges.Set("x", "A1:A2");
         _sheet.Rows.RemoveAt(0);
-        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1");
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("Sheet1!A1");
         _sheet.Commands.Undo();
-        _sheet.NamedRanges.GetRangeString("x").Should().Be("A1:A2");
+        _sheet.NamedRanges.GetRangeString("x").Should().Be("Sheet1!A1:A2");
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -385,8 +385,8 @@ public class SheetFormulaIntegrationTests
         env.RegisterFunction("if", new IfFunction());
         var eval = new Evaluator(env);
         var parser = new Parser(env);
-        var fA1 = new CellFormula(parser.Parse("=B1"));
-        var fB1 = new CellFormula(parser.Parse("=if(true,C1,A1)"));
+        var fA1 = parser.FromString("=B1");
+        var fB1 = parser.FromString("=if(true,C1,A1)");
         env.SetCellValue(0, 2, 3);
         env.SetCellFormula(0, 0, fA1);
         env.SetCellFormula(0, 1, fB1);
@@ -424,7 +424,7 @@ public class SheetFormulaIntegrationTests
     public void Named_Range_Variable_Should_Update_When_Variable_Changes()
     {
         _sheet.Cells["A1"]!.Formula = "=x";
-        _sheet.FormulaEngine.SetVariable("x", "=A2");
+        _sheet.FormulaEngine.SetVariable("x", "=Sheet1!A2");
         _sheet.Cells["A2"]!.Value = 10;
         _sheet.Cells["A1"]!.Value.Should().Be(10);
     }

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -7,6 +7,7 @@ using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
 using BlazorDatasheet.Formula.Core.Interpreter.Parsing;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
 using BlazorDatasheet.Formula.Functions.Logical;
 using FluentAssertions;
 using NUnit.Framework;
@@ -408,6 +409,23 @@ public class SheetFormulaIntegrationTests
     {
         _sheet.Cells["A1"]!.Formula = "=sum(a2:b2:c5)";
         _sheet.Cells["C4"]!.Value = 10;
+        _sheet.Cells["A1"]!.Value.Should().Be(10);
+    }
+
+    [Test]
+    public void Variable_With_Formula_Should_Update_When_Variable_Changes()
+    {
+        _sheet.Cells["A1"]!.Formula = "=x";
+        _sheet.FormulaEngine.SetVariable("x", "=10");
+        _sheet.Cells["A1"]!.Value.Should().Be(10);
+    }
+
+    [Test]
+    public void Named_Range_Variable_Should_Update_When_Variable_Changes()
+    {
+        _sheet.Cells["A1"]!.Formula = "=x";
+        _sheet.FormulaEngine.SetVariable("x", "=A2");
+        _sheet.Cells["A2"]!.Value = 10;
         _sheet.Cells["A1"]!.Value.Should().Be(10);
     }
 }

--- a/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
+++ b/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
@@ -55,6 +55,11 @@ public class TestEnvironment : IEnvironment
         _cellValues.TryAdd(new CellPosition(row, col), value);
     }
 
+    public void ClearVariable(string varName)
+    {
+        _variables.Remove(varName);
+    }
+
     public void SetVariable(string name, object variable)
     {
         SetVariable(name, new CellValue(variable));

--- a/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
@@ -24,7 +24,7 @@ public class MathFunctionTests
     {
         var eval = new Evaluator(_env);
         var parser = new Parser(_env);
-        return eval.Evaluate(parser.Parse(formulaString)).Data;
+        return eval.Evaluate(parser.FromString(formulaString)).Data;
     }
 
     [Test]


### PR DESCRIPTION
Adds ability to set variables as formula.

Adds named ranges to the sheet e.g ```Sheet.NamedRanges.Set("x","A1:A2");``` See #84 

TODO:

- [x] Ensure that named ranges use a sheet name.