### PR TITLE
Add column header grouping

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/RowCols/ClearHeadingGroupsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/ClearHeadingGroupsCommand.cs
@@ -1,0 +1,33 @@
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+
+namespace BlazorDatasheet.Core.Commands.RowCols;
+
+public class ClearHeadingGroupsCommand : BaseCommand, IUndoableCommand
+{
+    private readonly int _indexStart;
+    private readonly int _indexEnd;
+    private readonly Axis _axis;
+    private RowColInfoRestoreData _restoreData = null!;
+
+    public ClearHeadingGroupsCommand(int indexStart, int indexEnd, Axis axis)
+    {
+        _indexStart = indexStart;
+        _indexEnd = indexEnd;
+        _axis = axis;
+    }
+
+    public override bool CanExecute(Sheet sheet) => _indexStart <= _indexEnd;
+
+    public override bool Execute(Sheet sheet)
+    {
+        _restoreData = sheet.GetRowColStore(_axis).ClearGroupsImpl(_indexStart, _indexEnd);
+        return true;
+    }
+
+    public bool Undo(Sheet sheet)
+    {
+        sheet.GetRowColStore(_axis).Restore(_restoreData);
+        return true;
+    }
+}

--- a/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingGroupCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingGroupCommand.cs
@@ -1,0 +1,35 @@
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+
+namespace BlazorDatasheet.Core.Commands.RowCols;
+
+public class SetHeadingGroupCommand : BaseCommand, IUndoableCommand
+{
+    private readonly int _indexStart;
+    private readonly int _indexEnd;
+    private readonly string _label;
+    private readonly Axis _axis;
+    private RowColInfoRestoreData _restoreData = null!;
+
+    public SetHeadingGroupCommand(int indexStart, int indexEnd, string label, Axis axis)
+    {
+        _indexStart = indexStart;
+        _indexEnd = indexEnd;
+        _label = label;
+        _axis = axis;
+    }
+
+    public override bool CanExecute(Sheet sheet) => _indexStart <= _indexEnd;
+
+    public override bool Execute(Sheet sheet)
+    {
+        _restoreData = sheet.GetRowColStore(_axis).SetGroupImpl(_indexStart, _indexEnd, _label);
+        return true;
+    }
+
+    public bool Undo(Sheet sheet)
+    {
+        sheet.GetRowColStore(_axis).Restore(_restoreData);
+        return true;
+    }
+}

--- a/src/BlazorDatasheet.Core/Data/ColumnInfoStore.cs
+++ b/src/BlazorDatasheet.Core/Data/ColumnInfoStore.cs
@@ -1,4 +1,4 @@
-using BlazorDatasheet.Core.Data.Collections;
+﻿using BlazorDatasheet.Core.Data.Collections;
 using BlazorDatasheet.Core.Data.Filter;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Intervals;
@@ -25,6 +25,27 @@ public class ColumnInfoStore : RowColInfoStore
             EmitSizeModified(-1, -1);
         }
     }
+
+    private double _groupHeadingHeight = 24;
+
+    /// <summary>
+    /// The height (in px) of the column group heading band, shown above the column headings when
+    /// any column groups exist.
+    /// </summary>
+    public double GroupHeadingHeight
+    {
+        get => _groupHeadingHeight;
+        set
+        {
+            _groupHeadingHeight = value;
+            EmitSizeModified(-1, -1);
+        }
+    }
+
+    /// <summary>
+    /// The total height (in px) of the column heading area, including the group band if any groups exist.
+    /// </summary>
+    public double TotalHeadingHeight => HeadingHeight + (HasGroups ? GroupHeadingHeight : 0);
 
     public ColumnInfoStore(double defaultHeight, Sheet sheet) : base(defaultHeight, sheet, Axis.Col)
     {

--- a/src/BlazorDatasheet.Core/Data/HeadingGroup.cs
+++ b/src/BlazorDatasheet.Core/Data/HeadingGroup.cs
@@ -1,0 +1,15 @@
+namespace BlazorDatasheet.Core.Data;
+
+/// <summary>
+/// A labelled group spanning a contiguous range of rows/columns. Stored by reference so that
+/// two adjacent groups with the same label remain distinct.
+/// </summary>
+public class HeadingGroup
+{
+    public string Label { get; }
+
+    public HeadingGroup(string label)
+    {
+        Label = label;
+    }
+}

--- a/src/BlazorDatasheet.Core/Data/HeadingGroupInfo.cs
+++ b/src/BlazorDatasheet.Core/Data/HeadingGroupInfo.cs
@@ -1,0 +1,9 @@
+namespace BlazorDatasheet.Core.Data;
+
+/// <summary>
+/// The position and data of a <see cref="HeadingGroup"/>.
+/// </summary>
+public record HeadingGroupInfo(int Start, int End, HeadingGroup Group)
+{
+    public string Label => Group.Label;
+}

--- a/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
+++ b/src/BlazorDatasheet.Core/Data/RowColInfoStore.cs
@@ -15,6 +15,11 @@ public abstract class RowColInfoStore
 
     internal readonly Range1DStore<string> HeadingStore = new(null);
 
+    /// <summary>
+    /// Stores labelled groups that span contiguous rows/columns.
+    /// </summary>
+    internal readonly Range1DStore<HeadingGroup> GroupStore = new(null);
+
     // stores and manages the *cumulative* sizes, for visual purposes.
     protected readonly CumulativeRange1DStore CumulativeSizeStore;
 
@@ -82,6 +87,16 @@ public abstract class RowColInfoStore
     public virtual event EventHandler<HeadingsModifiedEventArgs>? HeadingsModified;
 
     /// <summary>
+    /// Fired when a row/column heading group is changed.
+    /// </summary>
+    public virtual event EventHandler<HeadingGroupsModifiedEventArgs>? GroupsModified;
+
+    /// <summary>
+    /// Whether any heading groups are defined.
+    /// </summary>
+    public bool HasGroups => GroupStore.Any();
+
+    /// <summary>
     /// Sets the sizes of rows/cols between (and including) the indices specified, to the value given.
     /// </summary>
     /// <param name="start"></param>
@@ -130,6 +145,52 @@ public abstract class RowColInfoStore
     }
 
     /// <summary>
+    /// Sets a group with the label given over the rows/columns between (and including) the indices specified.
+    /// Any existing groups overlapping the range are cleared first, since groups never overlap.
+    /// </summary>
+    internal RowColInfoRestoreData SetGroupImpl(int start, int end, string label)
+    {
+        var hadGroups = HasGroups;
+        var restoreData = GroupStore.Clear(start, end);
+        restoreData.Merge(GroupStore.Set(start, end, new HeadingGroup(label)));
+        EmitGroupsModified(start, end, hadGroups);
+        return new RowColInfoRestoreData()
+        {
+            GroupsRestoreData = restoreData
+        };
+    }
+
+    /// <summary>
+    /// Clears any groups overlapping the rows/columns between (and including) the indices specified.
+    /// </summary>
+    internal RowColInfoRestoreData ClearGroupsImpl(int start, int end)
+    {
+        var hadGroups = HasGroups;
+        // clear whole groups, not just the part of them inside the range
+        foreach (var group in GetGroups(start, end))
+        {
+            start = Math.Min(start, group.Start);
+            end = Math.Max(end, group.End);
+        }
+
+        var restoreData = GroupStore.Clear(start, end);
+        EmitGroupsModified(start, end, hadGroups);
+        return new RowColInfoRestoreData()
+        {
+            GroupsRestoreData = restoreData
+        };
+    }
+
+    private void EmitGroupsModified(int start, int end, bool hadGroups)
+    {
+        Sheet.MarkDirty(GetSpannedRegion(start, end));
+        GroupsModified?.Invoke(this, new HeadingGroupsModifiedEventArgs(start, end, _axis));
+        // the group band appearing/disappearing changes the heading gutter size
+        if (hadGroups != HasGroups)
+            EmitSizeModified(-1, -1);
+    }
+
+    /// <summary>
     /// Removes the rows/columns between (and including) the indexes given.
     /// Handles shifting the indices to the up/left and returns any modified data.
     /// </summary>
@@ -138,11 +199,13 @@ public abstract class RowColInfoStore
     /// <returns></returns>
     internal RowColInfoRestoreData RemoveImpl(int start, int end)
     {
+        var groupsBefore = GetGroups();
         var restoreData = new RowColInfoRestoreData()
         {
             CumulativeSizesRestoreData = CumulativeSizeStore.Delete(start, end),
             SizesRestoreData = SizeStore.Delete(start, end),
             HeadingsRestoreData = HeadingStore.Delete(start, end),
+            GroupsRestoreData = GroupStore.Delete(start, end),
             VisibilityRestoreData = Visible.Delete(start, end),
             RowColFormatRestoreData = new RowColFormatRestoreData()
             {
@@ -151,6 +214,7 @@ public abstract class RowColInfoStore
         };
 
         restoreData.RowColFormatRestoreData.Format1DRestoreData.Merge(Formats.ShiftLeft(start, (end - start) + 1));
+        EmitGroupsModifiedIfChanged(groupsBefore);
         Sheet.MarkDirty(GetSpannedRegion(start, Sheet.GetSize(_axis)));
         EmitRemoved(start, (end - start) + 1);
         return restoreData;
@@ -377,11 +441,13 @@ public abstract class RowColInfoStore
     /// <param name="count"></param>
     internal RowColInfoRestoreData InsertImpl(int start, int count)
     {
+        var groupsBefore = GetGroups();
         var restoreData = new RowColInfoRestoreData()
         {
             CumulativeSizesRestoreData = CumulativeSizeStore.InsertAt(start, count),
             SizesRestoreData = SizeStore.InsertAt(start, count),
             HeadingsRestoreData = HeadingStore.InsertAt(start, count),
+            GroupsRestoreData = GroupStore.InsertAt(start, count),
             VisibilityRestoreData = Visible.InsertAt(start, count),
             RowColFormatRestoreData = new RowColFormatRestoreData()
             {
@@ -389,6 +455,7 @@ public abstract class RowColInfoStore
             }
         };
 
+        EmitGroupsModifiedIfChanged(groupsBefore);
         EmitInserted(start, count);
         Sheet.MarkDirty(GetSpannedRegion(start, Sheet.GetSize(_axis)));
         return restoreData;
@@ -406,9 +473,11 @@ public abstract class RowColInfoStore
 
     internal void Restore(RowColInfoRestoreData data)
     {
+        var groupsBefore = GetGroups();
         CumulativeSizeStore.Restore(data.CumulativeSizesRestoreData);
         SizeStore.Restore(data.SizesRestoreData);
         HeadingStore.Restore(data.HeadingsRestoreData);
+        GroupStore.Restore(data.GroupsRestoreData);
         Visible.Restore(data.VisibilityRestoreData);
         Formats.Restore(data.RowColFormatRestoreData.Format1DRestoreData);
 
@@ -423,6 +492,20 @@ public abstract class RowColInfoStore
         {
             HeadingsModified?.Invoke(this, new HeadingsModifiedEventArgs(change.Start, change.End, _axis));
         }
+
+        EmitGroupsModifiedIfChanged(groupsBefore);
+    }
+
+    private void EmitGroupsModifiedIfChanged(IReadOnlyList<HeadingGroupInfo> groupsBefore)
+    {
+        var groupsAfter = GetGroups();
+        if (groupsBefore.SequenceEqual(groupsAfter))
+            return;
+
+        var affectedGroups = groupsBefore.Concat(groupsAfter).ToList();
+        var start = affectedGroups.Min(x => x.Start);
+        var end = affectedGroups.Max(x => x.End);
+        EmitGroupsModified(start, end, groupsBefore.Count > 0);
     }
 
     internal void EmitInserted(int start, int count)
@@ -498,6 +581,68 @@ public abstract class RowColInfoStore
     }
 
     /// <summary>
+    /// Sets a labelled group spanning (and including) <paramref name="indexStart"/> to <paramref name="indexEnd"/>.
+    /// Existing groups overlapping the range are replaced.
+    /// </summary>
+    public void SetGroup(int indexStart, int indexEnd, string label)
+    {
+        Sheet.Commands.ExecuteCommand(new SetHeadingGroupCommand(indexStart, indexEnd, label, _axis));
+    }
+
+    /// <summary>
+    /// Clears any groups overlapping (and including) <paramref name="indexStart"/> to <paramref name="indexEnd"/>.
+    /// </summary>
+    public void ClearGroups(int indexStart, int indexEnd)
+    {
+        Sheet.Commands.ExecuteCommand(new ClearHeadingGroupsCommand(indexStart, indexEnd, _axis));
+    }
+
+    /// <summary>
+    /// Returns the group that spans <paramref name="index"/>, or null if there is none.
+    /// </summary>
+    public HeadingGroupInfo? GetGroup(int index)
+    {
+        return GetGroups(index, index).FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Returns all groups, ordered by their start index.
+    /// </summary>
+    public List<HeadingGroupInfo> GetGroups()
+    {
+        // removing rows/cols inside a group can leave the store holding adjacent fragments that
+        // reference the same group, so adjacent fragments are joined back into one group here.
+        var groups = new List<HeadingGroupInfo>();
+        foreach (var (interval, group) in GroupStore.GetAllIntervalData())
+        {
+            if (group == null)
+                continue;
+
+            if (groups.Count > 0 &&
+                ReferenceEquals(groups[^1].Group, group) &&
+                groups[^1].End + 1 == interval.Start)
+            {
+                groups[^1] = groups[^1] with { End = interval.End };
+                continue;
+            }
+
+            groups.Add(new HeadingGroupInfo(interval.Start, interval.End, group));
+        }
+
+        return groups;
+    }
+
+    /// <summary>
+    /// Returns all groups overlapping (and including) <paramref name="indexStart"/> to <paramref name="indexEnd"/>.
+    /// </summary>
+    public List<HeadingGroupInfo> GetGroups(int indexStart, int indexEnd)
+    {
+        return GetGroups()
+            .Where(g => g.End >= indexStart && g.Start <= indexEnd)
+            .ToList();
+    }
+
+    /// <summary>
     /// Inserts a row/column at an index specified.
     /// </summary>
     /// <param name="index">The index that the new row/column will be at. The new row/column will have the index specified.</param>
@@ -536,6 +681,7 @@ internal class RowColInfoRestoreData
 
     public MergeableIntervalStoreRestoreData<OverwritingValue<double>> SizesRestoreData { get; init; } = new();
     public MergeableIntervalStoreRestoreData<OverwritingValue<string>> HeadingsRestoreData { get; init; } = new();
+    public MergeableIntervalStoreRestoreData<OverwritingValue<HeadingGroup>> GroupsRestoreData { get; init; } = new();
     public MergeableIntervalStoreRestoreData<OverwritingValue<bool>> VisibilityRestoreData { get; init; } = new();
     public RowColFormatRestoreData RowColFormatRestoreData { get; init; } = new();
 
@@ -544,6 +690,7 @@ internal class RowColInfoRestoreData
         CumulativeSizesRestoreData.Merge(other.CumulativeSizesRestoreData);
         SizesRestoreData.Merge(other.SizesRestoreData);
         HeadingsRestoreData.Merge(other.HeadingsRestoreData);
+        GroupsRestoreData.Merge(other.GroupsRestoreData);
         VisibilityRestoreData.Merge(other.VisibilityRestoreData);
         RowColFormatRestoreData.Merge(other.RowColFormatRestoreData);
     }

--- a/src/BlazorDatasheet.Core/Events/Layout/HeadingGroupsModifiedEventArgs.cs
+++ b/src/BlazorDatasheet.Core/Events/Layout/HeadingGroupsModifiedEventArgs.cs
@@ -1,0 +1,17 @@
+using BlazorDatasheet.DataStructures.Geometry;
+
+namespace BlazorDatasheet.Core.Events.Layout;
+
+public class HeadingGroupsModifiedEventArgs
+{
+    public int IndexStart { get; }
+    public int IndexEnd { get; }
+    public Axis Axis { get; }
+
+    public HeadingGroupsModifiedEventArgs(int indexStart, int indexEnd, Axis axis)
+    {
+        IndexStart = indexStart;
+        IndexEnd = indexEnd;
+        Axis = axis;
+    }
+}

--- a/src/BlazorDatasheet.Core/Serialization/Mappers/SheetMapper.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Mappers/SheetMapper.cs
@@ -85,6 +85,10 @@ internal class SheetMapper
 			sheetModel.Columns.Add(columnModel);
 		}
 
+		sheetModel.ColumnGroups = sheet.Columns.GetGroups()
+			.Select(g => new HeadingGroupModel { Start = g.Start, End = g.End, Label = g.Label })
+			.ToList();
+
 		sheetModel.Merges = sheet.Cells.GetMerges(sheet.Region)
 			.Select(x => new DataRegionModel<bool>(RangeText.RegionToText(x), true))
 			.ToList();
@@ -185,6 +189,9 @@ internal class SheetMapper
 
 		foreach (var validator in sheetModel.Validators)
 			sheet.Validators.Add(sheet.Range(validator.RegionString)!.Region, validator.Value);
+
+		foreach (var groupModel in sheetModel.ColumnGroups)
+			sheet.Columns.GroupStore.Set(groupModel.Start, groupModel.End, new HeadingGroup(groupModel.Label));
 
 		foreach (var colModel in sheetModel.Columns)
 		{

--- a/src/BlazorDatasheet.Core/Serialization/Models/HeadingGroupModel.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Models/HeadingGroupModel.cs
@@ -1,0 +1,8 @@
+namespace BlazorDatasheet.Core.Serialization.Models;
+
+internal class HeadingGroupModel
+{
+    public int Start { get; set; }
+    public int End { get; set; }
+    public string Label { get; set; } = string.Empty;
+}

--- a/src/BlazorDatasheet.Core/Serialization/Models/SheetModel.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Models/SheetModel.cs
@@ -9,6 +9,7 @@ internal class SheetModel
     public List<RowModel> Rows { get; set; } = new();
     public FreezeStateModel FreezeState { get; set; } = new();
     public List<ColumnModel> Columns { get; set; } = new();
+    public List<HeadingGroupModel> ColumnGroups { get; set; } = new();
     public List<DataRegionModel<int>> CellFormats { get; set; } = new();
     public List<DataRegionModel<bool>> Merges { get; set; } = new();
     public List<DataRegionModel<string>> Types { get; set; } = new();

--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Customisation/ColumnGroupsExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Customisation/ColumnGroupsExample.razor
@@ -1,0 +1,31 @@
+@using BlazorDatasheet.Core.Data
+
+<div style="max-width: 700px; height:400px; overflow: scroll;">
+    <Datasheet Sheet="_sheet">
+        <ColumnGroupTemplate>
+            <div style="width: 100%; text-align: center; font-style: italic;">@context.Label</div>
+        </ColumnGroupTemplate>
+    </Datasheet>
+</div>
+
+@code {
+
+    private readonly Sheet _sheet = new Sheet(300, 200);
+
+    protected override void OnInitialized()
+    {
+        _sheet.Columns.SetHeadings(0, 0, "Jan");
+        _sheet.Columns.SetHeadings(1, 1, "Feb");
+        _sheet.Columns.SetHeadings(2, 2, "Mar");
+        _sheet.Columns.SetHeadings(3, 3, "Apr");
+        _sheet.Columns.SetHeadings(4, 4, "May");
+        _sheet.Columns.SetHeadings(5, 5, "Jun");
+
+        _sheet.Columns.SetGroup(0, 2, "Q1");
+        _sheet.Columns.SetGroup(3, 5, "Q2");
+
+        _sheet.FreezeLeftColumns(1);
+        _sheet.Commands.ClearHistory();
+    }
+
+}

--- a/src/BlazorDatasheet.SharedPages/Components/Layout/NavMenu.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Layout/NavMenu.razor
@@ -46,6 +46,7 @@
     <ul class="menu-list">
         <MenuLink Href="CustomRendererAndEditor" Text="Custom renderer/editor"/>
         <MenuLink Href="CustomHeadings" Text="Custom headings"/>
+        <MenuLink Href="ColumnGroups" Text="Column groups"/>
     </ul>
     <p class="menu-label">Formula</p>
     <ul class="menu-list">

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/ColumnGroups.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/ColumnGroups.razor
@@ -1,0 +1,17 @@
+@page "/ColumnGroups"
+@using BlazorDatasheet.SharedPages.Components.Examples.Customisation
+<h3>Column groups</h3>
+
+<div class="block">
+    Column groups add a second heading band above the column headings, where a labelled cell spans a contiguous run of
+    columns. Groups are defined on the sheet with <code>sheet.Columns.SetGroup(start, end, label)</code> and removed
+    with <code>sheet.Columns.ClearGroups(start, end)</code>. Both are undoable, and groups grow, shrink and shift as
+    columns are inserted or removed.
+</div>
+
+<div class="block">
+    Clicking a group selects its columns. The band height is set by <code>sheet.Columns.GroupHeadingHeight</code>, and
+    the content of each group can be customised with the <code>ColumnGroupTemplate</code> render fragment.
+</div>
+
+<CodeExample ComponentType="typeof(ColumnGroupsExample)"/>

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -41,7 +41,7 @@
                                          background: var(--col-header-bg-color);
                                          z-index: @CornerHeadingZIndex;
                                          @(StickyHeaders ? "position: sticky; top: 0; left:0;" : "")
-                                         height: @(_sheet.Columns.HeadingHeight)px;">
+                                         height: @(GetGutterSize(Axis.Col))px;">
                                     </div>
                                 }
 
@@ -50,6 +50,8 @@
                                     ViewRegion="_viewRegion"
                                     Sheet="_sheet"
                                     ShowColumnMenu="_menuOptions.HeaderMenuEnabled"
+                                    GroupTemplate="ColumnGroupTemplate"
+                                    GroupMouseDown="HandleColumnGroupMouseDown"
                                     PreviewService="_previewService">
                                     @ColumnHeaderTemplate(context)
                                 </ColumnHeadingRenderer>
@@ -157,6 +159,14 @@
     [Parameter]
     public RenderFragment<HeadingContext> ColumnHeaderTemplate { get; set; } =
         context => @<div>@context.Heading</div>;
+
+    /// <summary>
+    /// Set this to render a custom column group heading. Column groups are defined with
+    /// <c>Sheet.Columns.SetGroup</c>.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<ColumnGroupContext> ColumnGroupTemplate { get; set; } =
+        context => @<div style="width: 100%; text-align: center;">@context.Label</div>;
 
     /// <summary>
     /// Set this to render a custom row heading

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -622,6 +622,14 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
             mouseButton: args.MouseButton);
     }
 
+    private void HandleColumnGroupMouseDown(HeadingGroupInfo group)
+    {
+        if (_sheet.Editor.IsEditing && !_sheet.Editor.AcceptEdit())
+            return;
+
+        _sheet.Selection.Set(new ColumnRegion(group.Start, group.End));
+    }
+
     private async Task<bool> HandleWindowKeyDown(KeyboardEventArgs e)
     {
         if (!IsDataSheetActive)
@@ -831,7 +839,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
             return;
 
         var gutterRow = _showRowHeadings ? _sheet.Rows.HeadingWidth : 0;
-        var gutterCol = _showColHeadings ? _sheet.Columns.HeadingHeight : 0;
+        var gutterCol = _showColHeadings ? _sheet.Columns.TotalHeadingHeight : 0;
 
         var constrainedViewRect = new Rect(
             currentViewRect.X + frozenLeftW,
@@ -912,7 +920,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         if (axis == Axis.Row && ShowRowHeadings)
             return _sheet.Rows.HeadingWidth;
         if (axis == Axis.Col && ShowColHeadings)
-            return _sheet.Columns.HeadingHeight;
+            return _sheet.Columns.TotalHeadingHeight;
         return 0;
     }
 

--- a/src/BlazorDatasheet/Render/Headings/ColumnGroupContext.cs
+++ b/src/BlazorDatasheet/Render/Headings/ColumnGroupContext.cs
@@ -1,0 +1,26 @@
+namespace BlazorDatasheet.Render.Headings;
+
+/// <summary>
+/// Passed to the column group heading template.
+/// </summary>
+public struct ColumnGroupContext
+{
+    /// <summary>
+    /// The first column of the group.
+    /// </summary>
+    public int Start { get; }
+
+    /// <summary>
+    /// The last column of the group.
+    /// </summary>
+    public int End { get; }
+
+    public string Label { get; }
+
+    public ColumnGroupContext(int start, int end, string label)
+    {
+        Start = start;
+        End = end;
+        Label = label;
+    }
+}

--- a/src/BlazorDatasheet/Render/Headings/ColumnHeadingRenderer.razor
+++ b/src/BlazorDatasheet/Render/Headings/ColumnHeadingRenderer.razor
@@ -1,4 +1,5 @@
-﻿@using BlazorDatasheet.DataStructures.Geometry
+﻿@using BlazorDatasheet.Core.Data
+@using BlazorDatasheet.DataStructures.Geometry
 @using BlazorDatasheet.Formula.Core
 @using BlazorDatasheet.Menu
 @using BlazorDatasheet.Render.Layers.Preview
@@ -8,6 +9,35 @@
 @inherits HeadingRenderer
 @implements IAsyncDisposable
 @inject IJSRuntime Js;
+
+<div style="display: flex; flex-direction: column;">
+
+@if (_sheet.Columns.HasGroups)
+{
+    <div class="bds-col-group-row" style="display: flex; flex-direction: row;">
+
+        @if (_sheet.FreezeState.Left > 0 && HasVisibleCols(LeftHeadingRegion))
+        {
+            <div style="position: sticky; left:var(--gutter-left-width); z-index: 4;" class="bds-frozen-left">
+                @ColGroupPane(LeftHeadingRegion)
+            </div>
+        }
+
+        @if (HasVisibleCols(MainHeadingRegion))
+        {
+            <div class="bds-sheet-col-head-container" style="z-index: 2;">
+                @ColGroupPane(MainHeadingRegion)
+            </div>
+        }
+
+        @if (_sheet.FreezeState.Right > 0 && HasVisibleCols(RightHeadingRegion))
+        {
+            <div style="position: sticky; right: 0; z-index: 4;" class="bds-frozen-right">
+                @ColGroupPane(RightHeadingRegion)
+            </div>
+        }
+    </div>
+}
 
 <div style="display: flex; flex-direction: row">
 
@@ -56,8 +86,118 @@
         </div>
     }
 </div>
+</div>
 
 @code {
+
+    private RenderFragment ColGroupPane(Region region) =>
+        @<div class="bds-col-group-pane" style="position: relative; height: @(_sheet.Columns.GroupHeadingHeight)px; width: @(_sheet.Columns.GetVisualWidth(region))px; overflow: hidden;">
+            @foreach (var group in _sheet.Columns.GetGroups(region.Left, region.Right))
+            {
+                var start = Math.Max(group.Start, region.Left);
+                var end = Math.Min(group.End, region.Right);
+                if (_sheet.Columns.CountVisible(start, end) == 0)
+                    continue;
+
+                var left = _sheet.Columns.GetVisualLeft(start) - _sheet.Columns.GetVisualLeft(region.Left);
+                var width = _sheet.Columns.GetVisualWidthBetween(start, end + 1);
+                var leftBorder = NeedsLeftBorder(group, start);
+                // a left border sits inside the group's box, one border-width right of the column line
+                // drawn by the previous column's right border, so shift the box left to line them up.
+                var position = leftBorder
+                    ? $"left: calc({left}px - var(--sheet-border-width)); width: calc({width}px + var(--sheet-border-width));"
+                    : $"left: {left}px; width: {width}px;";
+                <div @key="group.Start"
+                     class="bds-col-group-head bds-col-head bds-unselectable @(leftBorder ? "bds-col-group-head-left" : "") @GetGroupSelectedClass(group.Start, group.End)"
+                     data-group-start="@group.Start"
+                     data-group-end="@group.End"
+                     @onmousedown="GetGroupMouseDownHandler(group)"
+                     style="position: absolute; top: 0; @position height: 100%;">
+                    @GroupTemplate(new ColumnGroupContext(group.Start, group.End, group.Label))
+                </div>
+            }
+        </div>;
+
+    /// <summary>
+    /// A group draws its own left border only when it starts inside this pane (not clipped by a frozen
+    /// boundary) and the previous visible column is not in a group (whose right border is the shared line).
+    /// The first visible column's edge is drawn by the corner cell.
+    /// </summary>
+    private bool NeedsLeftBorder(HeadingGroupInfo group, int paneStart)
+    {
+        if (paneStart != group.Start)
+            return false;
+        var prev = _sheet.Columns.GetNextVisible(group.Start, -1);
+        if (prev < 0)
+            return false;
+        return _sheet.Columns.GetGroup(prev) == null;
+    }
+
+    /// <summary>
+    /// Renders the content of a column group heading.
+    /// </summary>
+    [Parameter]
+    public RenderFragment<ColumnGroupContext> GroupTemplate { get; set; } =
+        context => @<div style="width: 100%; text-align: center;">@context.Label</div>;
+
+    [Parameter]
+    public EventCallback<HeadingGroupInfo> GroupMouseDown { get; set; }
+
+    private readonly Dictionary<(int start, int end), Action<MouseEventArgs>> _groupHandlerCache = new();
+
+    private Action<MouseEventArgs> GetGroupMouseDownHandler(HeadingGroupInfo group)
+    {
+        (int start, int end) key = (group.Start, group.End);
+        if (!_groupHandlerCache.TryGetValue(key, out var handler))
+        {
+            handler = _ => GroupMouseDown.InvokeAsync(group);
+            _groupHandlerCache[key] = handler;
+        }
+
+        return handler;
+    }
+
+    /// <summary>
+    /// Full-selected when every column in the group is covered by a column-region selection,
+    /// partially selected when any selection touches the group.
+    /// </summary>
+    private string GetGroupSelectedClass(int start, int end)
+    {
+        var regions = _sheet.Selection.Regions.ToList();
+        if (_sheet.Selection.SelectingRegion != null)
+            regions.Add(_sheet.Selection.SelectingRegion);
+
+        if (regions.Count == 0)
+            return string.Empty;
+
+        var anySelected = false;
+        var allFull = true;
+        for (int col = start; col <= end; col++)
+        {
+            var spanned = false;
+            var fullySpanned = false;
+            foreach (var region in regions)
+            {
+                if (!region.SpansCol(col))
+                    continue;
+                spanned = true;
+                if (region is ColumnRegion)
+                {
+                    fullySpanned = true;
+                    break;
+                }
+            }
+
+            anySelected |= spanned;
+            allFull &= fullySpanned;
+        }
+
+        if (allFull)
+            return "bds-selected-header-full";
+        if (anySelected)
+            return "bds-selected-header";
+        return string.Empty;
+    }
 
     private RenderFragment ColHeadingItem(int col) =>
         @<div @key="col"

--- a/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
+++ b/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
@@ -73,6 +73,8 @@ public partial class HeadingRenderer : SheetComponentBase, IDisposable
         sheet.Columns.SizeModified -= HandleSizeModified;
         sheet.Rows.HeadingsModified -= HandleHeadingsModified;
         sheet.Columns.HeadingsModified -= HandleHeadingsModified;
+        sheet.Rows.GroupsModified -= HandleGroupsModified;
+        sheet.Columns.GroupsModified -= HandleGroupsModified;
         sheet.FrozenRowCols -= HandleFrozenRowCols;
     }
 
@@ -88,10 +90,21 @@ public partial class HeadingRenderer : SheetComponentBase, IDisposable
         sheet.Columns.SizeModified += HandleSizeModified;
         sheet.Rows.HeadingsModified += HandleHeadingsModified;
         sheet.Columns.HeadingsModified += HandleHeadingsModified;
+        sheet.Rows.GroupsModified += HandleGroupsModified;
+        sheet.Columns.GroupsModified += HandleGroupsModified;
         sheet.FrozenRowCols += HandleFrozenRowCols;
     }
 
     private void HandleHeadingsModified(object? sender, HeadingsModifiedEventArgs e)
+    {
+        if (e.Axis != Axis)
+            return;
+
+        _dirty = true;
+        StateHasChanged();
+    }
+
+    private void HandleGroupsModified(object? sender, HeadingGroupsModifiedEventArgs e)
     {
         if (e.Axis != Axis)
             return;

--- a/src/BlazorDatasheet/wwwroot/sheet-styles.css
+++ b/src/BlazorDatasheet/wwwroot/sheet-styles.css
@@ -269,6 +269,28 @@
     background: var(--col-header-bg-color);
 }
 
+.bds-col-group-pane {
+    background: var(--col-header-bg-color);
+    color: var(--col-header-foreground-color);
+}
+
+.bds-col-group-head-left {
+    border-left: var(--sheet-border-style);
+}
+
+.bds-col-group-head {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    border-right: var(--sheet-border-style);
+    border-bottom: var(--sheet-border-style);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    cursor: default;
+}
+
 .bds-col-head, .bds-row-head {
     font-weight: 600;
     letter-spacing: 0.01em;

--- a/test/BlazorDatasheet.Test/Render/SimpleRenderTests.razor
+++ b/test/BlazorDatasheet.Test/Render/SimpleRenderTests.razor
@@ -687,4 +687,161 @@
 
         return 0;
     }
+
+    [Test]
+    public void Datasheet_Without_Column_Groups_Does_Not_Render_Group_Band()
+    {
+        var sheet = new Sheet(3, 4);
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        cut.FindAll("div.bds-col-group-row").Should().BeEmpty();
+        cut.FindAll("div.bds-col-group-head").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Column_Group_Renders_Label_Spanning_Its_Columns()
+    {
+        var sheet = new Sheet(3, 4);
+        sheet.Columns.SetSize(0, 90);
+        sheet.Columns.SetGroup(0, 1, "Q1");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        var group = cut.Find("div.bds-col-group-head");
+        group.TextContent.Trim().Should().Be("Q1");
+        group.GetStyle().GetWidth().Should().Be((90 + sheet.Columns.DefaultSize) + "px");
+        group.GetStyle().GetLeft().Should().BeOneOf("0", "0px");
+
+        // the corner heading cell grows to match the taller gutter
+        var corner = cut.Find("div.bds-row-head.bds-col-head");
+        corner.GetStyle().GetHeight().Should().Be(sheet.Columns.TotalHeadingHeight + "px");
+
+        // adding a group at runtime re-renders the band
+        await cut.InvokeAsync(() => sheet.Columns.SetGroup(2, 3, "Q2"));
+        cut.WaitForAssertion(() => cut.FindAll("div.bds-col-group-head").Should().HaveCount(2));
+        var second = cut.FindAll("div.bds-col-group-head")[1];
+        second.GetStyle().GetLeft().Should().Be((90 + sheet.Columns.DefaultSize) + "px");
+    }
+
+    [Test]
+    public async Task Group_Band_Skips_Groups_Whose_Columns_Are_All_Hidden()
+    {
+        var sheet = new Sheet(3, 4);
+        sheet.Columns.SetGroup(0, 1, "Hidden");
+        sheet.Columns.SetGroup(2, 3, "Shown");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        await cut.InvokeAsync(() => sheet.Columns.Hide(0, 2));
+
+        cut.WaitForAssertion(() =>
+        {
+            var groups = cut.FindAll("div.bds-col-group-head");
+            groups.Should().HaveCount(1);
+            groups[0].TextContent.Trim().Should().Be("Shown");
+        });
+    }
+
+    [Test]
+    public async Task Clicking_Column_Group_Selects_Its_Columns_And_Highlights_Group()
+    {
+        var sheet = new Sheet(3, 4);
+        sheet.Columns.SetGroup(1, 2, "G");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        await cut.Find("div.bds-col-group-head").MouseDownAsync(new MouseEventArgs());
+
+        sheet.Selection.ActiveRegion.Should().BeOfType<ColumnRegion>();
+        sheet.Selection.ActiveRegion!.Left.Should().Be(1);
+        sheet.Selection.ActiveRegion.Right.Should().Be(2);
+        cut.WaitForAssertion(() =>
+            cut.Find("div.bds-col-group-head").ClassList.Should().Contain("bds-selected-header-full"));
+
+        await cut.InvokeAsync(() => sheet.Selection.Set(0, 1));
+        cut.WaitForAssertion(() =>
+        {
+            var cls = cut.Find("div.bds-col-group-head").ClassList;
+            cls.Should().Contain("bds-selected-header");
+            cls.Should().NotContain("bds-selected-header-full");
+        });
+    }
+
+    [Test]
+    public async Task Clicking_Column_Group_Accepts_Active_Edit_Before_Selecting_Columns()
+    {
+        var sheet = new Sheet(3, 4);
+        sheet.Columns.SetGroup(1, 2, "G");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        await cut.InvokeAsync(() => sheet.Editor.BeginEdit(0, 0));
+        sheet.Editor.IsEditing.Should().BeTrue();
+
+        await cut.Find("div.bds-col-group-head").MouseDownAsync(new MouseEventArgs());
+
+        sheet.Editor.IsEditing.Should().BeFalse();
+        sheet.Selection.ActiveRegion.Should().BeOfType<ColumnRegion>();
+        sheet.Selection.ActiveRegion!.Left.Should().Be(1);
+        sheet.Selection.ActiveRegion.Right.Should().Be(2);
+    }
+
+    [Test]
+    public void Custom_Column_Group_Template_Is_Used()
+    {
+        var sheet = new Sheet(3, 4);
+        sheet.Columns.SetGroup(0, 3, "G");
+        var cut = RenderComponent<Datasheet>(parameters =>
+        {
+            parameters.Add(p => p.Sheet, sheet);
+            parameters.Add(p => p.ColumnGroupTemplate,
+                (RenderFragment<ColumnGroupContext>)(ctx => @<span>@ctx.Label:@ctx.Start-@ctx.End</span>));
+        });
+
+        cut.Find("div.bds-col-group-head").TextContent.Trim().Should().Be("G:0-3");
+    }
+
+    [Test]
+    public void Frozen_Pane_Without_Group_Still_Renders_Header_Coloured_Group_Band()
+    {
+        var sheet = new Sheet(3, 5);
+        sheet.FreezeLeftColumns(1);
+        sheet.Columns.SetGroup(2, 3, "G");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        var frozenPanes = cut.FindAll("div.bds-col-group-row div.bds-frozen-left div.bds-col-group-pane");
+        frozenPanes.Should().HaveCount(1);
+        frozenPanes[0].QuerySelectorAll("div.bds-col-group-head").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Isolated_Group_Gets_Left_Border_But_Adjacent_Group_Does_Not()
+    {
+        var sheet = new Sheet(3, 6);
+        sheet.Columns.SetGroup(0, 1, "A");
+        sheet.Columns.SetGroup(3, 4, "B");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        var groups = cut.FindAll("div.bds-col-group-head");
+        groups.Should().HaveCount(2);
+        groups[0].ClassList.Should().NotContain("bds-col-group-head-left");
+        groups[1].ClassList.Should().Contain("bds-col-group-head-left");
+
+        // filling the gap makes B adjacent to a group, so it drops its own left border
+        await cut.InvokeAsync(() => sheet.Columns.SetGroup(2, 2, "C"));
+        cut.WaitForAssertion(() =>
+        {
+            var b = cut.Find("div.bds-col-group-head[data-group-start='3']");
+            b.ClassList.Should().NotContain("bds-col-group-head-left");
+        });
+    }
+
+    [Test]
+    public void Group_Clipped_By_Frozen_Boundary_Has_No_Left_Border_In_Main_Pane()
+    {
+        var sheet = new Sheet(3, 5);
+        sheet.FreezeLeftColumns(1);
+        sheet.Columns.SetGroup(0, 2, "G");
+        var cut = RenderComponent<Datasheet>(parameters => { parameters.Add(p => p.Sheet, sheet); });
+
+        var groups = cut.FindAll("div.bds-col-group-head");
+        groups.Should().HaveCount(2);
+        groups.Should().OnlyContain(g => !g.ClassList.Contains("bds-col-group-head-left"));
+    }
 }

--- a/test/BlazorDatasheet.Test/SheetTests/ColumnGroupTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/ColumnGroupTests.cs
@@ -1,0 +1,191 @@
+﻿using System.Linq;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.SheetTests;
+
+public class ColumnGroupTests
+{
+    [Test]
+    public void Set_Group_Then_Get_Group_Returns_Group_For_Each_Spanned_Column()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(1, 3, "Q1");
+
+        sheet.Columns.HasGroups.Should().BeTrue();
+        sheet.Columns.GetGroup(0).Should().BeNull();
+        sheet.Columns.GetGroup(4).Should().BeNull();
+        for (int col = 1; col <= 3; col++)
+        {
+            var g = sheet.Columns.GetGroup(col);
+            g.Should().NotBeNull();
+            g!.Start.Should().Be(1);
+            g.End.Should().Be(3);
+            g.Label.Should().Be("Q1");
+        }
+    }
+
+    [Test]
+    public void Overlapping_Set_Replaces_Existing_Group()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(0, 4, "A");
+        sheet.Columns.SetGroup(2, 6, "B");
+
+        var groups = sheet.Columns.GetGroups();
+        groups.Should().HaveCount(2);
+        groups[0].Should().Be(groups[0] with { Start = 0, End = 1 });
+        groups[0].Label.Should().Be("A");
+        groups[1].Start.Should().Be(2);
+        groups[1].End.Should().Be(6);
+        groups[1].Label.Should().Be("B");
+    }
+
+    [Test]
+    public void Adjacent_Groups_With_Same_Label_Stay_Separate()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(0, 1, "Same");
+        sheet.Columns.SetGroup(2, 3, "Same");
+
+        sheet.Columns.GetGroups().Should().HaveCount(2);
+    }
+
+    [Test]
+    public void Inserting_Columns_Inside_Group_Grows_It_And_Before_It_Shifts_It()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(2, 4, "G");
+
+        sheet.Columns.InsertAt(3, 2);
+        var g = sheet.Columns.GetGroups().Single();
+        g.Start.Should().Be(2);
+        g.End.Should().Be(6);
+
+        sheet.Columns.InsertAt(0, 1);
+        g = sheet.Columns.GetGroups().Single();
+        g.Start.Should().Be(3);
+        g.End.Should().Be(7);
+    }
+
+    [Test]
+    public void Removing_Columns_Inside_Group_Shrinks_It_And_Removing_All_Deletes_It()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(2, 4, "G");
+
+        sheet.Columns.RemoveAt(3, 1);
+        var g = sheet.Columns.GetGroups().Single();
+        g.Start.Should().Be(2);
+        g.End.Should().Be(3);
+
+        sheet.Columns.RemoveAt(2, 2);
+        sheet.Columns.HasGroups.Should().BeFalse();
+    }
+
+    [Test]
+    public void Setting_Group_Inside_Another_Splits_It_Into_Two_Groups_Sharing_A_Label()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(0, 4, "A");
+        sheet.Columns.SetGroup(2, 2, "B");
+
+        sheet.Columns.GetGroups().Select(g => (g.Start, g.End, g.Label))
+            .Should().Equal((0, 1, "A"), (2, 2, "B"), (3, 4, "A"));
+    }
+
+    [Test]
+    public void Undo_And_Redo_Restore_Groups()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(0, 2, "A");
+        sheet.Columns.SetGroup(1, 3, "B");
+
+        sheet.Commands.Undo();
+        var g = sheet.Columns.GetGroups().Single();
+        g.Start.Should().Be(0);
+        g.End.Should().Be(2);
+        g.Label.Should().Be("A");
+
+        sheet.Commands.Undo();
+        sheet.Columns.HasGroups.Should().BeFalse();
+
+        sheet.Commands.Redo();
+        sheet.Commands.Redo();
+        sheet.Columns.GetGroups().Select(x => x.Label).Should().Equal("A", "B");
+    }
+
+    [Test]
+    public void Clear_Groups_Removes_Overlapping_Groups_And_Is_Undoable()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(0, 1, "A");
+        sheet.Columns.SetGroup(2, 3, "B");
+
+        sheet.Columns.ClearGroups(1, 2);
+        sheet.Columns.HasGroups.Should().BeFalse();
+
+        sheet.Commands.Undo();
+        sheet.Columns.GetGroups().Select(x => x.Label).Should().Equal("A", "B");
+    }
+
+    [Test]
+    public void Total_Heading_Height_Includes_Group_Band_Only_When_Groups_Exist()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.HeadingHeight = 20;
+        sheet.Columns.GroupHeadingHeight = 30;
+        sheet.Columns.TotalHeadingHeight.Should().Be(20);
+
+        var sizeModified = 0;
+        sheet.Columns.SizeModified += (_, _) => sizeModified++;
+
+        sheet.Columns.SetGroup(0, 1, "A");
+        sheet.Columns.TotalHeadingHeight.Should().Be(50);
+        sizeModified.Should().Be(1);
+
+        sheet.Columns.SetGroup(3, 4, "B");
+        sizeModified.Should().Be(1, "the band was already visible");
+
+        sheet.Commands.Undo();
+        sheet.Commands.Undo();
+        sheet.Columns.TotalHeadingHeight.Should().Be(20);
+        sizeModified.Should().Be(2);
+    }
+
+    [Test]
+    public void Groups_Modified_Event_Fires_For_Column_Axis()
+    {
+        var sheet = new Sheet(5, 10);
+        Axis? axis = null;
+        sheet.Columns.GroupsModified += (_, e) => axis = e.Axis;
+        sheet.Columns.SetGroup(0, 1, "A");
+        axis.Should().Be(Axis.Col);
+    }
+
+    [Test]
+    public void Structural_Changes_Emit_Group_And_Heading_Size_Events()
+    {
+        var sheet = new Sheet(5, 10);
+        sheet.Columns.SetGroup(2, 4, "A");
+        var groupsModified = 0;
+        var sizeModified = 0;
+        sheet.Columns.GroupsModified += (_, _) => groupsModified++;
+        sheet.Columns.SizeModified += (_, _) => sizeModified++;
+
+        sheet.Columns.InsertAt(0);
+        groupsModified.Should().Be(1);
+        sheet.Columns.GetGroups().Single().Start.Should().Be(3);
+
+        sheet.Commands.Undo();
+        groupsModified.Should().Be(2);
+        sheet.Columns.GetGroups().Single().Start.Should().Be(2);
+
+        sheet.Columns.RemoveAt(2, 3);
+        groupsModified.Should().Be(3);
+        sizeModified.Should().Be(1, "removing the final group hides the group heading band");
+        sheet.Columns.HasGroups.Should().BeFalse();
+    }
+}

--- a/test/BlazorDatasheet.Test/SheetTests/SerializationTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SerializationTests.cs
@@ -21,6 +21,21 @@ namespace BlazorDatasheet.Test.SheetTests;
 public class SerializationTests
 {
     [Test]
+    public void Column_Groups_Round_Trip_Through_Serialization()
+    {
+        var wb = new Workbook();
+        var sheet = wb.AddSheet("SheetName", 5, 10);
+        sheet.Columns.SetGroup(0, 2, "Q1");
+        sheet.Columns.SetGroup(3, 5, "Q2");
+
+        var json = new SheetJsonSerializer().Serialize(wb);
+        var deserialized = new SheetJsonDeserializer().Deserialize(json);
+
+        var groups = deserialized.Sheets.First().Columns.GetGroups();
+        groups.Select(g => (g.Start, g.End, g.Label)).Should().Equal((0, 2, "Q1"), (3, 5, "Q2"));
+    }
+
+    [Test]
     public void Sheet_Serialization_Should_Serialize()
     {
         Assert.DoesNotThrow(() =>


### PR DESCRIPTION
Adds the ability to add custom column groups, which are rendered above standard headings.

For example:

```csharp
_sheet.Columns.SetGroup(0, 2, "Q1");
```

<img width="504" height="271" alt="image" src="https://github.com/user-attachments/assets/6ac12893-3cd3-40e4-bb35-71b27a4cfee0" />
