### PR TITLE
Don't handle mouse events in text editor unless value is actually formula

### DIFF
--- a/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
@@ -271,7 +271,7 @@
 
     public override bool HandleMouseDown(int row, int col, bool ctrlKey, bool shiftKey, bool altKey, bool metaKey)
     {
-        if (_canAcceptRanges)
+        if (_canAcceptRanges && IsFormulaValue)
         {
             SelectionInputManager?.HandlePointerDown(row, col, shiftKey, ctrlKey, metaKey, 1);
             SetEditValueToSelectionPreview();
@@ -283,7 +283,7 @@
 
     public override bool HandleMouseOver(int row, int col, bool ctrlKey, bool shiftKey, bool altKey, bool metaKey)
     {
-        if (_canAcceptRanges)
+        if (_canAcceptRanges && IsFormulaValue)
         {
             SelectionInputManager?.HandlePointerOver(row, col);
             SetEditValueToSelectionPreview();
@@ -297,7 +297,7 @@
     {
         SelectionInputManager?.HandleWindowMouseUp();
 
-        if (_canAcceptRanges)
+        if (_canAcceptRanges && IsFormulaValue)
         {
             SetEditValueToSelectionPreview();
             await _highlightedInput.FocusAndMoveCursorToEndAsync();


### PR DESCRIPTION
Prevents setting regions from mouse for cells that (for example) end in a colon.