### PR TITLE
Improve formula performance

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
@@ -7,27 +7,10 @@ namespace BlazorDatasheet.Core.Commands.Data;
 
 public class SetCellValuesCommand : BaseCommand, IUndoableCommand
 {
-    private readonly object[][]? _values;
-    private readonly CellValue[][]? _cellValues;
-    private readonly IRegion? _region;
-    private readonly object? _singleValue;
-    private readonly CellValue? _singleCellValue;
+    private readonly IEnumerable<IEnumerable<CellValue>> _cellValues;
     private readonly int _row;
     private readonly int _col;
     private readonly CellStoreRestoreData _restoreData = new();
-
-    /// <summary>
-    /// Creates a command to set multiple cell values starting at position <paramref name="row"/>/<paramref name="col"/>
-    /// </summary>
-    /// <param name="values">The values to set. values[row] is the row offset from <paramref name="row"/>. Each values[row][col] is the col offset from <paramref name="col"/></param>
-    /// <param name="row"></param>
-    /// <param name="col"></param>
-    public SetCellValuesCommand(int row, int col, object[][] values)
-    {
-        _values = values;
-        _row = row;
-        _col = col;
-    }
 
     /// <summary>
     /// Creates a command to set multiple cell values starting at position <paramref name="row"/>/<paramref name="col"/>
@@ -42,15 +25,18 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
         _col = col;
     }
 
+
     /// <summary>
-    /// Sets all the cells in the region <paramref name="region"/> to <paramref name="value"/>
+    /// Creates a command to set multiple cell values starting at position <paramref name="row"/>/<paramref name="col"/>
     /// </summary>
-    /// <param name="region"></param>
-    /// <param name="value"></param>
-    public SetCellValuesCommand(IRegion region, object? value)
+    /// <param name="row"></param>
+    /// <param name="col"></param>
+    /// <param name="values"></param>
+    public SetCellValuesCommand(int row, int col, IEnumerable<IEnumerable<CellValue>> values)
     {
-        _region = region;
-        _singleValue = value;
+        _cellValues = values;
+        _row = row;
+        _col = col;
     }
 
     /// <summary>
@@ -60,8 +46,9 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
     /// <param name="value"></param>
     public SetCellValuesCommand(IRegion region, CellValue value)
     {
-        _region = region;
-        _singleCellValue = value;
+        _row = region.Top;
+        _col = region.Left;
+        _cellValues = Enumerable.Repeat(Enumerable.Repeat(value, region.Width), region.Height);
     }
 
     public override bool CanExecute(Sheet sheet) => true;
@@ -70,84 +57,38 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
     {
         sheet.ScreenUpdating = false;
         sheet.BatchUpdates();
-        if (_values != null)
-            ExecuteSetObjectArrayData(sheet);
-        else if (_cellValues != null)
-            ExecuteSetCellValueData(sheet);
-        else if (_region != null && _singleCellValue != null)
-            ExecuteSetRegionDataAsCellValue(sheet);
-        else if (_region != null)
-            ExecuteSetRegionData(sheet);
-        else
-            return false;
+        ExecuteSetCellValueData(sheet);
         sheet.EndBatchUpdates();
         sheet.ScreenUpdating = true;
 
         return true;
     }
 
-    private void ExecuteSetObjectArrayData(Sheet sheet)
-    {
-        var rowEnd = _row + _values!.Length;
-        var colEnd = _col;
-
-        for (int i = 0; i < _values.Length; i++)
-        {
-            for (int j = 0; j < _values[i].Length; j++)
-            {
-                _restoreData.Merge(sheet.Cells.SetValueImpl(_row + i, _col + j, _values[i][j]));
-                colEnd = Math.Max(colEnd, j + _col);
-            }
-        }
-
-        sheet.MarkDirty(new Region(_row, rowEnd, _col, colEnd));
-    }
-
     private void ExecuteSetCellValueData(Sheet sheet)
     {
-        var rowEnd = _row + _cellValues!.Length;
+        var rowEnd = _row;
         var colEnd = _col;
 
-        for (int i = 0; i < _cellValues.Length; i++)
+        int rowOffset = 0;
+
+        foreach (var row in _cellValues)
         {
-            for (int j = 0; j < _cellValues[i].Length; j++)
+            int colOffset = 0;
+            
+            foreach (var value in row)
             {
-                _restoreData.Merge(sheet.Cells.SetValueImpl(_row + i, _col + j, _cellValues[i][j]));
-                colEnd = Math.Max(colEnd, j + _col);
+                _restoreData.Merge(sheet.Cells.SetValueImpl(_row + rowOffset, _col + colOffset, value));
+                colEnd = Math.Max(colEnd, _col + colOffset);
+                colOffset++;
             }
+
+            rowEnd = Math.Max(rowEnd, _row + rowOffset);
+            rowOffset++;
         }
 
         sheet.MarkDirty(new Region(_row, rowEnd, _col, colEnd));
     }
 
-
-    private void ExecuteSetRegionData(Sheet sheet)
-    {
-        for (int row = _region!.Top; row <= _region!.Bottom; row++)
-        {
-            for (int col = _region.Left; col <= _region.Right; col++)
-            {
-                _restoreData.Merge(sheet.Cells.SetValueImpl(row, col, _singleValue));
-            }
-        }
-
-        sheet.MarkDirty(_region);
-    }
-
-    private void ExecuteSetRegionDataAsCellValue(Sheet sheet)
-    {
-        sheet.ScreenUpdating = false;
-
-        for (int row = _region!.Top; row <= _region!.Bottom; row++)
-        {
-            for (int col = _region.Left; col <= _region.Right; col++)
-            {
-                _restoreData.Merge(sheet.Cells.SetValueImpl(row, col, _singleCellValue!));
-            }
-        }
-
-        sheet.MarkDirty(_region);
-    }
 
     public bool Undo(Sheet sheet)
     {

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.Validation.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.Validation.cs
@@ -22,7 +22,7 @@ public partial class CellStore
             _validStore.Set(row, col, result.IsValid);
         }
 
-        Sheet.MarkDirty(cellsAffected);
+        Sheet.MarkDirty(region);
     }
 
     public bool IsValid(int row, int col)

--- a/src/BlazorDatasheet.Core/Events/Visual/DirtySheetEventArgs.cs
+++ b/src/BlazorDatasheet.Core/Events/Visual/DirtySheetEventArgs.cs
@@ -5,5 +5,5 @@ namespace BlazorDatasheet.Core.Events.Visual;
 
 public class DirtySheetEventArgs
 {
-    public ConsolidatedDataStore<bool> DirtyRegions { get; init; } = default!;
+    public Range1DStore<bool> DirtyRows { get; init; } = default!;
 }

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -183,14 +183,14 @@ public class FormulaEngine
                 {
                     // check whether the formula has already been calculated in this scc group - may be the case if we lucked
                     // out on the first value calculation and it wasn't a circular reference.
-                    if (scc.Count > 1 && executionContext.TryGetExecutedValue(vertex.Formula, out var result))
+                    if (executionContext.TryGetExecutedValue(vertex.Formula, out var result))
                     {
-                        //TODO: This is never hit so we are always recalculating
                         value = result;
                     }
                     else
                     {
                         value = _evaluator.Evaluate(vertex.Formula, executionContext);
+                        executionContext.RecordExecuted(vertex.Formula, value);
                         if (value.IsError() && ((FormulaError)value.Data!).ErrorType == ErrorType.Circular)
                             isCircularGroup = true;
                     }

--- a/src/BlazorDatasheet.DataStructures/Intervals/MergeableIntervalStore.cs
+++ b/src/BlazorDatasheet.DataStructures/Intervals/MergeableIntervalStore.cs
@@ -411,8 +411,8 @@ public class MergeableIntervalStore<T> : ISparseSource where T : IMergeable<T>
     {
         if (_intervals.Any())
         {
-            Start = _intervals.First().Value.Start;
-            End = _intervals.Last().Value.End;
+            Start = _intervals.Values[0].Start;
+            End = _intervals.Values[_intervals.Count - 1].End;
         }
     }
 

--- a/src/BlazorDatasheet.DataStructures/Store/IStore.cs
+++ b/src/BlazorDatasheet.DataStructures/Store/IStore.cs
@@ -5,7 +5,7 @@ namespace BlazorDatasheet.DataStructures.Store;
 public interface IStore<T, TRestoreData>
 {
     /// <summary>
-    /// Returns whether the the store contains any non-empty data at the row, column specified.
+    /// Returns whether store contains any non-empty data at the row, column specified.
     /// </summary>
     /// <param name="row"></param>
     /// <param name="col"></param>

--- a/src/BlazorDatasheet.DataStructures/Store/Range1DStore.cs
+++ b/src/BlazorDatasheet.DataStructures/Store/Range1DStore.cs
@@ -142,6 +142,8 @@ public class Range1DStore<T> : ISparseSource
         var interval = Intervals.GetNextNonEmptyIndex(index);
         return interval;
     }
+
+    public bool Any() => Intervals.Any();
 }
 
 public class OverwritingValue<R> : IMergeable<OverwritingValue<R>>

--- a/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
+++ b/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
@@ -270,6 +270,14 @@ public class DependencyManager
 
     private List<FormulaVertex> GetVerticesInRegion(IRegion region, string sheetName)
     {
+        if (region.IsSingleCell())
+        {
+            var vertex = _dependencyGraph.GetVertex(new FormulaVertex(region, sheetName, null).SheetName);
+            if (vertex != null)
+                return [vertex];
+            return new List<FormulaVertex>();
+        }
+
         var vertices = new List<FormulaVertex>();
         foreach (var v in _dependencyGraph.GetAll())
         {

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
@@ -153,6 +153,9 @@ public class Evaluator
         if (formula == null)
             return CellValue.Reference(cellReference);
 
+        if (_formulaExecutionContext.TryGetExecutedValue(formula, out var result))
+            return result;
+
         return DoEvaluate(formula);
     }
 

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
@@ -2,14 +2,17 @@
 
 public class FormulaExecutionContext
 {
-    private readonly List<CellFormula> _executed = new();
     private readonly Dictionary<CellFormula, CellValue> _executedValues = new();
-    public IReadOnlyCollection<CellFormula> ExecutionOrder => _executed;
     private readonly Stack<CellFormula> _executing = new();
 
     internal bool IsExecuting(CellFormula formula)
     {
         return _executing.Contains(formula);
+    }
+
+    public void RecordExecuted(CellFormula formula, CellValue value)
+    {
+        _executedValues.TryAdd(formula, value);
     }
 
     /// <summary>
@@ -36,18 +39,6 @@ public class FormulaExecutionContext
     }
 
     /// <summary>
-    /// Marks the currently executing <see cref="CellFormula"/> as executed
-    /// </summary>
-    public void FinishCurrentExecuting(CellValue value)
-    {
-        if (_executing.TryPop(out var formula))
-        {
-            _executed.Add(formula);
-            _executedValues.Add(formula, value);
-        }
-    }
-
-    /// <summary>
     /// Clears the record of executing <see cref="CellFormula"/>
     /// </summary>
     public void ClearExecuting()
@@ -60,7 +51,6 @@ public class FormulaExecutionContext
     /// </summary>
     public void Clear()
     {
-        _executed.Clear();
         _executing.Clear();
         _executedValues.Clear();
     }

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -465,9 +465,9 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
 
     private void SheetOnSheetDirty(object? sender, DirtySheetEventArgs e)
     {
-        var dirtyRegions = e.DirtyRegions
-            .GetDataRegions(_currentViewport.ViewRegion)
-            .Select(x => x.Region)
+        var dirtyRegions = e.DirtyRows
+            .GetAllIntervalData()
+            .Select(x => new RowRegion(x.interval.Start, x.interval.End))
             .ToList();
 
         if (dirtyRegions.Count > 0)
@@ -490,7 +490,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
                 {
                     var position = new CellPosition(row, col);
                     var visualCell = new VisualCell(row, col, _sheet, _numberPrecisionDisplay);
-                    
+
                     if (!_visualCellCache.TryAdd(position, visualCell))
                         _visualCellCache[position] = visualCell;
                 }

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -230,7 +230,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
     /// </summary>
     private EditorLayer _editorLayer = default!;
 
-    private readonly List<IRegion> _dirtyRows = new();
+    private readonly List<IRegion> _dirtyRegions = new();
 
     private bool _sheetIsDirty;
 
@@ -363,7 +363,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
 
         _renderRequested = false;
         _sheetIsDirty = false;
-        _dirtyRows.Clear();
+        _dirtyRegions.Clear();
 
         await base.OnAfterRenderAsync(firstRender);
     }
@@ -482,7 +482,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
             if (boundedRegion == null)
                 continue;
 
-            _dirtyRows.Add(boundedRegion);
+            _dirtyRegions.Add(boundedRegion);
 
             foreach (var row in _sheet.Rows.GetVisibleIndices(boundedRegion.Top, boundedRegion.Bottom))
             {
@@ -946,14 +946,14 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
 
     private bool IsRowDirty(int rowIndex)
     {
-        return _sheetIsDirty || _dirtyRows.Any(x => x.SpansRow(rowIndex));
+        return _sheetIsDirty || _dirtyRegions.Any(x => x.SpansRow(rowIndex));
     }
 
     protected override bool ShouldRender()
     {
         _renderRequested = true;
 
-        var shouldRender = _sheet.ScreenUpdating && (_sheetIsDirty || _dirtyRows.Count != 0);
+        var shouldRender = _sheet.ScreenUpdating && (_sheetIsDirty || _dirtyRegions.Count != 0);
         return shouldRender;
     }
 

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -489,10 +489,10 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
                 foreach (var col in _sheet.Columns.GetVisibleIndices(boundedRegion.Left, boundedRegion.Right))
                 {
                     var position = new CellPosition(row, col);
-                    if (!_visualCellCache.TryAdd(position, new VisualCell(row, col, _sheet, _numberPrecisionDisplay)))
-                    {
-                        _visualCellCache[position] = new VisualCell(row, col, _sheet, _numberPrecisionDisplay);
-                    }
+                    var visualCell = new VisualCell(row, col, _sheet, _numberPrecisionDisplay);
+                    
+                    if (!_visualCellCache.TryAdd(position, visualCell))
+                        _visualCellCache[position] = visualCell;
                 }
             }
         }

--- a/test/BlazorDatasheet.Test/Commands/SetCellValuesCommandTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/SetCellValuesCommandTests.cs
@@ -12,12 +12,12 @@ public class SetCellValuesCommandTests
     public void Set_Cell_Values_Respects_Cell_Type()
     {
         var sheet = new Sheet(10, 10);
-        sheet.Commands.ExecuteCommand(new SetCellValuesCommand(0, 0, [["2020-09-09"]]));
+        sheet.Cells.SetValues(0, 0, [["2020-09-09"]]);
         // ensure the conversion happens without setting type first
         sheet.Cells.GetValue(0, 0).Should().BeOfType<DateTime>();
         sheet.Cells.SetType(0, 0, "text");
         // now since the type is "text" the conversion should not happen
-        sheet.Commands.ExecuteCommand(new SetCellValuesCommand(0, 0, [["2020-09-09"]]));
+        sheet.Cells.SetValues(0, 0, [["2020-09-09"]]);
         sheet.Cells.GetValue(0, 0).Should().BeOfType<string>();
     }
 

--- a/test/BlazorDatasheet.Test/SheetTests/SheetTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SheetTests.cs
@@ -31,7 +31,7 @@ public class SheetTests
         var copyPasteRegion = new Region(copyPasteRegionR0, copyPasteRegionR1, copyPasteRegionC0, copyPasteRegionC1);
 
         foreach (var posn in copyPasteRegion)
-            sheet.Cells.SetValue(posn.row, posn.col, getCellPosnString(posn.row, posn.col));
+            sheet.Cells.SetValue(posn.row, posn.col, GetCellPositionString(posn.row, posn.col));
 
         var copy = sheet.GetRegionAsDelimitedText(copyPasteRegion);
         Assert.NotNull(copy);
@@ -46,11 +46,15 @@ public class SheetTests
         Assert.True(insertedRegions!.Equals(copyPasteRegion));
 
         foreach (var posn in copyPasteRegion)
-            Assert.AreEqual(getCellPosnString(posn.row, posn.col),
-                sheet.Cells.GetCell(posn.row, posn.col).GetValue<string>());
+        {
+            var sheetCell = sheet.Cells.GetCell(posn.row, posn.col);
+            var cellValue = sheetCell.GetValue<string>();
+            var expected = GetCellPositionString(posn.row, posn.col);
+            cellValue.Should().Be(expected);
+        }
     }
 
-    private string getCellPosnString(int row, int col)
+    private string GetCellPositionString(int row, int col)
     {
         return $"({row},{col})";
     }


### PR DESCRIPTION
Uses some evaluated formula caching and better dependency management of single cell references.

Using similar code to #198:

```csharp
_sheet.BatchUpdates();
for (int i = 0; i < 200; i++)
{
    for (int j = 0; j < 200; j++)
    {
        var cell = RangeText.ToCellText(i + 1, j);
        _sheet.Cells.SetFormula(i, j, $"={cell}+1");
    }
}

_sheet.EndBatchUpdates();
```

We have the following results prior to this PR:

| Method         | Mean    | Error   | StdDev  | Allocated |
|--------------- |--------:|--------:|--------:|----------:|
| Set200x200Formula | 11.33 s | 0.150 s | 0.133 s |   1.46 GB |

And then after:

| Method         | Mean     | Error    | StdDev   | Allocated |
|--------------- |---------:|---------:|---------:|----------:|
| Set200x200Formula | 861.5 ms | 22.00 ms | 63.47 ms |   1.03 GB |

We can likely still get a lot better than this, especially memory allocations.