### PR TITLE
Add error parsing

### DIFF
--- a/src/BlazorDatasheet.Formula.Core/ErrorType.cs
+++ b/src/BlazorDatasheet.Formula.Core/ErrorType.cs
@@ -2,12 +2,48 @@
 
 public enum ErrorType
 {
-    Div0,
-    Na,
-    Name,
-    Null,
-    Num,
-    Ref,
-    Value,
-    Circular
+    Null = 1,
+    Div0 = 2,
+    Value = 3,
+    Ref = 4,
+    Name = 5,
+    Num = 6,
+    Na = 7,
+    Circular = 9,
+    None = 0,
+}
+
+public static class ErrorTypes
+{
+    public static string ToErrorString(this ErrorType errorType)
+    {
+        return errorType switch
+        {
+            ErrorType.Null => "#NULL!",
+            ErrorType.Div0 => "#DIV/0!",
+            ErrorType.Value => "#VALUE!",
+            ErrorType.Ref => "#REF!",
+            ErrorType.Name => "#NAME?",
+            ErrorType.Num => "#NUM!",
+            ErrorType.Na => "#N/A",
+            ErrorType.Circular => "#CIRCULAR",
+            _ => "Invalid"
+        };
+    }
+    
+    public static ErrorType FromErrorString(ReadOnlySpan<char> errorString)
+    {
+        return errorString switch
+        {
+            "#NULL!" => ErrorType.Null,
+            "#DIV/0!" => ErrorType.Div0,
+            "#VALUE!" => ErrorType.Value,
+            "#REF!" => ErrorType.Ref,
+            "#NAME?" => ErrorType.Name,
+            "#NUM!" => ErrorType.Num,
+            "#N/A" => ErrorType.Na,
+            "#CIRCULAR" => ErrorType.Circular,
+            _ => ErrorType.None
+        };
+    }
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
@@ -91,6 +91,8 @@ public class Evaluator
                 return EvaluateArrayConstantExpression((ArrayConstantExpression)expression);
             case NodeKind.Name:
                 return EvaluateNamedExpression((VariableExpression)expression);
+            case NodeKind.Error:
+                return CellValue.Error(((ErrorExpression)expression).ErrorType);
         }
 
         return CellValue.Error(new FormulaError(ErrorType.Na,

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/ErrorToken.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/ErrorToken.cs
@@ -1,0 +1,11 @@
+﻿namespace BlazorDatasheet.Formula.Core.Interpreter.Lexing;
+
+public class ErrorToken : Token
+{
+    public ErrorType ErrorType { get; }
+
+    public ErrorToken(ErrorType errorType, int positionStart) : base(Tag.ErrorToken, positionStart)
+    {
+        ErrorType = errorType;
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Lexer.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Lexer.cs
@@ -61,6 +61,9 @@ public ref struct Lexer
                 return new WhitespaceToken(_string.Slice(start, len).ToString(), start);
         }
 
+        if (_current == '#')
+            return ReadErrorToken();
+
         if (_current == '\0')
             return new EndOfFileToken(_position);
 
@@ -159,6 +162,29 @@ public ref struct Lexer
 
         Next();
         return token;
+    }
+
+    private Token ReadErrorToken()
+    {
+        int start = _position;
+        while (char.IsLetter(_current) ||
+               _current == '#' ||
+               _current == '/' ||
+               _current == '?' ||
+               _current == '!' ||
+               _current == '0')
+            Next();
+
+        int length = _position - start;
+        var errorStr = _string.Slice(start, length);
+        var errorType = ErrorTypes.FromErrorString(errorStr);
+        if (errorType == ErrorType.None)
+        {
+            Error("Invalid error token");
+            return new BadToken(start);
+        }
+
+        return new ErrorToken(errorType, start);
     }
 
     private Token ReadNumber()

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Tag.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Lexing/Tag.cs
@@ -30,5 +30,6 @@ public enum Tag
     AddressToken,
     LogicalToken,
     Whitespace,
-    SheetLocatorToken
+    SheetLocatorToken,
+    ErrorToken
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/ErrorExpression.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/ErrorExpression.cs
@@ -1,0 +1,18 @@
+﻿namespace BlazorDatasheet.Formula.Core.Interpreter.Parsing;
+
+public class ErrorExpression : Expression
+{
+    public ErrorType ErrorType { get; }
+
+    public ErrorExpression(ErrorType errorType)
+    {
+        ErrorType = errorType;
+    }
+
+    public override NodeKind Kind => NodeKind.Error;
+
+    public override string ToExpressionText()
+    {
+        return ErrorType.ToErrorString();
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/NodeKind.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/NodeKind.cs
@@ -9,5 +9,6 @@ public enum NodeKind
     FunctionCall,
     ArrayConstant,
     Name,
-    Range
+    Range,
+    Error
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
@@ -115,6 +115,8 @@ public class Parser
                 return ParseSheetReferenceExpression();
             case Tag.AddressToken:
                 return ParseReferenceExpressionFromAddress(((AddressToken)NextToken()).Address);
+            case Tag.ErrorToken:
+                return new ErrorExpression(((ErrorToken)NextToken()).ErrorType);
         }
 
         if (Peek(1).Tag == Tag.ColonToken && TryConvertToAddress(Current, out var address))

--- a/test/BlazorDatasheet.Test/Formula/Interpreter2Tests.cs
+++ b/test/BlazorDatasheet.Test/Formula/Interpreter2Tests.cs
@@ -255,4 +255,18 @@ public class InterpreterTests
     {
         _parser.FromString("=A1:A2").ContainsVolatiles.Should().BeFalse();
     }
+
+    [Test]
+    [TestCase("=#NULL!", ErrorType.Null)]
+    [TestCase("=#DIV/0!", ErrorType.Div0)]
+    [TestCase("=#VALUE!", ErrorType.Value)]
+    [TestCase("=#REF!", ErrorType.Ref)]
+    [TestCase("=#NAME?", ErrorType.Name)]
+    [TestCase("=#NUM!", ErrorType.Num)]
+    [TestCase("=#N/A", ErrorType.Na)]
+    [TestCase("=#CIRCULAR", ErrorType.Circular)]
+    public void Errors_Parsed_To_Correct_Error_Type(string formula, ErrorType expectedErrorType)
+    {
+        EvalExpression(formula).GetValue<FormulaError>().ErrorType.Should().Be(expectedErrorType);
+    }
 }

--- a/test/BlazorDatasheet.Test/Functions/LogicalFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/LogicalFunctionTests.cs
@@ -78,6 +78,7 @@ public class LogicalFunctionTests
         _env.SetCellValue(0, 0, new FormulaError(ErrorType.Div0));
         _env.SetCellValue(1, 0, true);
         Eval("=AND(A1:A2)").Should().BeOfType<FormulaError>();
+        Eval("=AND(#DIV/0)").Should().BeOfType<FormulaError>();
     }
 
     [Test]


### PR DESCRIPTION
Adds correct parsing of errors to formula, e.g ```=#DIV/0``` will parse as a formula error.