### PR TITLE
Prevent actions when Datasheet IsReadOnly is set to true

### DIFF
--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -171,7 +171,7 @@
                             CellRenderFragment="CellRenderFragment"
                             NumberPrecisionDisplay="NumberPrecisionDisplay"
                             Cache="_visualCellCache"/>
-                        <EditorLayer @ref="_editorLayer" CustomCellTypes="@CustomCellTypeDefinitions"/>
+                        <EditorLayer Disabled="@IsReadOnly" @ref="_editorLayer" CustomCellTypes="@CustomCellTypeDefinitions"/>
                         <SelectionRendererLayer/>
                         @if (_showFormulaDependents)
                         {

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -12,12 +12,13 @@
 <div class="vars" theme="@_theme">
     <SelectionMenu
         MenuOptions="_menuOptions"
+        Disabled="@IsReadOnly"
         DefaultFilterTypes="DefaultFilterTypes"/>
 
     <SheetMenuTarget MenuId="SelectionMenu"
                      MenuData="_sheet"
                      Margin="0"
-                     Disabled="!_menuOptions.ContextMenuEnabled"
+                     DisableMenuTarget="!_menuOptions.ContextMenuEnabled"
                      Trigger="@MenuTrigger.OnContextMenu"
                      Placement="@MenuPlacement.BottomRight">
 

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -154,7 +154,7 @@
                     <LayerContainer Depth="@GridLevel" Sheet="_sheet" ViewRegion="MainViewRegion"
                                     PointerInputService="_sheetPointerInputService">
                         <HighlightLayer/>
-                        @if (UseAutoFill)
+                        @if (UseAutoFill && !IsReadOnly)
                         {
                             <AutofillLayer/>
                         }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -335,20 +335,23 @@
                 break;
             case "boolean":
                 builder.OpenComponent(120, typeof(BoolRenderer));
-                builder.AddComponentParameter(140, "Cell", cell);
-                builder.AddComponentParameter(160, "Sheet", _sheet);
+                builder.AddComponentParameter(140, nameof(BaseRenderer.Cell), cell);
+                builder.AddComponentParameter(160, nameof(BaseRenderer.Sheet), _sheet);
+                builder.AddComponentParameter(180, nameof(BaseRenderer.IsReadonly), IsReadOnly);
                 builder.CloseComponent();
                 break;
             case "select":
                 builder.OpenComponent(120, typeof(SelectRenderer));
-                builder.AddComponentParameter(140, "Cell", cell);
-                builder.AddComponentParameter(160, "Sheet", _sheet);
+                builder.AddComponentParameter(140, nameof(BaseRenderer.Cell), cell);
+                builder.AddComponentParameter(160, nameof(BaseRenderer.Sheet), _sheet);
+                builder.AddComponentParameter(180, nameof(BaseRenderer.IsReadonly), IsReadOnly);
                 builder.CloseComponent();
                 break;
             default:
                 builder.OpenComponent(120, GetCellRendererType(cell.CellType));
-                builder.AddComponentParameter(140, "Cell", cell);
-                builder.AddComponentParameter(160, "Sheet", _sheet);
+                builder.AddComponentParameter(140, nameof(BaseRenderer.Cell), cell);
+                builder.AddComponentParameter(160, nameof(BaseRenderer.Sheet), _sheet);
+                builder.AddComponentParameter(180, nameof(BaseRenderer.IsReadonly), IsReadOnly);
                 builder.CloseComponent();
                 break;
         }

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -581,14 +581,14 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
 
         ShortcutManager.Register(["KeyY"], [KeyboardModifiers.Ctrl, KeyboardModifiers.Meta],
             _ => _sheet.Commands.Redo(),
-            _ => !_sheet.Editor.IsEditing);
+            _ => !_sheet.Editor.IsEditing && !IsReadOnly);
         ShortcutManager.Register(["KeyZ"], [KeyboardModifiers.Ctrl, KeyboardModifiers.Meta],
             _ => _sheet.Commands.Undo(),
-            _ => !_sheet.Editor.IsEditing);
+            _ => !_sheet.Editor.IsEditing && !IsReadOnly);
 
         ShortcutManager.Register(["Delete", "Backspace"], KeyboardModifiers.Any,
             _ => _sheet.Commands.ExecuteCommand(new ClearCellsCommand(_sheet.Selection.Regions)),
-            _ => _sheet.Selection.Regions.Any() && !_sheet.Editor.IsEditing);
+            _ => _sheet.Selection.Regions.Any() && !_sheet.Editor.IsEditing && !IsReadOnly);
     }
 
     private void HandleCellMouseDown(object? sender, SheetPointerEventArgs args)
@@ -703,6 +703,9 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable
             return Task.FromResult(false);
 
         if (_sheet.Editor.IsEditing)
+            return Task.FromResult(false);
+
+        if (IsReadOnly)
             return Task.FromResult(false);
 
         var posnToInput = _sheet.Selection.GetInputPosition();

--- a/src/BlazorDatasheet/Edit/EditorLayer.razor
+++ b/src/BlazorDatasheet/Edit/EditorLayer.razor
@@ -26,6 +26,8 @@
 
     [Parameter, EditorRequired] public Dictionary<string, CellTypeDefinition> CustomCellTypes { get; set; } = null!;
 
+    [Parameter] public bool Disabled { get; set; }
+
     private Sheet _sheet = new(0, 0);
 
     /// The type of the active editor, which is an ICellEditor
@@ -70,6 +72,9 @@
     private void EditorOnEditBegin(object? sender, EditBeginEventArgs e)
     {
         if (!ViewRegion!.Contains(e.Cell.Row, e.Cell.Col))
+            return;
+
+        if (Disabled)
             return;
 
         ActiveEditorType = GetEditorType(e.Type);

--- a/src/BlazorDatasheet/Menu/SheetMenu.razor
+++ b/src/BlazorDatasheet/Menu/SheetMenu.razor
@@ -6,11 +6,13 @@
 
 <CascadingValue Value="@MenuId">
     <CascadingValue Value="@CurrentContext">
-        <div id="@MenuId" popover="manual" class="sheetPopover">
-            <div class="sheetMenu">
-                @ChildContent(CurrentContext)
+        <CascadingValue Value="@Disabled">
+            <div id="@MenuId" popover="manual" class="sheetPopover">
+                <div class="sheetMenu">
+                    @ChildContent(CurrentContext)
+                </div>
             </div>
-        </div>
+        </CascadingValue>
     </CascadingValue>
 </CascadingValue>
 
@@ -52,6 +54,8 @@
     [Parameter] public EventCallback<MenuShownEventArgs> OnMenuOpen { get; set; }
 
     [Parameter] public EventCallback OnMenuClose { get; set; }
+
+    [Parameter] public bool Disabled { get; set; }
 
     public object? CurrentContext { get; set; } = null;
 

--- a/src/BlazorDatasheet/Menu/SheetMenuItem.razor
+++ b/src/BlazorDatasheet/Menu/SheetMenuItem.razor
@@ -2,7 +2,7 @@
 @inject IMenuService MenuService
 @inherits SheetComponentBase
 
-<div class="sheet-menu-item"
+<div class="sheet-menu-item @(Disabled ? "sheet-menu-item-disabled" : "")"
      @onmouseup="HandleMouseUp"
      @onmouseover="HandleMouseOver">
     @ChildContent
@@ -14,8 +14,18 @@
         cursor: pointer;
     }
 
+    .sheet-menu-item-disabled {
+        cursor: default;
+        color: var(--sheet-foreground-color-disabled) !important;
+    }
+
+    .sheet-menu-item-disabled:hover {
+        color: var(--sheet-foreground-color-disabled) !important;
+        background-color: transparent !important;
+    }
+
     .sheet-menu-item:hover {
-        background-color: var(--sheet-menu-hover-color);
+        background-color: var(--sheet-menu-hover-color)
     }
 </style>
 
@@ -29,8 +39,13 @@
 
     [Parameter] public string? SubmenuId { get; set; } = null;
 
+    [CascadingParameter] public bool Disabled { get; set; }
+
     private async Task HandleMouseUp(MouseEventArgs args)
     {
+        if(Disabled)
+            return;
+        
         if (OnClick.HasDelegate)
             await OnClick.InvokeAsync(args);
         if (SubmenuId == null)

--- a/src/BlazorDatasheet/Menu/SheetMenuTarget.razor
+++ b/src/BlazorDatasheet/Menu/SheetMenuTarget.razor
@@ -41,8 +41,8 @@
 
     [Parameter] public object? MenuData { get; set; }
 
-    [Parameter] public bool Disabled { get; set; }
-    private bool _disabled;
+    [Parameter] public bool DisableMenuTarget { get; set; }
+    private bool _disableMenuTarget;
 
     private ElementReference _menuTarget;
     private DotNetObjectReference<SheetMenuTarget>? _dotnetRef;
@@ -51,9 +51,9 @@
 
     protected override async Task OnParametersSetAsync()
     {
-        if (Disabled != _disabled && Disabled)
+        if (DisableMenuTarget != _disableMenuTarget && DisableMenuTarget)
         {
-            _disabled = Disabled;
+            _disableMenuTarget = DisableMenuTarget;
 
             if (_dotnetRef == null || _menuTargetService == null)
                 return;
@@ -66,7 +66,7 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender && !_disabled && Trigger == MenuTrigger.OnContextMenu)
+        if (firstRender && !_disableMenuTarget && Trigger == MenuTrigger.OnContextMenu)
         {
             _dotnetRef = DotNetObjectReference.Create(this);
 
@@ -117,6 +117,9 @@
     private async Task ShowMenu(string trigger, MouseEventArgs args)
     {
         if (string.IsNullOrEmpty(MenuId))
+            return;
+        
+        if(DisableMenuTarget)
             return;
 
         await MenuService.ShowMenuAsync(MenuId, new MenuTargetOptions(TargetId, Placement, Margin, trigger, args.ClientX, args.ClientY), MenuData);

--- a/src/BlazorDatasheet/Menu/SheetSubMenu.razor
+++ b/src/BlazorDatasheet/Menu/SheetSubMenu.razor
@@ -1,12 +1,15 @@
 @inherits SheetComponentBase
 
-<SheetMenuTarget MenuId="@SubMenuId" MenuData="@CurrentContext" Placement="@MenuPlacement.Right" Trigger="@MenuTrigger.OnHover" Margin="0">
+<SheetMenuTarget DisableMenuTarget="@Disabled" MenuId="@SubMenuId" MenuData="@CurrentContext"
+                 Placement="@MenuPlacement.Right"
+                 Trigger="@MenuTrigger.OnHover" Margin="0">
     <SheetMenuItem SubmenuId="@SubMenuId">
         <div style="display: flex; justify-content: space-between; width: 100%; height: 100%; pointer-events: none;">
             <div>@Label</div>
             <div style="color: black; width: 0.7em; height: 0.7rem;">
                 <!-- from heroicons.com -->
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                     stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5"/>
                 </svg>
             </div>
@@ -14,7 +17,7 @@
     </SheetMenuItem>
 </SheetMenuTarget>
 
-<SheetMenu MenuId="@SubMenuId" ParentMenuId="@MenuId">
+<SheetMenu MenuId="@SubMenuId" Disabled="@Disabled" ParentMenuId="@MenuId">
     @ChildContent
 </SheetMenu>
 
@@ -27,8 +30,10 @@
 
     // parent menu id
     [CascadingParameter] public string MenuId { get; set; } = null!;
-    
+
     [CascadingParameter] public object? CurrentContext { get; set; }
+
+    [CascadingParameter] public bool Disabled { get; set; }
 
     public string SubMenuId { get; set; } = Guid.NewGuid().ToString();
 

--- a/src/BlazorDatasheet/Render/BaseRenderer.razor
+++ b/src/BlazorDatasheet/Render/BaseRenderer.razor
@@ -19,4 +19,10 @@
     [Parameter]
     public VisualCell Cell { get; set; }
 
+    /// <summary>
+    /// True if the datasheet is read-only
+    /// </summary>
+    [Parameter]
+    public bool IsReadonly { get; set; }
+
 }

--- a/src/BlazorDatasheet/Render/CaretButton.razor
+++ b/src/BlazorDatasheet/Render/CaretButton.razor
@@ -1,6 +1,10 @@
 @inherits SheetComponentBase
 
-<button tabindex="-1" class="bds-sheet-dropper" @onclick="OnClick" @onmousedown="OnPress">
+<button 
+    tabindex="-1" 
+    class="bds-sheet-dropper" 
+    @onclick="HandleClick" 
+    @onmousedown="HandleMousePress">
     @CaretIcon
 </button>
 
@@ -8,6 +12,21 @@
 
     [Parameter] public EventCallback<MouseEventArgs> OnClick { get; set; }
     [Parameter] public EventCallback<MouseEventArgs> OnPress { get; set; }
+    [Parameter] public bool Disabled { get; set; }
+
+    private async Task HandleClick(MouseEventArgs args)
+    {
+        if (Disabled)
+            return;
+        await OnClick.InvokeAsync(args);
+    }
+
+    private async Task HandleMousePress(MouseEventArgs args)
+    {
+        if (Disabled)
+            return;
+        await OnPress.InvokeAsync(args);
+    }
 
     // Caret icon from HeroIcons.com
     public static RenderFragment CaretIcon = __builder =>

--- a/src/BlazorDatasheet/Render/DefaultComponents/BoolRenderer.razor
+++ b/src/BlazorDatasheet/Render/DefaultComponents/BoolRenderer.razor
@@ -1,14 +1,13 @@
 @namespace BlazorDatasheet.Render.DefaultComponents
 @inherits BaseRenderer
 
-<div style="margin-top:auto;margin-bottom: auto;">
-    <input type="checkbox" disabled="@Cell.Format?.IsReadOnly" @bind="Checked"/>
+<div style="margin-top:auto;margin-bottom: auto; @(IsReadonly ? "pointer-events:none;" : "")">
+    <input type="checkbox" disabled="@(Cell.Format?.IsReadOnly == true || IsReadonly)" @bind="Checked"/>
 </div>
 
 @code {
 
     private bool _checked;
-    private bool IsReadOnly { get; init; }
 
     public bool Checked
     {

--- a/src/BlazorDatasheet/Render/DefaultComponents/SelectRenderer.razor
+++ b/src/BlazorDatasheet/Render/DefaultComponents/SelectRenderer.razor
@@ -12,7 +12,7 @@
         @(Cell.Value?.ToString())
     </div>
     <div style="margin-right: 0; width: 16px;">
-        <CaretButton OnPress="@BeginEdit"/>
+        <CaretButton Disabled="@IsReadonly" OnPress="@BeginEdit"/>
     </div>
 </div>
 

--- a/src/BlazorDatasheet/SelectionMenu.razor
+++ b/src/BlazorDatasheet/SelectionMenu.razor
@@ -9,7 +9,7 @@
 @using BlazorDatasheet.Menu.Filters
 @inject IMenuService MenuService;
 
-<SheetMenu MenuId="@ContextMenus.Selection" OnMenuClose="OnSelectionMenuClose">
+<SheetMenu Disabled="@Disabled" MenuId="@ContextMenus.Selection" OnMenuClose="OnSelectionMenuClose">
 
     @{
         var sheet = context as Sheet;
@@ -32,7 +32,7 @@
             }
             @if (MenuOptions.AlignmentEnabled)
             {
-                <SheetSubMenu Label="Horiz. Alignment">
+                <SheetSubMenu Label="Horiz. Alignment ">
                     <SheetMenuItem
                         OnClick="@(() => sheet.SetFormat(sheet.Selection.Regions, new CellFormat() { HorizontalTextAlign = TextAlign.Start }))">
                         Left
@@ -178,6 +178,7 @@
 
     [Parameter] public SheetMenuOptions MenuOptions { get; set; } = new();
     [Parameter] public Type[] DefaultFilterTypes { get; set; } = default!;
+    [Parameter] public bool Disabled { get; set; }
 
     private SheetSubMenu _filterSubMenu = default!;
     private bool HasOpenedFilterMenu { get; set; }

--- a/src/BlazorDatasheet/wwwroot/sheet-styles.css
+++ b/src/BlazorDatasheet/wwwroot/sheet-styles.css
@@ -6,6 +6,7 @@
 
 .vars[theme='default'] {
     --sheet-foreground-color: #454545;
+    --sheet-foreground-color-disabled: #a5a5a5;
     --sheet-bg-color: #ffffff;
     --sheet-border-style: 1px solid #c5c5c5;
     --row-header-bg-color: #fafafa;
@@ -37,6 +38,7 @@
 
 .vars[theme='dark'] {
     --sheet-foreground-color: #a9a9a9;
+    --sheet-foreground-color-disabled: #807f7f;
     --sheet-bg-color: #262626;
     --sheet-border-style: 1px solid #3f3f3f;
     --row-header-bg-color: #2d2d2d;
@@ -310,14 +312,14 @@
 
 .bds-sheet-dropper {
     background: none;
-    color:#999999;
+    color: #999999;
     margin: 0;
     padding: 0 2px 0 2px;
     border: none;
     cursor: pointer;
 }
 
-.bds-sheet-dropper:hover{
+.bds-sheet-dropper:hover {
     background: var(--selection-bg-color);
 }
 
@@ -355,14 +357,14 @@
     background: var(--selection-bg-color)
 }
 
-.bds-func-suggestions{
-    min-width:100px;
-    margin-top:4px;
+.bds-func-suggestions {
+    min-width: 100px;
+    margin-top: 4px;
     background: var(--sheet-bg-color);
     box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px;
 }
 
-.bds-func-suggestions-item{
+.bds-func-suggestions-item {
     padding: 2px 4px;
 }
 


### PR DESCRIPTION
This still allows programmatic interaction with the sheet while IsReadOnly = true, however limits user interaction.

Fix #238 

- Disables menu selection
- Disables keyboard interaction (ctrl+v, ctrl+z, ctrl+y, delete) when Datasheet is read only.
- Stops editor from appearing
- Removes auto-fill option.
- Removes bool/select editing when Datasheet is read only.