### PR TITLE
Tidy cell metadata API

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/Data/ClearMetaDataCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/ClearMetaDataCommand.cs
@@ -1,0 +1,32 @@
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Metadata;
+
+namespace BlazorDatasheet.Core.Commands.Data;
+
+public class ClearMetaDataCommand : BaseCommand, IUndoableCommand
+{
+    private readonly int _row;
+    private readonly int _col;
+    private CellMetadata? _oldMetaData;
+
+    public ClearMetaDataCommand(int row, int col)
+    {
+        _row = row;
+        _col = col;
+    }
+
+    public override bool CanExecute(Sheet sheet) => sheet.Region.Contains(_row, _col);
+
+    public override bool Execute(Sheet sheet)
+    {
+        _oldMetaData = sheet.Cells.GetCellMetaData(_row, _col)?.Clone();
+        sheet.Cells.ClearMetaDataImpl(_row, _col);
+        return true;
+    }
+
+    public bool Undo(Sheet sheet)
+    {
+        sheet.Cells.SetMetaDataImpl(_row, _col, _oldMetaData?.Clone());
+        return true;
+    }
+}

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.Metadata.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.Metadata.cs
@@ -24,13 +24,64 @@ public partial class CellStore
         return Sheet.Commands.ExecuteCommand(cmd);
     }
 
+    /// <summary>
+    /// Clears all metadata for the cell at position row, col.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <param name="col"></param>
+    /// <returns>Whether clearing the cell metadata was successful</returns>
+    public bool ClearCellMetaData(int row, int col)
+    {
+        var cmd = new ClearMetaDataCommand(row, col);
+        return Sheet.Commands.ExecuteCommand(cmd);
+    }
+
+    /// <summary>
+    /// Clears the metadata specified by name for the cell at position row, col.
+    /// </summary>
+    /// <param name="row"></param>
+    /// <param name="col"></param>
+    /// <param name="name"></param>
+    /// <returns>Whether clearing the cell metadata was successful</returns>
+    public bool ClearCellMetaData(int row, int col, string name)
+    {
+        return SetCellMetaData(row, col, name, null);
+    }
+
     internal void SetMetaDataImpl(int row, int col, string name, object? value)
     {
-        var newMetaData = new CellMetadata();
+        var oldValue = GetMetaData(row, col, name);
+        var newMetaData = GetCellMetaData(row, col)?.Clone() ?? new CellMetadata();
         newMetaData.SetItem(name, value);
+        SetMetaDataImpl(row, col, newMetaData);
         MetaDataChanged?.Invoke(this,
-            new CellMetaDataChangeEventArgs(row, col, name, _metaDataStore.GetData(row, col), value));
-        _metaDataStore.Add(new Region(row, col), newMetaData);
+            new CellMetaDataChangeEventArgs(row, col, name, oldValue, value));
+    }
+
+    internal void ClearMetaDataImpl(int row, int col)
+    {
+        var oldMetaData = GetCellMetaData(row, col);
+        if (oldMetaData == null)
+            return;
+
+        _metaDataStore.Clear(new Region(row, col));
+        foreach (var item in oldMetaData.GetItems())
+        {
+            MetaDataChanged?.Invoke(this,
+                new CellMetaDataChangeEventArgs(row, col, item.Key, item.Value, null));
+        }
+    }
+
+    internal void ClearMetaDataImpl(int row, int col, string name)
+    {
+        SetMetaDataImpl(row, col, name, null);
+    }
+
+    internal void SetMetaDataImpl(int row, int col, CellMetadata? metaData)
+    {
+        _metaDataStore.Clear(new Region(row, col));
+        if (metaData?.IsEmpty == false)
+            _metaDataStore.Add(new Region(row, col), metaData);
     }
 
     /// <summary>
@@ -42,9 +93,11 @@ public partial class CellStore
     /// <returns></returns>
     public object? GetMetaData(int row, int col, string name)
     {
-        var container = _metaDataStore.GetData(row, col).FirstOrDefault() ?? new CellMetadata();
+        var container = GetCellMetaData(row, col) ?? new CellMetadata();
         return container.GetItem(name);
     }
+
+    internal CellMetadata? GetCellMetaData(int row, int col) => _metaDataStore.GetData(row, col).FirstOrDefault();
 
     internal MergeRegionDataStore<CellMetadata> GetMetaDataStore() => _metaDataStore;
 }

--- a/src/BlazorDatasheet.Core/Data/SheetCell.cs
+++ b/src/BlazorDatasheet.Core/Data/SheetCell.cs
@@ -113,13 +113,28 @@ public class SheetCell : IReadOnlyCell
         return _sheet.Cells.GetMetaData(Row, Col, name);
     }
 
+    public void SetMetaData(string name, object? value)
+    {
+        _sheet.Cells.SetCellMetaData(Row, Col, name, value);
+    }
+
+    public void ClearMetaData()
+    {
+        _sheet.Cells.ClearCellMetaData(Row, Col);
+    }
+
+    public void ClearMetaData(string name)
+    {
+        _sheet.Cells.ClearCellMetaData(Row, Col, name);
+    }
+
     public IEnumerable<KeyValuePair<string, object>> MetaData
     {
         get
         {
-            var collection = _sheet.Cells.GetMetaDataStore().GetData(Row, Col).ToList();
-            if (collection?.Any() == true)
-                return collection.First().GetItems();
+            var metaData = _sheet.Cells.GetCellMetaData(Row, Col);
+            if (metaData != null)
+                return metaData.GetItems();
             return [];
         }
     }

--- a/src/BlazorDatasheet.Core/Data/SheetRange.cs
+++ b/src/BlazorDatasheet.Core/Data/SheetRange.cs
@@ -103,6 +103,22 @@ public class SheetRange
         Sheet.EndBatchUpdates();
     }
 
+    public void ClearMetaData()
+    {
+        Sheet.BatchUpdates();
+        foreach (var cellPosition in this.Positions)
+        {
+            Sheet.Cells.ClearMetaDataImpl(cellPosition.row, cellPosition.col);
+        }
+
+        Sheet.EndBatchUpdates();
+    }
+
+    public void ClearMetaData(string name)
+    {
+        SetMetaData(name, null);
+    }
+
     /// <summary>
     /// Set the cell type e.g "text", "boolean", "select" on the range.
     /// </summary>

--- a/src/BlazorDatasheet.Core/Metadata/CellMetadata.cs
+++ b/src/BlazorDatasheet.Core/Metadata/CellMetadata.cs
@@ -8,7 +8,7 @@ public class CellMetadata : IMergeable<CellMetadata>, IEquatable<CellMetadata>
 
     internal CellMetadata(Dictionary<string, object> data)
     {
-        _data = data;
+        _data = data.ToDictionary(x => x.Key, x => x.Value);
     }
 
     internal CellMetadata()
@@ -36,15 +36,29 @@ public class CellMetadata : IMergeable<CellMetadata>, IEquatable<CellMetadata>
 
     public void SetItem(string key, object? item)
     {
-        if (_data == null)
-            _data = new();
         if (item == null)
         {
-            _data.Remove(key);
+            RemoveItem(key);
             return;
         }
+
+        if (_data == null)
+            _data = new();
+
         if (!_data.TryAdd(key, item))
             _data[key] = item;
+    }
+
+    public bool RemoveItem(string key)
+    {
+        if (_data == null)
+            return false;
+
+        var removed = _data.Remove(key);
+        if (_data.Count == 0)
+            _data = null;
+
+        return removed;
     }
 
     public object? GetItem(string key)
@@ -69,5 +83,7 @@ public class CellMetadata : IMergeable<CellMetadata>, IEquatable<CellMetadata>
                _data.All(kp => other._data.ContainsKey(kp.Key) && other._data[kp.Key] == kp.Value);
     }
 
-    public IEnumerable<KeyValuePair<string, object>> GetItems() => _data ?? new Dictionary<string, object>();
+    public bool IsEmpty => _data == null || _data.Count == 0;
+
+    public IEnumerable<KeyValuePair<string, object>> GetItems() => _data ?? Enumerable.Empty<KeyValuePair<string, object>>();
 }

--- a/test/BlazorDatasheet.Test/SheetTests/MetaDataTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/MetaDataTests.cs
@@ -22,6 +22,118 @@ public class MetaDataTests
     }
 
     [Test]
+    public void Clear_Cell_MetaData_Key_And_Undo_Works()
+    {
+        var sheet = new Sheet(3, 3);
+        sheet.Cells.SetCellMetaData(1, 1, "test", 7);
+        sheet.Cells.SetCellMetaData(1, 1, "other", 8);
+
+        sheet.Cells.ClearCellMetaData(1, 1, "test");
+
+        sheet.Cells.GetMetaData(1, 1, "test").Should().BeNull();
+        sheet.Cells.GetMetaData(1, 1, "other").Should().Be(8);
+
+        sheet.Commands.Undo();
+
+        sheet.Cells.GetMetaData(1, 1, "test").Should().Be(7);
+        sheet.Cells.GetMetaData(1, 1, "other").Should().Be(8);
+    }
+
+    [Test]
+    public void Setting_Cell_MetaData_To_Null_Clears_Key()
+    {
+        var sheet = new Sheet(3, 3);
+        sheet.Cells.SetCellMetaData(1, 1, "test", 7);
+        sheet.Cells.SetCellMetaData(1, 1, "other", 8);
+
+        sheet.Cells.SetCellMetaData(1, 1, "test", null);
+
+        sheet.Cells.GetMetaData(1, 1, "test").Should().BeNull();
+        sheet.Cells.GetMetaData(1, 1, "other").Should().Be(8);
+    }
+
+    [Test]
+    public void Clear_Cell_MetaData_And_Undo_Works()
+    {
+        var sheet = new Sheet(3, 3);
+        sheet.Cells.SetCellMetaData(1, 1, "test", 7);
+        sheet.Cells.SetCellMetaData(1, 1, "other", 8);
+
+        sheet.Cells.ClearCellMetaData(1, 1);
+
+        sheet.Cells.GetMetaData(1, 1, "test").Should().BeNull();
+        sheet.Cells.GetMetaData(1, 1, "other").Should().BeNull();
+
+        sheet.Commands.Undo();
+
+        sheet.Cells.GetMetaData(1, 1, "test").Should().Be(7);
+        sheet.Cells.GetMetaData(1, 1, "other").Should().Be(8);
+    }
+
+    [Test]
+    public void Sheet_Cell_Can_Set_And_Clear_MetaData()
+    {
+        var sheet = new Sheet(3, 3);
+        var cell = sheet.Cells[1, 1];
+
+        cell.SetMetaData("test", 7);
+        cell.SetMetaData("other", 8);
+        cell.ClearMetaData("test");
+
+        cell.GetMetaData("test").Should().BeNull();
+        cell.GetMetaData("other").Should().Be(8);
+
+        cell.ClearMetaData();
+
+        cell.MetaData.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Sheet_Range_Can_Clear_Specific_And_All_MetaData()
+    {
+        var sheet = new Sheet(3, 3);
+        var range = sheet.Range(0, 1, 0, 1);
+        range.SetMetaData("test", 7);
+        range.SetMetaData("other", 8);
+
+        range.ClearMetaData("test");
+
+        sheet.Cells.GetMetaData(0, 0, "test").Should().BeNull();
+        sheet.Cells.GetMetaData(1, 1, "test").Should().BeNull();
+        sheet.Cells.GetMetaData(0, 0, "other").Should().Be(8);
+        sheet.Cells.GetMetaData(1, 1, "other").Should().Be(8);
+
+        range.ClearMetaData();
+
+        sheet.Cells.GetMetaData(0, 0, "other").Should().BeNull();
+        sheet.Cells.GetMetaData(1, 1, "other").Should().BeNull();
+    }
+
+    [Test]
+    public void MetaData_Changed_Event_Reports_Key_Old_And_New_Values()
+    {
+        var sheet = new Sheet(3, 3);
+        var changes = new List<(string Name, object? OldValue, object? NewValue)>();
+        sheet.Cells.MetaDataChanged += (_, args) => changes.Add((args.Name, args.OldValue, args.NewValue));
+
+        sheet.Cells.SetCellMetaData(1, 1, "test", 7);
+        sheet.Cells.SetCellMetaData(1, 1, "test", 8);
+        sheet.Cells.SetCellMetaData(1, 1, "other", 9);
+        sheet.Cells.ClearCellMetaData(1, 1, "test");
+        sheet.Cells.ClearCellMetaData(1, 1);
+
+        var expected = new List<(string Name, object? OldValue, object? NewValue)>
+        {
+            ("test", null, 7),
+            ("test", 7, 8),
+            ("other", null, 9),
+            ("test", 8, null),
+            ("other", 9, null)
+        };
+        changes.Should().Equal(expected);
+    }
+
+    [Test]
     public void Insert_Row_Shifts_MetaData()
     {
         var sheet = new Sheet(100, 100);
@@ -51,8 +163,8 @@ public class MetaDataTests
     public void Metadata_Moves_Correctly_With_Sort()
     {
         var sheet = new Sheet(100, 100);
-        sheet.Cells["A1"].Value = 10;
-        sheet.Cells["A2"].Value = 5;
+        sheet.Cells[0, 0].Value = 10;
+        sheet.Cells[1, 0].Value = 5;
         sheet.Cells.SetCellMetaData(0, 0, "test", "testMd");
         sheet.SortRange(new ColumnRegion(0), [new(0, true)]);
         sheet.Cells.GetMetaData(1, 0, "test").Should().Be("testMd");


### PR DESCRIPTION
Adds explicit clear-all and clear-key metadata APIs across CellStore, SheetCell, and SheetRange, fixes null-as-clear behavior, and adds undo/event coverage.
