### PR TITLE
Fix shift select inconsistency headers

### DIFF
--- a/src/BlazorDatasheet.Core/Selecting/Selection.cs
+++ b/src/BlazorDatasheet.Core/Selecting/Selection.cs
@@ -452,14 +452,14 @@ public class Selection
                 currRow = merge.Bottom;
         }
 
-        currRow = _sheet.Rows.GetNextVisible(currRow, rowDir);
-        if (currRow == -1)
-            currRow = rowDir == 1 ? ActiveRegion.Bottom + 1 : ActiveRegion.Top - 1;
-
         // Fix the active region to surrounds of the sheet
         var activeRegionFixed = ActiveRegion.GetIntersection(_sheet.Region);
         if (activeRegionFixed == null)
             return;
+
+        currRow = _sheet.Rows.GetNextVisible(currRow, rowDir);
+        if (currRow == -1)
+            currRow = rowDir == 1 ? activeRegionFixed.Bottom + 1 : activeRegionFixed.Top - 1;
 
         // If the active region is only one cell and there are no other regions,
         // clear the regions and move the whole thing down
@@ -547,14 +547,14 @@ public class Selection
                 currCol = merge.Right;
         }
 
-        currCol = _sheet.Columns.GetNextVisible(currCol, colDir);
-        if (currCol == -1)
-            currCol = colDir == 1 ? ActiveRegion.Right + 1 : ActiveRegion.Left - 1;
-
         // Fix the active region to surrounds of the sheet
         var activeRegionFixed = ActiveRegion.GetIntersection(_sheet.Region);
         if (activeRegionFixed == null)
             return;
+
+        currCol = _sheet.Columns.GetNextVisible(currCol, colDir);
+        if (currCol == -1)
+            currCol = colDir == 1 ? activeRegionFixed.Right + 1 : activeRegionFixed.Left - 1;
 
         // If the active region is only one cell and there are no other regions,
         // clear the regions and move the whole thing down

--- a/test/BlazorDatasheet.Test/SheetTests/SelectionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SelectionTests.cs
@@ -207,7 +207,7 @@ public class SelectionManagerTests
         manager.Selection.ActiveRegion.Height.Should().Be(2);
         manager.Selection.ActiveRegion.Top.Should().Be(1);
     }
-    
+
     [Test]
     public void Select_Col_Header_Then_Shift_Select_Col_Header_Should_Extend_Col_Selection()
     {
@@ -221,5 +221,35 @@ public class SelectionManagerTests
         manager.Selection.ActiveRegion.Should().BeOfType<ColumnRegion>();
         manager.Selection.ActiveRegion.Width.Should().Be(2);
         manager.Selection.ActiveRegion.Left.Should().Be(1);
+    }
+
+    [Test]
+    public void Active_Cell_Should_Move_To_Top_With_Row_Selection_And_Enter()
+    {
+        var manager = new SelectionInputManager(_sheet.Selection);
+        manager.HandlePointerDown(-1, 1, false, false, false, 0);
+        manager.HandleWindowMouseUp();
+
+        for (int i = 0; i < _sheet.NumRows; i++)
+        {
+            manager.Selection.MoveActivePositionByRow(1);
+        }
+
+        manager.Selection.ActiveCellPosition.row.Should().Be(0);
+    }
+
+    [Test]
+    public void Active_Cell_Should_Move_To_Left_With_Col_Selection_And_Enter()
+    {
+        var manager = new SelectionInputManager(_sheet.Selection);
+        manager.HandlePointerDown(1, -1, false, false, false, 0);
+        manager.HandleWindowMouseUp();
+
+        for (int i = 0; i < _sheet.NumCols; i++)
+        {
+            manager.Selection.MoveActivePositionByCol(1);
+        }
+
+        manager.Selection.ActiveCellPosition.col.Should().Be(0);
     }
 }


### PR DESCRIPTION
Fixes inconsistency when selecting row/column headers with shift, as described in #261 