### PR TITLE
Load highlight.js on first page load to reduce lag when first editing.

### DIFF
--- a/src/BlazorDatasheet/Edit/DefaultComponents/HighlightedInput.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/HighlightedInput.razor
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.JSInterop
-@using System.Diagnostics
 @using System.Text
 @using BlazorDatasheet.DataStructures.Geometry
 @using BlazorDatasheet.Formula.Core.Interpreter
@@ -35,7 +34,6 @@
 
     [Parameter] public double CellWidth { get; set; }
     [Parameter] public double CellHeight { get; set; }
-    private bool _softEdit;
     [Parameter] public bool SoftEdit { get; set; }
     [Parameter] public string? Style { get; set; }
 
@@ -193,7 +191,7 @@
 
             _dotnetRef?.Dispose();
         }
-        catch (Exception e)
+        catch (Exception)
         {
             // ignore
         }

--- a/src/BlazorDatasheet/wwwroot/blazor-datasheet.js
+++ b/src/BlazorDatasheet/wwwroot/blazor-datasheet.js
@@ -1,3 +1,6 @@
+// import eagerly to avoid lag when first edit occurs.
+import("./js/highlighter.js");
+
 window.writeTextToClipboard = async function (text) {
     if (window.isSecureContext) {
         await window.navigator.clipboard.writeText(text)


### PR DESCRIPTION
May reduce some lag as described in #237 as it will load the .js for the formula editor on page load, rather than load it when the user first types in a cell. Previously, there was a minor lag when the user first types due to the loading of the .js.