### PR TITLE
Add option to disable format copying on autofill (dragging to expand values)

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -153,6 +153,8 @@ public class Sheet
 
     public NamedRangeManager NamedRanges { get; }
 
+    public bool AutoFillCopyFormat { get; set; } = true;
+
     /// <summary>
     /// If the sheet is batching dirty rows, they are stored here.
     /// </summary>

--- a/src/BlazorDatasheet.Core/Patterns/DefaultAutofillPattern.cs
+++ b/src/BlazorDatasheet.Core/Patterns/DefaultAutofillPattern.cs
@@ -19,7 +19,7 @@ public class DefaultAutofillPattern : IAutoFillPattern
 
     public ICommand GetCommand(int offset, int repeatNo, IReadOnlyCell cellData, CellPosition newDataPosition)
     {
-        var options = new CopyOptions();
+        var options = new CopyOptions() { CopyFormat = _sheet.AutoFillCopyFormat };
         if (cellData.HasFormula())
             options.CopyValues = false;
 

--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Formatting/CellFormatSimpleExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Formatting/CellFormatSimpleExample.razor
@@ -4,22 +4,15 @@
 <div class="block">
     <button @onclick="SetRedBackground">Red Bg</button>
     <button @onclick="SetBlueBackground">Blue Bg</button>
-    <button @onclick="SetReadOnly">Set ReadOnly</button>
-    <button @onclick="SetDefaultBackground">Clear format</button>
-    <label>
-        <input type="checkbox" @bind="_copyFormat" />
-        Copy format on autoFill
-    </label>
 </div>
 
 <div style="width: 500px; height: 300px; overflow: scroll;">
-    <Datasheet Sheet="_sheet" AutoFillCopyFormat="@_copyFormat"></Datasheet>
+    <Datasheet Sheet="_sheet"></Datasheet>
 </div>
 
 @code {
 
     private Sheet _sheet = null!;
-    private bool _copyFormat = true;
 
     protected override void OnInitialized()
     {
@@ -38,7 +31,4 @@
 
     private void SetBlueBackground() => SetFormatToSelection(new CellFormat() { BackgroundColor = "blue" });
 
-    private void SetReadOnly() => SetFormatToSelection(new CellFormat() { BackgroundColor = "lightgray", IsReadOnly = true });
-
-    private void SetDefaultBackground() => SetFormatToSelection(new CellFormat() { BackgroundColor = null, IsReadOnly = null });
 }

--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Formatting/CellFormatSimpleExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Formatting/CellFormatSimpleExample.razor
@@ -4,15 +4,22 @@
 <div class="block">
     <button @onclick="SetRedBackground">Red Bg</button>
     <button @onclick="SetBlueBackground">Blue Bg</button>
+    <button @onclick="SetReadOnly">Set ReadOnly</button>
+    <button @onclick="SetDefaultBackground">Clear format</button>
+    <label>
+        <input type="checkbox" @bind="_copyFormat" />
+        Copy format on autoFill
+    </label>
 </div>
 
 <div style="width: 500px; height: 300px; overflow: scroll;">
-    <Datasheet Sheet="_sheet"></Datasheet>
+    <Datasheet Sheet="_sheet" AutoFillCopyFormat="@_copyFormat"></Datasheet>
 </div>
 
 @code {
 
     private Sheet _sheet = null!;
+    private bool _copyFormat = true;
 
     protected override void OnInitialized()
     {
@@ -31,4 +38,7 @@
 
     private void SetBlueBackground() => SetFormatToSelection(new CellFormat() { BackgroundColor = "blue" });
 
+    private void SetReadOnly() => SetFormatToSelection(new CellFormat() { BackgroundColor = "lightgray", IsReadOnly = true });
+
+    private void SetDefaultBackground() => SetFormatToSelection(new CellFormat() { BackgroundColor = null, IsReadOnly = null });
 }

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -141,6 +141,12 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
     private bool _useAutoFill = true;
 
     /// <summary>
+    /// When true, the autofill will copy the format
+    /// </summary>
+    [Parameter]
+    public bool AutoFillCopyFormat { get; set; } = true;
+
+    /// <summary>
     /// When true, the datasheet will Auto-fit cells when edited or the format is changed.
     /// </summary>
     [Parameter]
@@ -358,6 +364,11 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
         if (NumberPrecisionDisplay != _numberPrecisionDisplay)
         {
             _numberPrecisionDisplay = Math.Min(15, NumberPrecisionDisplay);
+        }
+
+        if (_sheet is not null && _sheet.AutoFillCopyFormat != AutoFillCopyFormat)
+        {
+            _sheet.AutoFillCopyFormat = AutoFillCopyFormat;
         }
 
         if (forceRerender)

--- a/test/BlazorDatasheet.Test/Commands/AutofillCommandTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/AutofillCommandTests.cs
@@ -144,6 +144,21 @@ public class AutofillCommandTests
     }
 
     [Test]
+    public void Auto_Fill_With_CopyFormat_False_Cell_Format_Not_Copied()
+    {
+        var sheet = new Sheet(100, 100)
+        {
+            AutoFillCopyFormat = false
+        };
+        var originalFormat = sheet.GetFormat(1, 0);
+        var f = new CellFormat() { BackgroundColor = "f1" };
+        sheet.SetFormat(new Region(0, 0), f);
+        var cmd = new AutoFillCommand(new Region(0, 0), new Region(0, 1, 0, 0));
+        sheet.Commands.ExecuteCommand(cmd);
+        sheet.GetFormat(1, 0).Should().BeEquivalentTo(originalFormat);
+    }
+
+    [Test]
     public void Auto_Fill_Does_Not_Expand_Into_Readonly_Cells()
     {
         var sheet = new Sheet(100, 100);


### PR DESCRIPTION
Fixes #212

I want to be able to set auto fill CopyFormat on the datasheet, but is there a better way to do this without sending it via the sheet?