### PR TITLE
Formula bug fixes

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Workbook.cs
+++ b/src/BlazorDatasheet.Core/Data/Workbook.cs
@@ -99,6 +99,7 @@ public class Workbook
             var sheet = _sheets[sheetIndex];
             _formulaEngine.RemoveSheet(_sheets[sheetIndex]);
             _sheets.RemoveAt(sheetIndex);
+            _formulaEngine.CalculateSheet(true);
             SheetRemoved?.Invoke(this, new WorkbookSheetRemovedEventArgs(sheet));
         }
     }

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -117,6 +117,16 @@ public class FormulaEngine
     public IEnumerable<FunctionDefinition> GetDefinitionsStartingWith(string identifierText) =>
         _environment.SearchForFunctions(identifierText);
 
+    private void QueueVariableForCalculation(string varName, bool includeVariableVertex)
+    {
+        var variableVertex = DependencyManager.GetVertex(varName) ?? new FormulaVertex(varName, null);
+        if (includeVariableVertex)
+            _requiresCalculation.Add(variableVertex);
+
+        foreach (var dependent in DependencyManager.GetDirectDependents(variableVertex))
+            _requiresCalculation.Add(dependent);
+    }
+
     internal DependencyManagerRestoreData SetFormula(int row, int col, string sheetName, CellFormula? formula)
     {
         return DependencyManager.SetFormula(row, col, sheetName, formula);
@@ -263,21 +273,24 @@ public class FormulaEngine
                 throw new Exception("Formula references in variables must have explicit sheet names");
 
             DependencyManager.SetFormula(varName, formula);
+            QueueVariableForCalculation(varName, true);
         }
         else
         {
             DependencyManager.ClearFormula(varName);
             _environment.SetVariable(varName, new CellValue(value));
+            QueueVariableForCalculation(varName, false);
         }
 
-        CalculateSheet(true);
+        CalculateSheet(false);
     }
 
     public void SetVariable(string varName, CellValue value)
     {
         DependencyManager.ClearFormula(varName);
         _environment.SetVariable(varName, value);
-        CalculateSheet(true);
+        QueueVariableForCalculation(varName, false);
+        CalculateSheet(false);
     }
 
     public IEnumerable<Variable> GetVariables()

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -275,7 +275,9 @@ public class FormulaEngine
 
     public void SetVariable(string varName, CellValue value)
     {
+        DependencyManager.ClearFormula(varName);
         _environment.SetVariable(varName, value);
+        CalculateSheet(true);
     }
 
     public IEnumerable<Variable> GetVariables()

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -266,6 +266,7 @@ public class FormulaEngine
         }
         else
         {
+            DependencyManager.ClearFormula(varName);
             _environment.SetVariable(varName, new CellValue(value));
         }
 

--- a/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
+++ b/src/BlazorDatasheet.Formula.Core/Dependencies/DependencyManager.cs
@@ -45,6 +45,15 @@ public class DependencyManager
 
     public void RemoveSheet(string sheetName)
     {
+        var verticesOnSheet = _dependencyGraph.GetAll()
+            .Where(x => x.VertexType == VertexType.Cell && x.SheetName == sheetName)
+            .Select(x => x.Position)
+            .Where(x => x != null)
+            .ToList();
+
+        foreach (var position in verticesOnSheet)
+            ClearFormula(position!.Value.row, position.Value.col, sheetName);
+
         _referencedVertexStores.Remove(sheetName);
         _formulaLocations.Remove(sheetName);
     }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/Evaluation/FormulaExecutionContext.cs
@@ -17,7 +17,7 @@ public class FormulaExecutionContext
 
     internal bool IsInSccGroup(Reference reference)
     {
-        if (_currentSccGroup == null || _currentSccGroup.Count == 1)
+        if (_currentSccGroup == null)
             return false;
         
         if (reference is not NamedReference namedRef)

--- a/test/BlazorDatasheet.Test/Formula/MultiSheetTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/MultiSheetTests.cs
@@ -140,6 +140,19 @@ public class MultiSheetTests
     }
 
     [Test]
+    public void Remove_Referenced_Sheet_Recalculates_Dependents_To_Ref_Error()
+    {
+        _sheet2.Cells["A1"]!.Value = 10;
+        _sheet1.Cells["A1"]!.Formula = "=Sheet2!A1";
+
+        _workbook.RemoveSheet("Sheet2");
+
+        _sheet1.Cells["A1"]!.Value.Should().BeOfType<FormulaError>();
+        ((FormulaError)_sheet1.Cells["A1"]!.Value!).ErrorType.Should().Be(ErrorType.Ref);
+        _sheet1.FormulaEngine.DependencyManager.FormulaCount.Should().Be(1);
+    }
+
+    [Test]
     public void Multi_Sheet_Col_Ref_Evaluate_Correctly()
     {
         var r = _sheet1.Range("Sheet2!A:Sheet2!B");

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -455,4 +455,35 @@ public class SheetFormulaIntegrationTests
         _sheet.Cells["B1"]!.Formula = "=A1=\"\"";
         _sheet.Cells["B1"]!.Value.Should().Be(true);
     }
+
+    [Test]
+    public void Self_Referencing_Formula_Returns_Circular_Error()
+    {
+        _sheet.Cells.SetFormula(0, 0, "=A1+1");
+        _sheet.Cells.GetCellValue(0, 0).GetValue<FormulaError>().ErrorType.Should().Be(ErrorType.Circular);
+    }
+
+    [Test]
+    public void Self_Identity_Formula_Returns_Circular_Error()
+    {
+        _sheet.Cells.SetFormula(0, 0, "=A1");
+        _sheet.Cells.GetCellValue(0, 0).GetValue<FormulaError>().ErrorType.Should().Be(ErrorType.Circular);
+    }
+
+    [Test]
+    public void Two_Cell_Cycle_Returns_Circular_Error()
+    {
+        _sheet.Cells.SetFormula(0, 0, "=B1");
+        _sheet.Cells.SetFormula(0, 1, "=A1");
+        _sheet.Cells.GetCellValue(0, 0).GetValue<FormulaError>().ErrorType.Should().Be(ErrorType.Circular);
+        _sheet.Cells.GetCellValue(0, 1).GetValue<FormulaError>().ErrorType.Should().Be(ErrorType.Circular);
+    }
+
+    [Test]
+    public void Non_Self_Referencing_Single_Vertex_Scc_Evaluates_Correctly()
+    {
+        _sheet.Cells.SetValue(0, 0, 5);
+        _sheet.Cells.SetFormula(0, 1, "=A1+1");
+        _sheet.Cells.GetCellValue(0, 1).GetValue<int>().Should().Be(6);
+    }
 }

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -421,6 +421,17 @@ public class SheetFormulaIntegrationTests
     }
 
     [Test]
+    public void Variable_Reassigned_From_Formula_To_Literal_Uses_Literal_Value()
+    {
+        _sheet.Cells["A1"]!.Formula = "=x";
+        _sheet.FormulaEngine.SetVariable("x", "=10");
+
+        _sheet.FormulaEngine.SetVariable("x", 5);
+
+        _sheet.Cells["A1"]!.Value.Should().Be(5);
+    }
+
+    [Test]
     public void Named_Range_Variable_Should_Update_When_Variable_Changes()
     {
         _sheet.Cells["A1"]!.Formula = "=x";

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -442,6 +442,50 @@ public class SheetFormulaIntegrationTests
     }
 
     [Test]
+    public void SetVariable_Formula_Does_Not_Recalculate_Unrelated_Nonvolatile_Formulas()
+    {
+        int evalCount = 0;
+        var workbook = new Workbook(new FormulaOptions
+        {
+            ConfigureFunctions = builder => builder.Add(new FunctionDescriptor(
+                "TRACKFN",
+                [],
+                (_, _) => CellValue.Number(++evalCount)))
+        });
+        var sheet = workbook.AddSheet(10, 10);
+        sheet.Cells["A1"]!.Formula = "=TRACKFN()";
+        sheet.Cells["B1"]!.Formula = "=x";
+        evalCount.Should().Be(1);
+
+        sheet.FormulaEngine.SetVariable("x", "=10");
+
+        sheet.Cells["B1"]!.Value.Should().Be(10);
+        evalCount.Should().Be(1);
+    }
+
+    [Test]
+    public void SetVariable_CellValue_Does_Not_Recalculate_Unrelated_Nonvolatile_Formulas()
+    {
+        int evalCount = 0;
+        var workbook = new Workbook(new FormulaOptions
+        {
+            ConfigureFunctions = builder => builder.Add(new FunctionDescriptor(
+                "TRACKFN",
+                [],
+                (_, _) => CellValue.Number(++evalCount)))
+        });
+        var sheet = workbook.AddSheet(10, 10);
+        sheet.Cells["A1"]!.Formula = "=TRACKFN()";
+        sheet.Cells["B1"]!.Formula = "=x";
+        evalCount.Should().Be(1);
+
+        sheet.FormulaEngine.SetVariable("x", new CellValue(10));
+
+        sheet.Cells["B1"]!.Value.Should().Be(10);
+        evalCount.Should().Be(1);
+    }
+
+    [Test]
     public void Named_Range_Variable_Should_Update_When_Variable_Changes()
     {
         _sheet.Cells["A1"]!.Formula = "=x";

--- a/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/SheetFormulaIntegrationTests.cs
@@ -432,6 +432,16 @@ public class SheetFormulaIntegrationTests
     }
 
     [Test]
+    public void SetVariable_CellValue_Recalculates_Dependents()
+    {
+        _sheet.Cells["A1"]!.Formula = "=x";
+
+        _sheet.FormulaEngine.SetVariable("x", new CellValue(7));
+
+        _sheet.Cells["A1"]!.Value.Should().Be(7);
+    }
+
+    [Test]
     public void Named_Range_Variable_Should_Update_When_Variable_Changes()
     {
         _sheet.Cells["A1"]!.Formula = "=x";


### PR DESCRIPTION
  Fixes
   - Circular references not resolving to errors.
   - Stale references persisting after sheet removal.
   - Inefficient full-sheet recalculation when updating individual workbook variables.