### PR TITLE
Add height and width to editor component

### DIFF
--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Customisation/ProgressEditor.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Customisation/ProgressEditor.razor
@@ -4,7 +4,7 @@
 @inherits BlazorDatasheet.Edit.BaseEditor
 
 <input type="range" 
-       style="width:@(CellWidth)px;height: @(CellHeight)px; outline: none;" 
+       style=" outline: none; width: 100%; height: 100%;" 
        min="0" max="200" @bind-value="CurrentValue" @ref="InputRef"/>
 
 @code {

--- a/src/BlazorDatasheet/Edit/EditorLayer.razor
+++ b/src/BlazorDatasheet/Edit/EditorLayer.razor
@@ -221,6 +221,9 @@
         sb.AddStyle("left", $"{left + 1}px;");
         sb.AddStyle("top", $"{top + 1}px;");
 
+        sb.AddStyle("width", w + "px");
+        sb.AddStyle("height", h + "px");
+        
         sb.AddStyle("max-width", LayerWidth + "px");
         sb.AddStyle("max-height", LayerHeight + "px");
 


### PR DESCRIPTION
Attempts to make custom editor styling more consistent as mentioned in #205 .

Custom editors can now set width to 100% to size properly but this still allows for overflow which is desirable in some cases.