### PR TITLE
Allow formula variables to reference other variables

### DIFF
--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -12,6 +12,7 @@ using BlazorDatasheet.Formula.Core.Dependencies;
 using BlazorDatasheet.Formula.Core.Interpreter;
 using BlazorDatasheet.Formula.Core.Interpreter.Evaluation;
 using BlazorDatasheet.Formula.Core.Interpreter.Parsing;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
 using CellFormula = BlazorDatasheet.Formula.Core.Interpreter.CellFormula;
 
 namespace BlazorDatasheet.Core.FormulaEngine;
@@ -242,7 +243,8 @@ public class FormulaEngine
                 stopwatch.Stop();
                 EmitPendingVariableChanges();
                 CalculationCompleted?.Invoke(this,
-                    new CalculationCompletedEventArgs(calculateAll, evaluatedFormulaCount, stopwatch.Elapsed, exception));
+                    new CalculationCompletedEventArgs(calculateAll, evaluatedFormulaCount, stopwatch.Elapsed,
+                        exception));
             }
         }
     }
@@ -353,8 +355,13 @@ public class FormulaEngine
         if (value is string s && IsFormula(s))
         {
             var formula = ParseFormula(s, "");
-            if (formula.References.Any(x => !x.ExplicitSheetName))
-                throw new Exception("Formula references in variables must have explicit sheet names");
+            if (formula.References.Any(x =>
+                    x.Kind != ReferenceKind.Named &&
+                    !x.ExplicitSheetName))
+            {
+                throw new Exception(
+                    "Formula references in variables must have explicit sheet names");
+            }
 
             QueueVariableChange(varName, true);
             DependencyManager.SetFormula(varName, formula);

--- a/test/BlazorDatasheet.Test/Formula/FormulaEngineTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/FormulaEngineTests.cs
@@ -132,6 +132,44 @@ public class FormulaEngineTests
         dependentValueWhenEmitted.Should().Be(new CellValue(2));
         calculatingWhenEmitted.Should().BeFalse();
     }
+
+    [Test]
+    public void Formula_Variable_Can_Reference_Other_Formula_Variables()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet(10, 10);
+        sheet.FormulaEngine.SetVariable("x", CellValue.Number(10));
+        sheet.FormulaEngine.SetVariable("y", "=x");
+        var hasValue = sheet.FormulaEngine.TryGetVariable("y", out var value);
+        hasValue.Should().BeTrue();
+        value.Should().Be(CellValue.Number(10));
+    }
+
+    [Test]
+    public void Formula_Variable_Can_Reference_Other_Formula_Variables_Does_Not_Throw_With_MixedCell_Ref()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet(10, 10);
+        sheet.FormulaEngine.SetVariable("x", CellValue.Number(10));
+        Assert.DoesNotThrow(() =>
+        {
+            sheet.FormulaEngine.SetVariable("y", "=x+Sheet1!A1");
+            var hasValue = sheet.FormulaEngine.TryGetVariable("y", out var value);
+        });
+    }
+
+    [Test]
+    public void Formula_Variable_Throws_When_Referencing_Cell_Without_Sheet_Specification()
+    {
+        var workbook = new Workbook();
+        var sheet = workbook.AddSheet(10, 10);
+        sheet.FormulaEngine.SetVariable("x", CellValue.Number(10));
+        Assert.Throws<Exception>(() =>
+        {
+            sheet.FormulaEngine.SetVariable("y", "=x+A1");
+            var hasValue = sheet.FormulaEngine.TryGetVariable("y", out var value);
+        });
+    }
 }
 
 internal static class ThrowingFunction


### PR DESCRIPTION
Allows formula variables to reference other variables, e.g previously setting a variable "y" to "=x" would throw as it didn't have a sheet name specified.