### PR TITLE
Replace ISheetFunction with  FunctionDescriptor registry.

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Workbook.cs
+++ b/src/BlazorDatasheet.Core/Data/Workbook.cs
@@ -3,6 +3,7 @@ using BlazorDatasheet.Core.FormulaEngine;
 using BlazorDatasheet.Core.Interfaces;
 using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter;
+using BlazorDatashet.Formula.Functions;
 
 namespace BlazorDatasheet.Core.Data;
 
@@ -31,8 +32,19 @@ public class Workbook
 
     public Workbook(FormulaOptions? options = null)
     {
-        Environment = new WorkbookEnvironment(this);
+        var registry = BuildDefaultRegistry(options);
+        Environment = new WorkbookEnvironment(this, registry);
         _formulaEngine = new FormulaEngine.FormulaEngine(Environment, options);
+    }
+
+    public static FunctionRegistry BuildDefaultRegistry(FormulaOptions? options)
+    {
+        var builder = new FunctionRegistryBuilder();
+        builder.RegisterLogicalFunctions();
+        builder.RegisterMathFunctions();
+        builder.RegisterLookupFunctions();
+        options?.ConfigureFunctions?.Invoke(builder);
+        return builder.Build();
     }
 
     public Sheet AddSheet(int numRows, int numColumns, int defaultWidth = 105, int defaultHeight = 24)

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -10,7 +10,6 @@ using BlazorDatasheet.Formula.Core.Dependencies;
 using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
 using BlazorDatasheet.Formula.Core.Interpreter.Parsing;
-using BlazorDatashet.Formula.Functions;
 using CellFormula = BlazorDatasheet.Formula.Core.Interpreter.CellFormula;
 
 namespace BlazorDatasheet.Core.FormulaEngine;
@@ -38,7 +37,6 @@ public class FormulaEngine
         _environment = environment;
         _parser = new Parser(_environment, Options);
         _evaluator = new Evaluator(_environment);
-        RegisterDefaultFunctions();
     }
 
     internal void AddSheet(Sheet sheet)
@@ -101,13 +99,6 @@ public class FormulaEngine
     private void RowColsOnRemoved(object? sender, RowColRemovedEventArgs e)
     {
         CalculateSheet(true);
-    }
-
-    private void RegisterDefaultFunctions()
-    {
-        _environment.RegisterLogicalFunctions();
-        _environment.RegisterMathFunctions();
-        _environment.RegisterLookupFunctions();
     }
 
     private void SheetOnBeforeCellEdit(object? sender, BeforeCellEditEventArgs e)
@@ -319,24 +310,10 @@ public class FormulaEngine
     }
 
     /// <summary>
-    /// Returns whether the function with name <paramref name="functionName"/> has been registered.
+    /// Returns the registered function with name <paramref name="functionName"/>, or null if not registered.
     /// </summary>
-    /// <param name="functionName"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    public bool FunctionExists(string functionName)
+    public FunctionDescriptor? GetFunction(string functionName)
     {
-        return _environment.FunctionExists(functionName);
-    }
-
-    /// <summary>
-    /// Returns the registered function with name <paramref name="functionName"/>
-    /// </summary>
-    /// <param name="functionName"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    public ISheetFunction? GetFunction(string functionName)
-    {
-        return _environment.GetFunctionDefinition(functionName);
+        return _environment.TryGetFunction(functionName, out var function) ? function : null;
     }
 }

--- a/src/BlazorDatasheet.Core/FormulaEngine/WorkbookEnvironment.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/WorkbookEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+﻿using System.Diagnostics.CodeAnalysis;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.References;
@@ -9,11 +10,12 @@ public class WorkbookEnvironment : IEnvironment
 {
     private readonly Workbook _workbook;
     private readonly Dictionary<string, CellValue> _variables = new();
-    private readonly Dictionary<string, ISheetFunction> _functions = new(StringComparer.OrdinalIgnoreCase);
+    private readonly FunctionRegistry _functionRegistry;
 
-    public WorkbookEnvironment(Workbook workbook)
+    public WorkbookEnvironment(Workbook workbook, FunctionRegistry functionRegistry)
     {
         _workbook = workbook;
+        _functionRegistry = functionRegistry;
     }
 
     public bool VariableExists(string name)
@@ -47,28 +49,14 @@ public class WorkbookEnvironment : IEnvironment
         return _variables.Keys;
     }
 
-    public bool FunctionExists(string name)
+    public bool TryGetFunction(string name, [MaybeNullWhen(false)] out FunctionDescriptor functionDescriptor)
     {
-        return _functions.ContainsKey(name);
-    }
-
-    public ISheetFunction? GetFunctionDefinition(string name)
-    {
-        return _functions.GetValueOrDefault(name);
-    }
-
-    public void RegisterFunction(string name, ISheetFunction value)
-    {
-        if (!_functions.ContainsKey(name))
-            _functions.Add(name, value);
-        else
-            _functions[name] = value;
+        return _functionRegistry.TryGetFunction(name, out functionDescriptor);
     }
 
     public IEnumerable<FunctionDefinition> SearchForFunctions(string functionName)
     {
-        return _functions.Where(x => x.Key.StartsWith(functionName, StringComparison.OrdinalIgnoreCase))
-            .Select(x => new FunctionDefinition(x.Key, x.Value));
+        return _functionRegistry.SearchForFunctions(functionName);
     }
 
     public IEnumerable<CellValue> GetNonEmptyInRange(Reference reference)

--- a/src/BlazorDatasheet.Formula.Core/FunctionDefinition.cs
+++ b/src/BlazorDatasheet.Formula.Core/FunctionDefinition.cs
@@ -3,9 +3,9 @@
 public class FunctionDefinition
 {
     public string Name { get; }
-    public ISheetFunction Function { get; }
+    public FunctionDescriptor Function { get; }
 
-    public FunctionDefinition(string name, ISheetFunction function)
+    public FunctionDefinition(string name, FunctionDescriptor function)
     {
         Name = name;
         Function = function;

--- a/src/BlazorDatasheet.Formula.Core/FunctionDescriptor.cs
+++ b/src/BlazorDatasheet.Formula.Core/FunctionDescriptor.cs
@@ -1,0 +1,66 @@
+namespace BlazorDatasheet.Formula.Core;
+
+public sealed class FunctionDescriptor
+{
+    private readonly Func<CellValue[], FunctionCallMetaData, CellValue> _invoker;
+    private readonly FunctionCallMetaData _callMetaData;
+
+    public string Name { get; }
+    public ParameterDefinition[] ParameterDefinitions { get; }
+    public int MinArity { get; }
+    public int MaxArity { get; }
+    public bool AcceptsErrors { get; }
+    public bool IsVolatile { get; }
+    public ReturnShape ReturnShape { get; }
+
+    public FunctionDescriptor(
+        string name,
+        ParameterDefinition[] parameterDefinitions,
+        Func<CellValue[], FunctionCallMetaData, CellValue> invoker,
+        bool acceptsErrors = false,
+        bool isVolatile = false,
+        ReturnShape returnShape = ReturnShape.Scalar)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Function name cannot be null or empty", nameof(name));
+
+        Name = name;
+        ParameterDefinitions = parameterDefinitions ?? throw new ArgumentNullException(nameof(parameterDefinitions));
+        _invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
+        AcceptsErrors = acceptsErrors;
+        IsVolatile = isVolatile;
+        ReturnShape = returnShape;
+
+        var validator = new FunctionParameterValidator();
+        validator.ValidateOrThrow(ParameterDefinitions);
+        _callMetaData = new FunctionCallMetaData(ParameterDefinitions);
+
+        MinArity = ComputeMinArity(ParameterDefinitions);
+        MaxArity = ComputeMaxArity(ParameterDefinitions);
+    }
+
+    public CellValue Invoke(CellValue[] args)
+    {
+        return _invoker(args, _callMetaData);
+    }
+
+    private static int ComputeMinArity(ParameterDefinition[] parameterDefinitions)
+    {
+        var min = 0;
+        for (int i = 0; i < parameterDefinitions.Length; i++)
+        {
+            if (parameterDefinitions[i].Requirement == ParameterRequirement.Required)
+                min++;
+        }
+
+        return min;
+    }
+
+    private static int ComputeMaxArity(ParameterDefinition[] parameterDefinitions)
+    {
+        if (parameterDefinitions.Length == 0)
+            return 0;
+
+        return parameterDefinitions[^1].IsRepeating ? 128 : parameterDefinitions.Length;
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/FunctionRegistry.cs
+++ b/src/BlazorDatasheet.Formula.Core/FunctionRegistry.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorDatasheet.Formula.Core;
+
+public sealed class FunctionRegistry
+{
+    private readonly Dictionary<string, FunctionDescriptor> _functions;
+    private readonly string[] _sortedNames;
+
+    internal FunctionRegistry(IDictionary<string, FunctionDescriptor> functions)
+    {
+        _functions = new Dictionary<string, FunctionDescriptor>(functions, StringComparer.OrdinalIgnoreCase);
+        _sortedNames = _functions.Keys.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToArray();
+    }
+
+    public bool TryGetFunction(string functionIdentifier, [MaybeNullWhen(false)] out FunctionDescriptor functionDescriptor)
+    {
+        return _functions.TryGetValue(functionIdentifier, out functionDescriptor);
+    }
+
+    public IEnumerable<FunctionDefinition> SearchForFunctions(string prefix)
+    {
+        prefix ??= string.Empty;
+
+        foreach (var name in _sortedNames)
+        {
+            if (!name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            yield return new FunctionDefinition(name, _functions[name]);
+        }
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/FunctionRegistryBuilder.cs
+++ b/src/BlazorDatasheet.Formula.Core/FunctionRegistryBuilder.cs
@@ -1,0 +1,27 @@
+namespace BlazorDatasheet.Formula.Core;
+
+public sealed class FunctionRegistryBuilder
+{
+    private readonly Dictionary<string, FunctionDescriptor> _functions = new(StringComparer.OrdinalIgnoreCase);
+    private bool _isBuilt;
+
+    public FunctionRegistryBuilder Add(FunctionDescriptor descriptor)
+    {
+        if (_isBuilt)
+            throw new InvalidOperationException("Cannot add functions after registry has been built.");
+
+        if (!_functions.TryAdd(descriptor.Name, descriptor))
+            throw new InvalidOperationException($"Function '{descriptor.Name}' has already been registered.");
+
+        return this;
+    }
+
+    public FunctionRegistry Build()
+    {
+        if (_isBuilt)
+            throw new InvalidOperationException("Registry has already been built.");
+
+        _isBuilt = true;
+        return new FunctionRegistry(_functions);
+    }
+}

--- a/src/BlazorDatasheet.Formula.Core/IFunctionProvider.cs
+++ b/src/BlazorDatasheet.Formula.Core/IFunctionProvider.cs
@@ -1,9 +1,9 @@
-﻿namespace BlazorDatasheet.Formula.Core;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BlazorDatasheet.Formula.Core;
 
 public interface IFunctionProvider
 {
-    bool FunctionExists(string functionIdentifier);
-    ISheetFunction? GetFunctionDefinition(string identifierText);
-    void RegisterFunction(string name, ISheetFunction value);
+    bool TryGetFunction(string functionIdentifier, [MaybeNullWhen(false)] out FunctionDescriptor functionDescriptor);
     IEnumerable<FunctionDefinition> SearchForFunctions(string functionName);
 }

--- a/src/BlazorDatasheet.Formula.Core/ISheetFunction.cs
+++ b/src/BlazorDatasheet.Formula.Core/ISheetFunction.cs
@@ -1,9 +1,0 @@
-namespace BlazorDatasheet.Formula.Core;
-
-public interface ISheetFunction
-{
-    public ParameterDefinition[] GetParameterDefinitions();
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData);
-    public bool AcceptsErrors { get; }
-    public bool IsVolatile { get; }
-}

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/Evaluator.cs
@@ -171,13 +171,12 @@ public class Evaluator
         if (!node.FunctionExists)
             return CellValue.Error(new FormulaError(ErrorType.Name, $"Function {id} not found"));
 
-        var func = node.Function!;
-        var nArgsProvided = node.Args.Count();
+        var func = node.FunctionDescriptor!;
+        var nArgsProvided = node.Args.Count;
+        var paramDefinitions = func.ParameterDefinitions;
 
-        var paramDefinitions = func.GetParameterDefinitions();
-
-        if (nArgsProvided < MinArity(paramDefinitions) ||
-            nArgsProvided > MaxArity(paramDefinitions))
+        if (nArgsProvided < func.MinArity ||
+            nArgsProvided > func.MaxArity)
         {
             return CellValue.Error(ErrorType.Na, "Incorrect number of function arguments");
         }
@@ -204,25 +203,13 @@ public class Evaluator
             argIndex++;
         }
 
-        var funcResult = func.Call(convertedArgs, new FunctionCallMetaData(paramDefinitions));
+        var funcResult = func.Invoke(convertedArgs);
         return funcResult;
     }
 
     private bool IsConsumable(ParameterDefinition param)
     {
         return !param.IsRepeating;
-    }
-
-    private int MaxArity(ParameterDefinition[] parameterDefinitions)
-    {
-        if (parameterDefinitions.Length == 0)
-            return 0;
-        return parameterDefinitions.Last().IsRepeating ? 128 : parameterDefinitions.Length;
-    }
-
-    private int MinArity(ParameterDefinition[] parameterDefinitions)
-    {
-        return parameterDefinitions.Count(x => x.Requirement == ParameterRequirement.Required);
     }
 
     private CellValue EvaluateBinaryExpression(BinaryOperationExpression expression, EvalContext ctx)

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/FormulaOptions.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/FormulaOptions.cs
@@ -5,4 +5,5 @@ namespace BlazorDatasheet.Formula.Core.Interpreter;
 public class FormulaOptions
 {
     public SeparatorSettings SeparatorSettings { get; init; } = new();
+    public Action<FunctionRegistryBuilder>? ConfigureFunctions { get; init; }
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/FunctionExpression.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/FunctionExpression.cs
@@ -9,9 +9,9 @@ public class FunctionExpression : Expression
     public IdentifierToken FunctionToken { get; }
     public List<Expression> Args { get; }
 
-    public ISheetFunction? Function { get; }
+    public FunctionDescriptor? FunctionDescriptor { get; }
 
-    public bool FunctionExists => Function != null;
+    public bool FunctionExists => FunctionDescriptor != null;
 
     private int[] _argPositionStarts;
     private readonly Token _rightParenthToken;
@@ -19,7 +19,7 @@ public class FunctionExpression : Expression
     public FunctionExpression(
         IdentifierToken functionToken,
         List<Expression> args,
-        ISheetFunction? function,
+        FunctionDescriptor? function,
         FormulaOptions options,
         int[] argPositionStarts,
         Token rightParenthToken)
@@ -27,7 +27,7 @@ public class FunctionExpression : Expression
         _options = options;
         FunctionToken = functionToken;
         Args = args;
-        Function = function;
+        FunctionDescriptor = function;
         _argPositionStarts = argPositionStarts;
         _rightParenthToken = rightParenthToken;
     }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Parsing/Parser.cs
@@ -381,10 +381,10 @@ public class Parser
 
         var rightParenth = MatchToken(Tag.RightParenthToken);
 
-        if (!_environment.FunctionExists(funcToken.Value))
+        var functionExists = _environment.TryGetFunction(funcToken.Value, out var functionDefinition);
+        if (!functionExists)
             Error($"Function {funcToken.Value} does not exist");
 
-        var functionDefinition = _environment.GetFunctionDefinition(funcToken.Value);
         if (functionDefinition != null && functionDefinition.IsVolatile)
             _containsVolatiles = true;
 

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/ParsingEnvironment.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/ParsingEnvironment.cs
@@ -1,0 +1,38 @@
+using System.Diagnostics.CodeAnalysis;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
+
+namespace BlazorDatasheet.Formula.Core.Interpreter;
+
+/// <summary>
+/// A lightweight <see cref="IEnvironment"/> for parse-only scenarios (e.g. hint calculation).
+/// Data-access members throw because parsing never reads cell or variable state.
+/// </summary>
+public sealed class ParsingEnvironment : IEnvironment
+{
+    private readonly FunctionRegistry _functionRegistry;
+
+    public ParsingEnvironment(FunctionRegistry functionRegistry)
+    {
+        _functionRegistry = functionRegistry;
+    }
+
+    public bool TryGetFunction(string functionIdentifier, [MaybeNullWhen(false)] out FunctionDescriptor functionDescriptor)
+        => _functionRegistry.TryGetFunction(functionIdentifier, out functionDescriptor);
+
+    public IEnumerable<FunctionDefinition> SearchForFunctions(string functionName)
+        => _functionRegistry.SearchForFunctions(functionName);
+
+    public CellValue GetCellValue(int row, int col, string sheetName) => throw NotSupported();
+    public CellFormula? GetFormula(int row, int col, string sheetName) => throw NotSupported();
+    public CellValue[][] GetRangeValues(Reference reference) => throw NotSupported();
+    public bool VariableExists(string variableIdentifier) => throw NotSupported();
+    public CellValue GetVariable(string variableIdentifier) => throw NotSupported();
+    public void SetVariable(string name, CellValue value) => throw NotSupported();
+    public IEnumerable<CellValue> GetNonEmptyInRange(Reference reference) => throw NotSupported();
+    public void SetCellValue(int row, int col, string sheetName, CellValue value) => throw NotSupported();
+    public void ClearVariable(string varName) => throw NotSupported();
+    public IEnumerable<string> GetVariableNames() => throw NotSupported();
+
+    private static NotSupportedException NotSupported() =>
+        new("ParsingEnvironment does not support runtime data access.");
+}

--- a/src/BlazorDatasheet.Formula.Core/ParameterDefinition.cs
+++ b/src/BlazorDatasheet.Formula.Core/ParameterDefinition.cs
@@ -6,15 +6,18 @@ public class ParameterDefinition
     public ParameterType Type { get; init; }
     public bool IsRepeating { get; init; }
     public ParameterRequirement Requirement { get; init; }
+    public ParameterShape Shape { get; init; }
 
     public ParameterDefinition(string name,
         ParameterType type,
         ParameterRequirement requirement = ParameterRequirement.Required,
-        bool isRepeating = false)
+        bool isRepeating = false,
+        ParameterShape shape = ParameterShape.Scalar)
     {
         Name = name;
         Type = type;
         IsRepeating = isRepeating;
         Requirement = requirement;
+        Shape = shape;
     }
 }

--- a/src/BlazorDatasheet.Formula.Core/ParameterShape.cs
+++ b/src/BlazorDatasheet.Formula.Core/ParameterShape.cs
@@ -1,0 +1,8 @@
+namespace BlazorDatasheet.Formula.Core;
+
+public enum ParameterShape
+{
+    Scalar,
+    Array,
+    ScalarOrArray
+}

--- a/src/BlazorDatasheet.Formula.Core/ReturnShape.cs
+++ b/src/BlazorDatasheet.Formula.Core/ReturnShape.cs
@@ -1,0 +1,7 @@
+namespace BlazorDatasheet.Formula.Core;
+
+public enum ReturnShape
+{
+    Scalar,
+    Array
+}

--- a/src/BlazorDatasheet.Formula.Functions/Logical/AndFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Logical/AndFunction.cs
@@ -2,22 +2,26 @@ using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatasheet.Formula.Functions.Logical;
 
-public class AndFunction : ISheetFunction
+public static class AndFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition(
-                name: "logical",
-                type: ParameterType.LogicalSequence,
-                requirement: ParameterRequirement.Required,
-                isRepeating: true
-            )
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new(
+            name: "logical",
+            type: ParameterType.LogicalSequence,
+            requirement: ParameterRequirement.Required,
+            isRepeating: true,
+            shape: ParameterShape.ScalarOrArray)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "AND",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var isTrue = true;
         foreach (var arg in args)
@@ -25,18 +29,16 @@ public class AndFunction : ISheetFunction
             var seq = arg.GetValue<CellValue[]>()!;
             if (seq.Length == 0)
                 return CellValue.Error(ErrorType.Value);
+
             foreach (var cv in seq)
             {
                 if (cv.IsError())
                     return cv;
-                else
-                    isTrue &= cv.GetValue<bool>();
+
+                isTrue &= cv.GetValue<bool>();
             }
         }
 
         return CellValue.Logical(isTrue);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Logical/IfFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Logical/IfFunction.cs
@@ -1,48 +1,36 @@
-﻿using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatasheet.Formula.Functions.Logical;
 
-public class IfFunction : ISheetFunction
+public static class IfFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition(
-                "logical1",
-                ParameterType.Logical,
-                ParameterRequirement.Required
-            ),
-            new ParameterDefinition(
-                "val_if_true",
-                ParameterType.Any,
-                ParameterRequirement.Optional
-            ),
-            new ParameterDefinition(
-                "val_if_false",
-                ParameterType.Any,
-                ParameterRequirement.Optional
-            ),
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("logical1", ParameterType.Logical, ParameterRequirement.Required),
+        new("val_if_true", ParameterType.Any, ParameterRequirement.Optional, shape: ParameterShape.ScalarOrArray),
+        new("val_if_false", ParameterType.Any, ParameterRequirement.Optional, shape: ParameterShape.ScalarOrArray)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "IF",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: true,
+        isVolatile: false,
+        returnShape: ReturnShape.Scalar);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         if (args[0].IsError())
             return args[0];
 
-        var isTrue = args.First().GetValue<bool>();
+        var isTrue = args[0].GetValue<bool>();
         if (args.Length > 1 && isTrue)
-        {
             return args[1];
-        }
 
         if (args.Length > 2 && !isTrue)
             return args[2];
 
         return CellValue.Logical(isTrue);
     }
-
-    public bool AcceptsErrors => true;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Logical/NotFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Logical/NotFunction.cs
@@ -1,23 +1,23 @@
-﻿using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatasheet.Formula.Functions.Logical;
 
-public class NotFunction : ISheetFunction
+public static class NotFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new ParameterDefinition[]
-        {
-            new("value", ParameterType.Logical, ParameterRequirement.Required)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("value", ParameterType.Logical, ParameterRequirement.Required)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
-    {
-        var val = args[0].GetValue<bool>();
-        return CellValue.Logical(!val);
-    }
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "NOT",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
 
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
+    {
+        return CellValue.Logical(!args[0].GetValue<bool>());
+    }
 }

--- a/src/BlazorDatasheet.Formula.Functions/Logical/OrFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Logical/OrFunction.cs
@@ -2,22 +2,26 @@ using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatasheet.Formula.Functions.Logical;
 
-public class OrFunction : ISheetFunction
+public static class OrFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition(
-                name: "logical",
-                type: ParameterType.LogicalSequence,
-                requirement: ParameterRequirement.Required,
-                isRepeating: true
-            )
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new(
+            name: "logical",
+            type: ParameterType.LogicalSequence,
+            requirement: ParameterRequirement.Required,
+            isRepeating: true,
+            shape: ParameterShape.ScalarOrArray)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "OR",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var isTrue = false;
         foreach (var arg in args)
@@ -25,18 +29,16 @@ public class OrFunction : ISheetFunction
             var seq = arg.GetValue<CellValue[]>()!;
             if (seq.Length == 0)
                 return CellValue.Error(ErrorType.Value);
+
             foreach (var cv in seq)
             {
                 if (cv.IsError())
                     return cv;
-                else
-                    isTrue |= cv.GetValue<bool>();
+
+                isTrue |= cv.GetValue<bool>();
             }
         }
 
         return CellValue.Logical(isTrue);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Lookup/VLookupFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Lookup/VLookupFunction.cs
@@ -1,29 +1,35 @@
-﻿using BlazorDatasheet.DataStructures.Search;
+using BlazorDatasheet.DataStructures.Search;
 using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
 
 namespace BlazorDatashet.Formula.Functions.Lookup;
 
-public class VLookupFunction : ISheetFunction
+public static class VLookupFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition("Lookup", ParameterType.Any, ParameterRequirement.Required),
-            new ParameterDefinition("DataSource", ParameterType.Array, ParameterRequirement.Required),
-            new ParameterDefinition("Column", ParameterType.Integer, ParameterRequirement.Required),
-            new ParameterDefinition("RangeLookup", ParameterType.Logical, ParameterRequirement.Optional)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("Lookup", ParameterType.Any, ParameterRequirement.Required, shape: ParameterShape.ScalarOrArray),
+        new("DataSource", ParameterType.Array, ParameterRequirement.Required, shape: ParameterShape.Array),
+        new("Column", ParameterType.Integer, ParameterRequirement.Required),
+        new("RangeLookup", ParameterType.Logical, ParameterRequirement.Optional)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "VLOOKUP",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var isRangeLookup = args.Length > 3 ? args[3].GetValue<bool>() : true;
 
         for (int i = 1; i < args.Length; i++)
+        {
             if (args[i].IsError())
                 return args[i];
+        }
 
         var lookupValue = args[0];
         var data = args[1];
@@ -35,7 +41,7 @@ public class VLookupFunction : ISheetFunction
         var nRows = data.Rows();
         var dataArr = (CellValue[][])data.Data!;
 
-        if (isRangeLookup == false)
+        if (!isRangeLookup)
         {
             for (int row = 0; row < nRows; row++)
             {
@@ -46,20 +52,16 @@ public class VLookupFunction : ISheetFunction
             return CellValue.Error(ErrorType.Na);
         }
 
-        var arrAsList = dataArr.Select(x => x[0]).ToList()!;
-        
+        var arrAsList = dataArr.Select(x => x[0]).ToList();
         var indexSearched = arrAsList.BinarySearchIndexOf(lookupValue);
         if (indexSearched >= 0)
             return dataArr[indexSearched][column];
-        else
-            indexSearched = ~indexSearched - 1;
+
+        indexSearched = ~indexSearched - 1;
 
         if (indexSearched < 0 || indexSearched > arrAsList.Count - 1)
             return CellValue.Error(ErrorType.Na);
 
         return dataArr[indexSearched][column];
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/AverageFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/AverageFunction.cs
@@ -2,22 +2,26 @@ using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class AverageFunction : ISheetFunction
+public static class AverageFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition(
-                "number",
-                ParameterType.NumberSequence,
-                ParameterRequirement.Required,
-                isRepeating: true
-            )
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new(
+            "number",
+            ParameterType.NumberSequence,
+            ParameterRequirement.Required,
+            isRepeating: true,
+            shape: ParameterShape.ScalarOrArray)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "AVERAGE",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var sum = 0d;
         var count = 0d;
@@ -25,18 +29,15 @@ public class AverageFunction : ISheetFunction
         {
             var seq = arg.GetValue<CellValue[]>()!;
             foreach (var item in seq)
+            {
                 if (item.IsError())
                     return item;
-                else
-                {
-                    sum += item.GetValue<double>();
-                    count++;
-                }
+
+                sum += item.GetValue<double>();
+                count++;
+            }
         }
 
         return CellValue.Number(sum / count);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/InterceptFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/InterceptFunction.cs
@@ -3,23 +3,27 @@ using BlazorDatasheet.Formula.Core.Regression;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class InterceptFunction : ISheetFunction
+public static class InterceptFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition("known_ys", ParameterType.Array, ParameterRequirement.Required),
-            new ParameterDefinition("known_xs", ParameterType.Array, ParameterRequirement.Required)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("known_ys", ParameterType.Array, ParameterRequirement.Required, shape: ParameterShape.Array),
+        new("known_xs", ParameterType.Array, ParameterRequirement.Required, shape: ParameterShape.Array)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "INTERCEPT",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var allY = args[0].GetValue<CellValue[][]>()!;
         var allX = args[1].GetValue<CellValue[][]>()!;
 
-        if (!allX.Any() || !allY.Any())
+        if (allX.Length == 0 || allY.Length == 0)
             return CellValue.Error(ErrorType.Na, "Empty array");
 
         if (allX.Length != allY.Length)
@@ -52,7 +56,4 @@ public class InterceptFunction : ISheetFunction
 
         return CellValue.Number(fun.YIntercept);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/PowerFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/PowerFunction.cs
@@ -1,32 +1,24 @@
-﻿using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class PowerFunction : ISheetFunction
+public static class PowerFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("number", ParameterType.Number, ParameterRequirement.Required),
+        new("exponent", ParameterType.Number, ParameterRequirement.Required)
+    ];
+
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "POW",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
-        return new[]
-        {
-            new ParameterDefinition("number",
-                ParameterType.Number,
-                ParameterRequirement.Required,
-                isRepeating: false),
-            new ParameterDefinition("exponent",
-                ParameterType.Number,
-                ParameterRequirement.Required,
-                isRepeating: false)
-        };
+        return CellValue.Number(System.Math.Pow(args[0].GetValue<double>(), args[1].GetValue<double>()));
     }
-
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
-    {
-        var number = args[0].GetValue<double>();
-        var exponent = args[1].GetValue<double>();
-
-        return CellValue.Number(System.Math.Pow(number, exponent));
-    }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/RandFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/RandFunction.cs
@@ -1,26 +1,21 @@
-﻿using BlazorDatasheet.Formula.Core;
+using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class RandFunction : ISheetFunction
+public static class RandFunction
 {
-    private Random _random;
+    private static readonly ParameterDefinition[] Parameters = [];
+    private static readonly Random Random = new();
 
-    public ParameterDefinition[] GetParameterDefinitions()
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "RAND",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: true);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
-        return [];
+        return CellValue.Number(Random.NextDouble());
     }
-
-    public RandFunction()
-    {
-        _random = new Random();
-    }
-
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
-    {
-        return CellValue.Number(_random.NextDouble());
-    }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => true;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/SinFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/SinFunction.cs
@@ -2,25 +2,22 @@ using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class SinFunction : ISheetFunction
+public static class SinFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition("x",
-                ParameterType.Number,
-                ParameterRequirement.Required,
-                isRepeating: false)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("x", ParameterType.Number, ParameterRequirement.Required)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
-    {
-        var val = args[0];
-        return CellValue.Number(System.Math.Sin((double)val.Data!));
-    }
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "SIN",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
 
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
+    {
+        return CellValue.Number(System.Math.Sin(args[0].GetValue<double>()));
+    }
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/SlopeFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/SlopeFunction.cs
@@ -3,23 +3,27 @@ using BlazorDatasheet.Formula.Core.Regression;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class SlopeFunction : ISheetFunction
+public static class SlopeFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition("known_ys", ParameterType.Array, ParameterRequirement.Required),
-            new ParameterDefinition("known_xs", ParameterType.Array, ParameterRequirement.Required)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new("known_ys", ParameterType.Array, ParameterRequirement.Required, shape: ParameterShape.Array),
+        new("known_xs", ParameterType.Array, ParameterRequirement.Required, shape: ParameterShape.Array)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "SLOPE",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var allY = args[0].GetValue<CellValue[][]>()!;
         var allX = args[1].GetValue<CellValue[][]>()!;
 
-        if (!allX.Any() || !allY.Any())
+        if (allX.Length == 0 || allY.Length == 0)
             return CellValue.Error(ErrorType.Na, "Empty array");
 
         if (allX.Length != allY.Length)
@@ -52,7 +56,4 @@ public class SlopeFunction : ISheetFunction
 
         return CellValue.Number(fun.Gradient);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/Math/SumFunction.cs
+++ b/src/BlazorDatasheet.Formula.Functions/Math/SumFunction.cs
@@ -2,36 +2,40 @@ using BlazorDatasheet.Formula.Core;
 
 namespace BlazorDatashet.Formula.Functions.Math;
 
-public class SumFunction : ISheetFunction
+public static class SumFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return new[]
-        {
-            new ParameterDefinition(
-                "number",
-                ParameterType.NumberSequence,
-                ParameterRequirement.Required,
-                isRepeating: true)
-        };
-    }
+    private static readonly ParameterDefinition[] Parameters =
+    [
+        new(
+            "number",
+            ParameterType.NumberSequence,
+            ParameterRequirement.Required,
+            isRepeating: true,
+            shape: ParameterShape.ScalarOrArray)
+    ];
 
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
+    public static FunctionDescriptor Descriptor { get; } = new(
+        name: "SUM",
+        parameterDefinitions: Parameters,
+        invoker: Evaluate,
+        acceptsErrors: false,
+        isVolatile: false);
+
+    private static CellValue Evaluate(CellValue[] args, FunctionCallMetaData metaData)
     {
         var sum = 0d;
         foreach (var arg in args)
         {
             var seq = (CellValue[])arg.Data!;
             foreach (var item in seq)
+            {
                 if (item.IsError())
                     return item;
-                else
-                    sum += item.GetValue<double>();
+
+                sum += item.GetValue<double>();
+            }
         }
 
         return CellValue.Number(sum);
     }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
 }

--- a/src/BlazorDatasheet.Formula.Functions/RegisterExtensions.cs
+++ b/src/BlazorDatasheet.Formula.Functions/RegisterExtensions.cs
@@ -7,27 +7,27 @@ namespace BlazorDatashet.Formula.Functions;
 
 public static class RegisterExtensions
 {
-    public static void RegisterLogicalFunctions(this IEnvironment e)
+    public static void RegisterLogicalFunctions(this FunctionRegistryBuilder builder)
     {
-        e.RegisterFunction("AND", new AndFunction());
-        e.RegisterFunction("IF", new IfFunction());
-        e.RegisterFunction("OR", new OrFunction());
-        e.RegisterFunction("NOT", new NotFunction());
+        builder.Add(AndFunction.Descriptor);
+        builder.Add(IfFunction.Descriptor);
+        builder.Add(OrFunction.Descriptor);
+        builder.Add(NotFunction.Descriptor);
     }
 
-    public static void RegisterMathFunctions(this IEnvironment e)
+    public static void RegisterMathFunctions(this FunctionRegistryBuilder builder)
     {
-        e.RegisterFunction("AVERAGE", new AverageFunction());
-        e.RegisterFunction("INTERCEPT", new InterceptFunction());
-        e.RegisterFunction("SUM", new SumFunction());
-        e.RegisterFunction("SIN", new SinFunction());
-        e.RegisterFunction("SLOPE", new SlopeFunction());
-        e.RegisterFunction("POW", new PowerFunction());
-        e.RegisterFunction("RAND", new RandFunction());
+        builder.Add(AverageFunction.Descriptor);
+        builder.Add(InterceptFunction.Descriptor);
+        builder.Add(SumFunction.Descriptor);
+        builder.Add(SinFunction.Descriptor);
+        builder.Add(SlopeFunction.Descriptor);
+        builder.Add(PowerFunction.Descriptor);
+        builder.Add(RandFunction.Descriptor);
     }
 
-    public static void RegisterLookupFunctions(this IEnvironment e)
+    public static void RegisterLookupFunctions(this FunctionRegistryBuilder builder)
     {
-        e.RegisterFunction("VLOOKUP", new VLookupFunction());
+        builder.Add(VLookupFunction.Descriptor);
     }
 }

--- a/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
@@ -32,14 +32,14 @@
 <!-- shows hints when caret position is inside a formula -->
 <BdsPopover
     AnchorId="@_anchorId"
-    IsOpen="@(_formulaHint != null && _sheet.FormulaEngine.FunctionExists(_formulaHint.FunctionName))"
+    IsOpen="@(_formulaHint != null && _sheet.FormulaEngine.GetFunction(_formulaHint.FunctionName) != null)"
     CssClass="bds-func-suggestions">
-    @if (_formulaHint != null)
+    @if (_formulaHint != null && _sheet.FormulaEngine.GetFunction(_formulaHint.FunctionName) is { } hintFunction)
     {
         <FormulaHintBox
             ArgIndex="@_formulaHint.ParameterIndex"
             FunctionName="@_formulaHint.FunctionName"
-            Function="@_sheet.FormulaEngine.GetFunction(_formulaHint.FunctionName)"/>
+            Function="@hintFunction"/>
     }
 </BdsPopover>
 

--- a/src/BlazorDatasheet/Edit/FormulaHintBox.razor
+++ b/src/BlazorDatasheet/Edit/FormulaHintBox.razor
@@ -6,7 +6,7 @@
     <span>(</span>
 
     @{
-        var definitions = Function.GetParameterDefinitions();
+        var definitions = Function.ParameterDefinitions;
     }
     @for (var i = 0; i < definitions.Length; i++)
     {
@@ -30,7 +30,7 @@
 
     [Parameter] public required string FunctionName { get; set; }
 
-    [Parameter] public required ISheetFunction Function { get; set; }
+    [Parameter] public required FunctionDescriptor Function { get; set; }
 
     [Parameter] public required int ArgIndex { get; set; }
 

--- a/src/BlazorDatasheet/Edit/FormulaHintBoxCalculator.cs
+++ b/src/BlazorDatasheet/Edit/FormulaHintBoxCalculator.cs
@@ -1,5 +1,6 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.FormulaEngine;
+using BlazorDatasheet.Formula.Core;
 using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.Lexing;
 using BlazorDatasheet.Formula.Core.Interpreter.Parsing;
@@ -8,6 +9,9 @@ namespace BlazorDatasheet.Edit;
 
 internal class FormulaHintBoxCalculator
 {
+    private static readonly ParsingEnvironment s_parsingEnvironment =
+        new(Workbook.BuildDefaultRegistry(options: null));
+
     private FormulaOptions _options;
 
     public FormulaHintBoxCalculator(FormulaOptions options)
@@ -30,9 +34,7 @@ internal class FormulaHintBoxCalculator
 
     private FormulaHintBoxResult? ExtractResult(List<Token> tokens, int cursorPosition)
     {
-        // now we have a position start, so we can find the function node in the parsed expression
-        // we don't care if the function exists, so we can have a dummy environment
-        var parser = new Parser(new WorkbookEnvironment(new Workbook(_options)), _options);
+        var parser = new Parser(s_parsingEnvironment, _options);
         var tree = parser.Parse(tokens, []);
         var funcNodes = tree.Root.FindNodes(node =>
         {

--- a/test/BlazorDatasheet.Test/Formula/CustomFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/CustomFunctionTests.cs
@@ -61,26 +61,3 @@ public class CustomFunctionTests
         Assert.DoesNotThrow(() => { _validator.ValidateOrThrow(defns); });
     }
 }
-
-public class CustomFunctionDefinition : ISheetFunction
-{
-    private readonly ParameterDefinition[] _parameterDefinitions;
-
-    public CustomFunctionDefinition(params ParameterDefinition[] parameterDefinitions)
-    {
-        _parameterDefinitions = parameterDefinitions;
-    }
-
-    public ParameterDefinition[] GetParameterDefinitions()
-    {
-        return _parameterDefinitions;
-    }
-
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData)
-    {
-        return CellValue.Empty;
-    }
-
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
-}

--- a/test/BlazorDatasheet.Test/Formula/FormulaEngineTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/FormulaEngineTests.cs
@@ -11,7 +11,7 @@ public class FormulaEngineTests
     public void CalculateSheet_WhenEvaluationThrows_ResetsIsCalculating()
     {
         var environment = new TestEnvironment();
-        environment.RegisterFunction("THROWFN", new ThrowingFunction());
+        environment.RegisterFunction(ThrowingFunction.Descriptor);
         var formulaEngine = new BlazorDatasheet.Core.FormulaEngine.FormulaEngine(environment);
 
         Action action = () => formulaEngine.SetVariable("x", "=THROWFN()");
@@ -21,11 +21,12 @@ public class FormulaEngineTests
     }
 }
 
-internal class ThrowingFunction : ISheetFunction
+internal static class ThrowingFunction
 {
-    public ParameterDefinition[] GetParameterDefinitions() => [];
-    public CellValue Call(CellValue[] args, FunctionCallMetaData metaData) =>
-        throw new InvalidOperationException("Boom");
-    public bool AcceptsErrors => false;
-    public bool IsVolatile => false;
+    public static FunctionDescriptor Descriptor { get; } = new(
+        "THROWFN",
+        [],
+        (_, _) => throw new InvalidOperationException("Boom"),
+        acceptsErrors: false,
+        isVolatile: false);
 }

--- a/test/BlazorDatasheet.Test/Formula/FunctionRegistryTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/FunctionRegistryTests.cs
@@ -1,0 +1,63 @@
+using System;
+using BlazorDatasheet.Formula.Core;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Formula;
+
+public class FunctionRegistryTests
+{
+    [Test]
+    public void TryGetFunction_IsCaseInsensitive()
+    {
+        var descriptor = new FunctionDescriptor(
+            "SUMX",
+            [],
+            (_, _) => CellValue.Number(1));
+
+        var registry = new FunctionRegistryBuilder()
+            .Add(descriptor)
+            .Build();
+
+        var found = registry.TryGetFunction("sumx", out var result);
+
+        Assert.That(found, Is.True);
+        Assert.That(result.Name, Is.EqualTo("SUMX"));
+    }
+
+    [Test]
+    public void Builder_Rejects_Duplicate_Function_Names()
+    {
+        var builder = new FunctionRegistryBuilder();
+        builder.Add(new FunctionDescriptor("DUP", [], (_, _) => CellValue.Empty));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.Add(new FunctionDescriptor("dup", [], (_, _) => CellValue.Empty)));
+    }
+
+    [Test]
+    public void Builder_IsImmutable_AfterBuild()
+    {
+        var builder = new FunctionRegistryBuilder();
+        builder.Add(new FunctionDescriptor("A", [], (_, _) => CellValue.Empty));
+        _ = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            builder.Add(new FunctionDescriptor("B", [], (_, _) => CellValue.Empty)));
+    }
+
+    [Test]
+    public void FunctionDescriptor_Computes_Arity_Cache()
+    {
+        var descriptor = new FunctionDescriptor(
+            "TEST",
+            [
+                new ParameterDefinition("req", ParameterType.Number, ParameterRequirement.Required),
+                new ParameterDefinition("opt", ParameterType.Number, ParameterRequirement.Optional),
+                new ParameterDefinition("repeat", ParameterType.Number, ParameterRequirement.Optional, isRepeating: true)
+            ],
+            (_, _) => CellValue.Empty);
+
+        Assert.That(descriptor.MinArity, Is.EqualTo(1));
+        Assert.That(descriptor.MaxArity, Is.EqualTo(128));
+    }
+}

--- a/test/BlazorDatasheet.Test/Formula/Interpreter2Tests.cs
+++ b/test/BlazorDatasheet.Test/Formula/Interpreter2Tests.cs
@@ -213,7 +213,7 @@ public class InterpreterTests
         2d / (100 * 100 * 100))] // matches behaviour of excel but not google sheets (google sheets is error)
     public void Percent_Operator_Evaluates_To_Correct_Value(string formula, double value)
     {
-        _env.RegisterFunction("sum", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         EvalExpression(formula).Data.Should().Be(value);
     }
 
@@ -302,5 +302,25 @@ public class InterpreterTests
 
         var formulaWithoutContext = _parser.FromString("=A1");
         formulaWithoutContext.References.First().SheetName.Should().Be("Sheet1");
+    }
+
+    [Test]
+    public void Known_Function_Binds_Descriptor_In_Parse_Tree()
+    {
+        _env.RegisterFunction(SumFunction.Descriptor);
+        var parsed = _parser.Parse("=SUM(1)");
+
+        var fn = parsed.Root.Should().BeOfType<FunctionExpression>().Subject;
+        fn.FunctionDescriptor.Should().NotBeNull();
+        fn.FunctionDescriptor!.Name.Should().Be("SUM");
+    }
+
+    [Test]
+    public void Unknown_Function_Produces_Error_On_Evaluation()
+    {
+        var result = EvalExpression("=MISSING_FN(1)");
+
+        result.IsError().Should().BeTrue();
+        result.GetValue<FormulaError>().ErrorType.Should().Be(ErrorType.Na);
     }
 }

--- a/test/BlazorDatasheet.Test/Formula/InterpretorCultureTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/InterpretorCultureTests.cs
@@ -12,7 +12,7 @@ namespace BlazorDatasheet.Test.Formula;
 
 public class InterpretorCultureTests
 {
-    private IEnvironment _env;
+    private TestEnvironment _env;
 
     [SetUp]
     public void Setup()
@@ -51,7 +51,7 @@ public class InterpretorCultureTests
     [SetCulture("fr-FR")]
     public void Non_Eng_Culture_Has_Correct_Function_Param_Separator()
     {
-        _env.RegisterFunction("SUM", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         var parser = new Parser(_env, new FormulaOptions());
         var evaluator = new Evaluator(_env);
         var formulaStr = @"=SUM(1,2;2;0,3)";
@@ -85,7 +85,7 @@ public class InterpretorCultureTests
     [SetCulture("fr-FR")]
     public void Provide_Custom_Func_Param_Seperator_Should_Eval_Ok()
     {
-        _env.RegisterFunction("SUM", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         var options = new FormulaOptions()
         {
             SeparatorSettings = new SeparatorSettings()

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -382,7 +382,7 @@ public class SheetFormulaIntegrationTests
     public void Simple_Non_Circular_Strongly_Grouped_Reference_Calculates_Correctly()
     {
         var env = new TestEnvironment();
-        env.RegisterFunction("if", new IfFunction());
+        env.RegisterFunction(IfFunction.Descriptor);
         var eval = new Evaluator(env);
         var parser = new Parser(env);
         var fA1 = parser.FromString("=B1");

--- a/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
+++ b/test/BlazorDatasheet.Test/Formula/TestEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Util;
@@ -12,7 +13,7 @@ namespace BlazorDatasheet.Test.Formula;
 public class TestEnvironment : IEnvironment
 {
     private Dictionary<CellPosition, CellValue> _cellValues = new();
-    private Dictionary<string, ISheetFunction> _functions = new(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, FunctionDescriptor> _functions = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, CellValue> _variables = new();
     private Dictionary<CellPosition, CellFormula> _formulas = new();
 
@@ -34,14 +35,10 @@ public class TestEnvironment : IEnvironment
             _formulas[position] = formula;
     }
 
-    public void RegisterFunction(string name, ISheetFunction functionDefinition)
+    public void RegisterFunction(FunctionDescriptor functionDefinition)
     {
-        var validator = new FunctionParameterValidator();
-        validator.ValidateOrThrow(functionDefinition.GetParameterDefinitions());
-
-        if (!_functions.ContainsKey(name))
-            _functions.Add(name, functionDefinition);
-        _functions[name] = functionDefinition;
+        if (!_functions.TryAdd(functionDefinition.Name, functionDefinition))
+            throw new InvalidOperationException($"Function '{functionDefinition.Name}' has already been registered.");
     }
 
     public IEnumerable<FunctionDefinition> SearchForFunctions(string functionName)
@@ -141,14 +138,9 @@ public class TestEnvironment : IEnvironment
         return arr;
     }
 
-    public bool FunctionExists(string functionIdentifier)
+    public bool TryGetFunction(string identifierText, [MaybeNullWhen(false)] out FunctionDescriptor functionDescriptor)
     {
-        return _functions.ContainsKey(functionIdentifier);
-    }
-
-    public ISheetFunction? GetFunctionDefinition(string identifierText)
-    {
-        return _functions.GetValueOrDefault(identifierText);
+        return _functions.TryGetValue(identifierText, out functionDescriptor);
     }
 
     public bool VariableExists(string variableIdentifier)

--- a/test/BlazorDatasheet.Test/Functions/Logical/LogicalFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/Logical/LogicalFunctionTests.cs
@@ -31,7 +31,7 @@ public class LogicalFunctionTests
     [Test]
     public void If_Function_Tests()
     {
-        _env.RegisterFunction("IF", new IfFunction());
+        _env.RegisterFunction(IfFunction.Descriptor);
         Eval("=IF(true,5,4)").Should().Be(5);
         Eval("=IF(false,5,4)").Should().Be(4);
         Eval("=IF(\"s\",5,4)").Should().BeOfType<FormulaError>();
@@ -56,7 +56,7 @@ public class LogicalFunctionTests
     [Test]
     public void And_Function_Tests()
     {
-        _env.RegisterFunction("AND", new AndFunction());
+        _env.RegisterFunction(AndFunction.Descriptor);
         Eval("=AND(true)").Should().Be(true);
         Eval("=AND(false)").Should().Be(false);
         Eval("=AND(true, true, true, true)").Should().Be(true);
@@ -84,7 +84,7 @@ public class LogicalFunctionTests
     [Test]
     public void Or_Function_Tests()
     {
-        _env.RegisterFunction("OR", new OrFunction());
+        _env.RegisterFunction(OrFunction.Descriptor);
         Eval("=OR(true)").Should().Be(true);
         Eval("=OR(false)").Should().Be(false);
         Eval("=OR(true, true, true, true)").Should().Be(true);

--- a/test/BlazorDatasheet.Test/Functions/Logical/NotFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/Logical/NotFunctionTests.cs
@@ -27,7 +27,7 @@ public class NotFunctionTests
     public void Setup()
     {
         _env = new();
-        _env.RegisterFunction("NOT", new NotFunction());
+        _env.RegisterFunction(NotFunction.Descriptor);
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Functions/LookupFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/LookupFunctionTests.cs
@@ -29,7 +29,7 @@ public class LookupFunctionTests
     [Test]
     public void VLookup_With_Range_False_Tests()
     {
-        _env.RegisterFunction("VLOOKUP", new VLookupFunction());
+        _env.RegisterFunction(VLookupFunction.Descriptor);
         Eval("=VLOOKUP(2,{1;2},1,false)").Should().Be(2);
         // a lookup value outside of the array should be false
         Eval("=VLOOKUP(2,{1;3},1,false)").Should().BeOfType<FormulaError>();
@@ -40,7 +40,7 @@ public class LookupFunctionTests
     [Test]
     public void VLookup_With_Range_True_Tests()
     {
-        _env.RegisterFunction("VLOOKUP", new VLookupFunction());
+        _env.RegisterFunction(VLookupFunction.Descriptor);
         Eval("=VLOOKUP(3,{1;2;4},1)").Should().Be(2);
         Eval("=VLOOKUP(5,{1;2;4},1,true)").Should().Be(4);
         // a lookup value outside of the array should be false

--- a/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
+++ b/test/BlazorDatasheet.Test/Functions/MathFunctionTests.cs
@@ -30,7 +30,7 @@ public class MathFunctionTests
     [Test]
     public void Sin_Function_Tests()
     {
-        _env.RegisterFunction("sin", new SinFunction());
+        _env.RegisterFunction(SinFunction.Descriptor);
         Eval("=sin(true)").Should().Be(Math.Sin(1));
         _env.SetCellValue(0, 0, true);
         Eval("=sin(A1)").Should().Be(Math.Sin(1));
@@ -44,7 +44,7 @@ public class MathFunctionTests
     [Test]
     public void Sum_Function_Tests()
     {
-        _env.RegisterFunction("sum", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         var res1 = Eval("=sum(1, 2)");
         res1.Should().Be(3);
         Eval("=sum(1/0)").Should().BeOfType<FormulaError>();
@@ -69,7 +69,7 @@ public class MathFunctionTests
     [Test]
     public void Sum_With_True_Cell_Value_Should_Return_0()
     {
-        _env.RegisterFunction("sum", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         _env.SetCellValue(0, 0, true);
         Eval("=sum(A1)").Should().Be(0);
     }
@@ -78,7 +78,7 @@ public class MathFunctionTests
     public void Sum_With_Text_Cell_Value_Should_Return_0()
     {
         // correct behaviour from excel - if sum range contains text it should be valuated as 0
-        _env.RegisterFunction("sum", new SumFunction());
+        _env.RegisterFunction(SumFunction.Descriptor);
         _env.SetCellValue(0, 0, "abc");
         Eval("=sum(A1)").Should().Be(0);
     }
@@ -86,7 +86,7 @@ public class MathFunctionTests
     [Test]
     public void Pow_Function_Tests()
     {
-        _env.RegisterFunction("pow", new PowerFunction());
+        _env.RegisterFunction(PowerFunction.Descriptor);
         Eval("=pow(5,true)").Should().Be(Math.Pow(5, 1));
         _env.SetCellValue(0, 0, true);
         Eval("=pow(5,A1)").Should().Be(Math.Pow(5, 1));
@@ -102,7 +102,7 @@ public class MathFunctionTests
     [Test]
     public void Intercept_Function_Tests()
     {
-        _env.RegisterFunction("intercept", new InterceptFunction());
+        _env.RegisterFunction(InterceptFunction.Descriptor);
         // ys
         _env.SetCellValue(0, 0, 1d);
         _env.SetCellValue(1, 0, 3d);
@@ -131,7 +131,7 @@ public class MathFunctionTests
     [Test]
     public void Slope_Function_Tests()
     {
-        _env.RegisterFunction("slope", new SlopeFunction());
+        _env.RegisterFunction(SlopeFunction.Descriptor);
         // ys
         _env.SetCellValue(0, 0, 1d);
         _env.SetCellValue(1, 0, 3d);


### PR DESCRIPTION
Modifies the way that functions are registered. Why? Improve speed of function resolution and cleaner API.

Allows for custom registration of functions through 

```csharp
        _sheet = new Sheet(1000, 5, 105, 24, new FormulaOptions()
        {
            ConfigureFunctions = builder => builder.Add(new("CUSTOM", [],
                (_, _) => CellValue.Text("Custom func")
            ))
        });
```

Using ```=CUSTOM()``` in a cell will then return "Custom func"