### PR TITLE
Add workbook named ranges and variable inspection APIs

### DIFF
--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using BlazorDatasheet.Core.Commands;
 using BlazorDatasheet.Core.Commands.Data;
 using BlazorDatasheet.Core.Commands.Formatting;
@@ -186,6 +186,10 @@ public class Sheet
     /// </summary>
     private bool _isBatchingChanges;
 
+    /// <summary>
+    /// Sheet-scoped view over the workbook's named ranges. Named ranges are workbook-wide;
+    /// see <see cref="Workbook.NamedRanges"/>.
+    /// </summary>
     public NamedRangeManager NamedRanges { get; }
 
     /// <summary>

--- a/src/BlazorDatasheet.Core/Data/Workbook.cs
+++ b/src/BlazorDatasheet.Core/Data/Workbook.cs
@@ -14,6 +14,11 @@ public class Workbook
     private readonly FormulaEngine.FormulaEngine _formulaEngine;
     internal WorkbookEnvironment Environment { get; }
 
+    /// <summary>
+    /// Named ranges defined in the workbook. Named ranges are workbook-wide.
+    /// </summary>
+    public NamedRangeManager NamedRanges { get; }
+
     public event EventHandler<WorkbookSheetAddedEventArgs>? SheetAdded;
     public event EventHandler<WorkbookSheetRemovedEventArgs>? SheetRemoved;
     public event EventHandler<WorkbookSheetRenamedEventArgs>? SheetRenamed;
@@ -35,6 +40,7 @@ public class Workbook
         var registry = BuildDefaultRegistry(options);
         Environment = new WorkbookEnvironment(this, registry);
         _formulaEngine = new FormulaEngine.FormulaEngine(Environment, options);
+        NamedRanges = new NamedRangeManager(this);
     }
 
     public static FunctionRegistry BuildDefaultRegistry(FormulaOptions? options)

--- a/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/FormulaEngine.cs
@@ -485,6 +485,112 @@ public class FormulaEngine
         }
     }
 
+    /// <summary>
+    /// Returns the names of all variables defined in the engine, including formula variables
+    /// and named ranges.
+    /// </summary>
+    public IReadOnlyList<string> GetVariableNames()
+    {
+        var names = new List<string>(_environment.GetVariableNames());
+        var seen = new HashSet<string>(names);
+        foreach (var vertex in DependencyManager.GetAllVertices())
+        {
+            if (vertex.VertexType == VertexType.Named && seen.Add(vertex.Key.Name))
+                names.Add(vertex.Key.Name);
+        }
+
+        return names;
+    }
+
+    /// <summary>
+    /// Whether a variable with the name <paramref name="varName"/> is defined.
+    /// </summary>
+    public bool VariableExists(string varName)
+    {
+        return _environment.VariableExists(varName) || DependencyManager.GetVertex(varName) != null;
+    }
+
+    /// <summary>
+    /// Returns a detached snapshot describing the variable <paramref name="varName"/>, or null if the
+    /// variable is not defined.
+    /// </summary>
+    public VariableInfo? GetVariableInfo(string varName)
+    {
+        var vertex = DependencyManager.GetVertex(varName);
+        var hasValue = _environment.TryGetVariable(varName, out var value);
+        if (!hasValue && vertex == null)
+            return null;
+
+        if (!hasValue)
+            value = CellValue.Empty;
+        else
+            value = DetachCellValue(value);
+
+        var formula = vertex?.Formula;
+        var references = formula == null
+            ? Array.Empty<Reference>()
+            : formula.References.Select(r => r.Copy()).ToArray();
+
+        // The stored value of a formula variable is the resolved value (e.g. an array for a range), so
+        // to discover whether the variable *is* a range we evaluate the formula without resolving references.
+        IRegion? region = null;
+        string? sheetName = null;
+        if (formula != null)
+        {
+            var unresolved = EvaluateFormula(formula, resolveReferences: false);
+            if (unresolved.ValueType == CellValueType.Reference &&
+                unresolved.GetValue<Reference>() is { Region: not null } reference)
+            {
+                region = reference.Region.Clone();
+                sheetName = reference.SheetName;
+            }
+            else if (formula.IsReferenceFormula() && references is [var storedReference])
+            {
+                // A named range remains a named range after its reference is invalidated. Keeping the
+                // last region and sheet allows it to remain discoverable and clearable as "=#REF!".
+                region = storedReference.Region.Clone();
+                sheetName = storedReference.SheetName;
+            }
+        }
+
+        return new VariableInfo(
+            varName,
+            formula == null ? VariableKind.Value : VariableKind.Formula,
+            formula?.ToFormulaString(),
+            value,
+            references,
+            region,
+            sheetName);
+    }
+
+    private static CellValue DetachCellValue(CellValue value)
+    {
+        return value.ValueType switch
+        {
+            CellValueType.Array => CellValue.Array(value.GetValue<CellValue[][]>()!
+                .Select(row => row.Select(DetachCellValue).ToArray()).ToArray()),
+            CellValueType.Sequence => CellValue.Sequence(value.GetValue<CellValue[]>()!
+                .Select(DetachCellValue).ToArray()),
+            CellValueType.Reference => CellValue.Reference(value.GetValue<Reference>()!.Copy()),
+            _ => value
+        };
+    }
+
+    /// <summary>
+    /// Returns detached snapshots of all variables defined in the engine.
+    /// </summary>
+    public IReadOnlyList<VariableInfo> GetVariableInfos()
+    {
+        var infos = new List<VariableInfo>();
+        foreach (var name in GetVariableNames())
+        {
+            if (GetVariableInfo(name) is { } info)
+                infos.Add(info);
+        }
+
+        return infos;
+    }
+
     public void ClearVariable(string varName)
     {
         QueueVariableChange(varName, true);

--- a/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
+++ b/src/BlazorDatasheet.Core/FormulaEngine/NamedRangeManager.cs
@@ -1,70 +1,103 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.Formula.Core;
-using BlazorDatasheet.Formula.Core.Interpreter;
-using BlazorDatasheet.Formula.Core.Interpreter.References;
 
 namespace BlazorDatasheet.Core.FormulaEngine;
 
+/// <summary>
+/// Manages named ranges for a workbook. Named ranges are workbook-wide variables whose value is a
+/// reference to a range; the formula engine is the single source of truth for them.
+/// </summary>
 public class NamedRangeManager
 {
-    private readonly Sheet _sheet;
+    private readonly Workbook? _workbook;
+    private readonly Sheet? _sheet;
+
+    public NamedRangeManager(Workbook workbook)
+    {
+        _workbook = workbook;
+    }
 
     /// <summary>
-    /// Stores named ranges - we store in a computed formula rather than a range to allow for dynamic ranges
+    /// Creates a sheet-scoped view of the workbook's named ranges. This constructor is retained for
+    /// compatibility; named ranges themselves remain workbook-wide.
     /// </summary>
-    private Dictionary<string, CellFormula> _namedRanges = new();
-
     public NamedRangeManager(Sheet sheet)
     {
         _sheet = sheet;
     }
 
+    private Workbook Workbook => _sheet?.Workbook ?? _workbook!;
+    private FormulaEngine Engine => Workbook.GetFormulaEngine();
+
     /// <summary>
     /// Set a named range.
     /// </summary>
-    /// <param name="name"></param>
-    /// <param name="rangeString"></param>
+    /// <param name="name">The name of the range.</param>
+    /// <param name="rangeString">The range, e.g. "A1:B2" or "Sheet2!A1:B2".</param>
     /// <returns>Whether the name was set successfully.</returns>
-    public bool Set(string name, string rangeString)
+    public bool Set(string name, string rangeString) => Set(name, rangeString, null);
+
+    /// <summary>
+    /// Set a named range, resolving un-qualified ranges against <paramref name="callingSheetName"/>.
+    /// </summary>
+    public bool Set(string name, string rangeString, string? callingSheetName)
     {
         if (string.IsNullOrEmpty(rangeString))
             return false;
 
         if (!RangeText.IsValidName(name))
-        {
             return false;
-        }
 
-        if (_namedRanges.ContainsKey(name))
-            Clear(name);
+        callingSheetName ??= _sheet?.Name ?? Workbook.Sheets.FirstOrDefault()?.Name;
+        if (callingSheetName == null)
+            return false;
 
-        var rangeStrFormula = $"={rangeString}";
-        var formula = _sheet.FormulaEngine.ParseFormula(rangeStrFormula, _sheet.Name, true);
+        var formula = Engine.ParseFormula($"={rangeString}", callingSheetName, true);
+        var evaluatedValue = Engine.EvaluateFormula(formula, resolveReferences: false);
+        if (evaluatedValue.ValueType != CellValueType.Reference ||
+            evaluatedValue.GetValue<Formula.Core.Interpreter.References.Reference>()?.Region == null)
+            return false;
 
-        var evaluatedValue = _sheet.FormulaEngine.EvaluateFormula(formula, resolveReferences: false);
-        if (evaluatedValue.ValueType == CellValueType.Reference && evaluatedValue.GetValue<Reference>()?.Region != null)
-        {
-            _sheet.FormulaEngine.SetVariable(name, formula.ToFormulaString());
-            _namedRanges[name] = _sheet.FormulaEngine.DependencyManager.GetVertex(name)!.Formula!;
-
-            return true;
-        }
-
-        return false;
+        Engine.SetVariable(name, formula.ToFormulaString());
+        return true;
     }
 
     /// <summary>
-    /// Clears a named range.
+    /// Clears a named range. Variables that are not named ranges are left untouched.
     /// </summary>
     /// <param name="name"></param>
     public void Clear(string name)
     {
-        if (_namedRanges.ContainsKey(name))
-        {
-            _namedRanges.Remove(name);
-            _sheet.FormulaEngine.ClearVariable(name);
-        }
+        if (IsNamedRange(name))
+            Engine.ClearVariable(name);
+    }
+
+    /// <summary>
+    /// Whether a named range with the name <paramref name="name"/> exists.
+    /// </summary>
+    public bool IsNamedRange(string name)
+    {
+        return Engine.GetVariableInfo(name)?.IsRange == true;
+    }
+
+    /// <summary>
+    /// Returns the names of all named ranges in the workbook.
+    /// </summary>
+    public IReadOnlyList<string> GetNames()
+    {
+        return Engine.GetVariableInfos().Where(x => x.IsRange).Select(x => x.Name).ToList();
+    }
+
+    /// <summary>
+    /// Returns detached snapshots of all named ranges in the workbook.
+    /// </summary>
+    public IReadOnlyList<VariableInfo> GetAll()
+    {
+        var ranges = Engine.GetVariableInfos().Where(x => x.IsRange);
+        if (_sheet != null)
+            ranges = ranges.Where(x => x.SheetName == _sheet.Name);
+        return ranges.ToList();
     }
 
     /// <summary>
@@ -72,35 +105,39 @@ public class NamedRangeManager
     /// </summary>
     /// <param name="region"></param>
     /// <returns></returns>
-    public string? GetRegionName(IRegion region)
+    public string? GetRegionName(IRegion region) => GetRegionName(region, null);
+
+    /// <summary>
+    /// Returns the name for the region on <paramref name="sheetName"/>, if any.
+    /// </summary>
+    public string? GetRegionName(IRegion region, string? sheetName)
     {
-        foreach (var kp in _namedRanges)
+        sheetName ??= _sheet?.Name;
+        foreach (var info in Engine.GetVariableInfos())
         {
-            var formula = kp.Value;
-            if (formula.References.Count() == 1)
-            {
-                if (formula.References.First().Region.Equals(region))
-                {
-                    return kp.Key;
-                }
-            }
+            if (!info.IsRange || info.References.Count != 1)
+                continue;
+            if (sheetName != null && info.SheetName != sheetName)
+                continue;
+            if (!info.References[0].IsInvalid && info.References[0].Region.Equals(region))
+                return info.Name;
         }
 
         return null;
     }
 
     /// <summary>
-    /// Returns the named range <paramref name="name"/> as  as string.
+    /// Returns the named range <paramref name="name"/> as a string, e.g. "Sheet1!A1:B2".
+    /// Returns null if the name is not a named range.
     /// </summary>
     /// <param name="name"></param>
     /// <returns></returns>
     public string? GetRangeString(string name)
     {
-        if (_namedRanges.TryGetValue(name, out var formula))
-        {
-            return formula.ToFormulaString(includeEquals: false);
-        }
+        var info = Engine.GetVariableInfo(name);
+        if (info is not { IsRange: true, Formula: not null })
+            return null;
 
-        return null;
+        return info.Formula.StartsWith('=') ? info.Formula.Substring(1) : info.Formula;
     }
 }

--- a/src/BlazorDatasheet.Formula.Core/Interpreter/CellFormula.cs
+++ b/src/BlazorDatasheet.Formula.Core/Interpreter/CellFormula.cs
@@ -24,6 +24,18 @@ public class CellFormula
         return !ExpressionTree.Errors.Any();
     }
 
+    /// <summary>
+    /// Returns whether the formula consists solely of a cell or range reference, optionally wrapped
+    /// in parentheses. Invalidated references still count as reference formulas.
+    /// </summary>
+    public bool IsReferenceFormula()
+    {
+        Expression expression = ExpressionTree.Root;
+        while (expression is ParenthesizedExpression parenthesized)
+            expression = parenthesized.Expression;
+        return expression is ReferenceExpression;
+    }
+
     public string ToFormulaString(bool includeEquals = true)
     {
         return includeEquals ? $"={ExpressionTree.Root.ToExpressionText()}" : ExpressionTree.Root.ToExpressionText();

--- a/src/BlazorDatasheet.Formula.Core/VariableInfo.cs
+++ b/src/BlazorDatasheet.Formula.Core/VariableInfo.cs
@@ -1,0 +1,87 @@
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Formula.Core.Interpreter.References;
+
+namespace BlazorDatasheet.Formula.Core;
+
+/// <summary>
+/// Describes how a variable is defined.
+/// </summary>
+public enum VariableKind
+{
+    /// <summary>
+    /// The variable holds a literal value that was set directly.
+    /// </summary>
+    Value,
+
+    /// <summary>
+    /// The variable is defined by a formula, and its value is the calculated result of that formula.
+    /// </summary>
+    Formula
+}
+
+/// <summary>
+/// A read-only snapshot of a variable defined in the formula engine. References, regions, arrays and
+/// sequences are detached from the engine. Mutable custom objects stored in a <see cref="CellValue"/>
+/// remain the caller's responsibility.
+/// </summary>
+public sealed class VariableInfo
+{
+    /// <summary>
+    /// The name of the variable.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Whether the variable is a literal value or defined by a formula.
+    /// </summary>
+    public VariableKind Kind { get; }
+
+    /// <summary>
+    /// The formula string (including the leading '='), or null if the variable is a literal value.
+    /// </summary>
+    public string? Formula { get; }
+
+    /// <summary>
+    /// The current value of the variable. For formula variables this is the calculated result.
+    /// </summary>
+    public CellValue Value { get; }
+
+    /// <summary>
+    /// The type of the current value.
+    /// </summary>
+    public CellValueType ValueType => Value.ValueType;
+
+    /// <summary>
+    /// True if the variable's formula resolves to a range/cell reference, i.e. it is a named range.
+    /// The <see cref="Value"/> of a named range is the resolved value of the range (e.g. an array), and
+    /// the range itself is described by <see cref="Region"/> and <see cref="SheetName"/>.
+    /// </summary>
+    public bool IsRange => Region != null;
+
+    /// <summary>
+    /// Detached copies of the references used in the variable's formula. Empty for literal values.
+    /// </summary>
+    public IReadOnlyList<Reference> References { get; }
+
+    /// <summary>
+    /// The region the variable resolves to when <see cref="IsRange"/> is true, otherwise null.
+    /// </summary>
+    public IRegion? Region { get; }
+
+    /// <summary>
+    /// The sheet the variable's range is on when <see cref="IsRange"/> is true, otherwise null.
+    /// </summary>
+    public string? SheetName { get; }
+
+    public VariableInfo(string name, VariableKind kind, string? formula, CellValue value,
+        IReadOnlyList<Reference> references, IRegion? region, string? sheetName)
+    {
+        Name = name;
+        Kind = kind;
+        Formula = formula;
+        Value = value;
+        References = references;
+        Region = region;
+        SheetName = sheetName;
+    }
+}

--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Formula/VariableManagerExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Formula/VariableManagerExample.razor
@@ -1,0 +1,96 @@
+@using BlazorDatasheet.Core.Data
+@using BlazorDatasheet.Core.Events.Formula
+@using BlazorDatasheet.Formula.Core
+@implements IDisposable
+
+<div style="display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-start">
+    <div style="width: 320px; height: 220px; overflow: auto">
+        <Datasheet Sheet="_sheet"/>
+    </div>
+
+    <div>
+        <table style="border-collapse: collapse; font-size: 0.9em">
+            <thead>
+            <tr>
+                <th style="text-align: left; padding: 2px 8px">Name</th>
+                <th style="text-align: left; padding: 2px 8px">Kind</th>
+                <th style="text-align: left; padding: 2px 8px">Type</th>
+                <th style="text-align: left; padding: 2px 8px">Formula</th>
+                <th style="text-align: left; padding: 2px 8px">Value</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach (var variable in _sheet.FormulaEngine.GetVariableInfos())
+            {
+                <tr>
+                    <td style="padding: 2px 8px">@variable.Name</td>
+                    <td style="padding: 2px 8px">@variable.Kind</td>
+                    <td style="padding: 2px 8px">@(variable.IsRange ? "Range" : variable.ValueType.ToString())</td>
+                    <td style="padding: 2px 8px"><code>@variable.Formula</code></td>
+                    <td style="padding: 2px 8px">@FormatValue(variable)</td>
+                    <td style="padding: 2px 8px">
+                        <button @onclick="() => _sheet.FormulaEngine.ClearVariable(variable.Name)">Delete</button>
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+
+        <div style="margin-top: 8px; display: flex; gap: 4px">
+            <input type="text" placeholder="Name" @bind="_newName" style="width: 80px"/>
+            <input type="text" placeholder="Value or =formula" @bind="_newValue" style="width: 160px"/>
+            <button @onclick="SetVariable">Set</button>
+        </div>
+    </div>
+</div>
+
+@code {
+
+    private Sheet _sheet = null!;
+    private string _newName = string.Empty;
+    private string _newValue = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        var workbook = new Workbook();
+        _sheet = workbook.AddSheet(8, 4);
+        _sheet.Cells.SetValues(0, 0, new object[][] { [1], [2], [3] });
+        _sheet.Cells.SetFormula(0, 2, "=SUM(prices) * rate");
+
+        _sheet.FormulaEngine.SetVariable("rate", 1.5);
+        _sheet.FormulaEngine.SetVariable("total", "=SUM(Sheet1!A1:A3)");
+        _sheet.NamedRanges.Set("prices", "A1:A3");
+
+        _sheet.FormulaEngine.VariableChanged += OnVariableChanged;
+    }
+
+    private void OnVariableChanged(object? sender, VariableChangedEventArgs e) => StateHasChanged();
+
+    private void SetVariable()
+    {
+        if (string.IsNullOrWhiteSpace(_newName))
+            return;
+
+        var trimmed = _newValue.Trim();
+        if (BlazorDatasheet.Core.FormulaEngine.FormulaEngine.IsFormula(trimmed))
+            _sheet.FormulaEngine.SetVariable(_newName, trimmed);
+        else if (double.TryParse(trimmed, out var number))
+            _sheet.FormulaEngine.SetVariable(_newName, number);
+        else
+            _sheet.FormulaEngine.SetVariable(_newName, trimmed);
+    }
+
+    private static string FormatValue(VariableInfo variable)
+    {
+        if (variable.IsRange)
+            return $"{variable.SheetName}!{RangeText.RegionToText(variable.Region!)}";
+        return variable.Value.ToString() ?? string.Empty;
+    }
+
+    public void Dispose()
+    {
+        _sheet.FormulaEngine.VariableChanged -= OnVariableChanged;
+    }
+
+}

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/NamedVariablesAndRanges.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/NamedVariablesAndRanges.razor
@@ -20,8 +20,9 @@
 <h4>Named ranges</h4>
 
 <div class="block">
-    Named ranges can be set and cleared through the sheet's NamedRanges property. The ranges are shifted appropriately
-    when rows or columns are inserted/deleted.
+    Named ranges are workbook-wide and can be set and cleared through the workbook's <code>NamedRanges</code> property,
+    or through a sheet's <code>NamedRanges</code> property which resolves un-qualified ranges against that sheet.
+    The ranges are shifted appropriately when rows or columns are inserted/deleted.
 </div>
 
 <div class="block">
@@ -29,6 +30,18 @@
 </div>
 
 <CodeExample ComponentType="typeof(NamedRangeExample)"/>
+
+<h4>Inspecting variables</h4>
+
+<div class="block">
+    All variables can be enumerated through <code>FormulaEngine.GetVariableInfos()</code>. Each
+    <code>VariableInfo</code> is a detached snapshot describing whether the variable is a literal value or a formula,
+    its current value, the formula string, its references and, for named ranges, the region and sheet it resolves to.
+    Subscribe to <code>FormulaEngine.VariableChanged</code> to be notified when variables are added, updated, removed
+    or recalculated. This is enough to build a variable or named range manager UI, as in the example below.
+</div>
+
+<CodeExample ComponentType="typeof(VariableManagerExample)"/>
 
 
 @code {

--- a/test/BlazorDatasheet.Test/Formula/VariableInfoTests.cs
+++ b/test/BlazorDatasheet.Test/Formula/VariableInfoTests.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Serialization.Json;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Formula.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Formula;
+
+public class VariableInfoTests
+{
+    private Workbook _workbook = null!;
+    private Sheet _sheet = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _workbook = new Workbook();
+        _sheet = _workbook.AddSheet(10, 10);
+    }
+
+    [Test]
+    public void Value_Variable_Info_Is_Value_Kind()
+    {
+        _sheet.FormulaEngine.SetVariable("x", 5);
+        var info = _sheet.FormulaEngine.GetVariableInfo("x");
+        info.Should().NotBeNull();
+        info!.Name.Should().Be("x");
+        info.Kind.Should().Be(VariableKind.Value);
+        info.Formula.Should().BeNull();
+        info.References.Should().BeEmpty();
+        info.IsRange.Should().BeFalse();
+        info.Region.Should().BeNull();
+        info.SheetName.Should().BeNull();
+        info.ValueType.Should().Be(CellValueType.Number);
+        info.Value.GetValue<double>().Should().Be(5);
+    }
+
+    [Test]
+    public void Formula_Variable_Info_Reflects_Formula_And_Recalculation()
+    {
+        _sheet.Cells.SetValue(0, 0, 2);
+        _sheet.FormulaEngine.SetVariable("y", "=Sheet1!A1*2");
+
+        var info = _sheet.FormulaEngine.GetVariableInfo("y")!;
+        info.Kind.Should().Be(VariableKind.Formula);
+        info.Formula.Should().Be("=Sheet1!A1*2");
+        info.References.Should().HaveCount(1);
+        info.IsRange.Should().BeFalse();
+        info.Value.GetValue<double>().Should().Be(4);
+
+        _sheet.Cells.SetValue(0, 0, 3);
+        _sheet.FormulaEngine.GetVariableInfo("y")!.Value.GetValue<double>().Should().Be(6);
+    }
+
+    [Test]
+    public void Named_Range_Info_Is_Range_With_Region_And_Sheet()
+    {
+        _sheet.NamedRanges.Set("r", "A1:B2").Should().BeTrue();
+        var info = _sheet.FormulaEngine.GetVariableInfo("r")!;
+        info.Kind.Should().Be(VariableKind.Formula);
+        info.IsRange.Should().BeTrue();
+        info.Region.Should().BeEquivalentTo(new Region(0, 1, 0, 1));
+        info.SheetName.Should().Be("Sheet1");
+        _sheet.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+        _workbook.NamedRanges.IsNamedRange("r").Should().BeTrue();
+    }
+
+    [Test]
+    public void GetVariableNames_And_VariableExists_Track_Set_And_Clear()
+    {
+        _sheet.FormulaEngine.SetVariable("x", 5);
+        _sheet.FormulaEngine.SetVariable("y", "=Sheet1!A1*2");
+        _sheet.NamedRanges.Set("r", "A1:B2");
+
+        _sheet.FormulaEngine.GetVariableNames().Should().BeEquivalentTo("x", "y", "r");
+        _sheet.FormulaEngine.GetVariableInfos().Select(v => v.Name).Should().BeEquivalentTo("x", "y", "r");
+        _workbook.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+        _sheet.FormulaEngine.VariableExists("x").Should().BeTrue();
+        _sheet.FormulaEngine.VariableExists("nope").Should().BeFalse();
+        _sheet.FormulaEngine.GetVariableInfo("nope").Should().BeNull();
+
+        _sheet.FormulaEngine.ClearVariable("x");
+        _sheet.FormulaEngine.VariableExists("x").Should().BeFalse();
+        _sheet.FormulaEngine.GetVariableNames().Should().BeEquivalentTo("y", "r");
+    }
+
+    [Test]
+    public void NamedRanges_Clear_Leaves_Non_Range_Variables_Alone()
+    {
+        _sheet.FormulaEngine.SetVariable("x", 5);
+        _sheet.NamedRanges.Clear("x");
+        _sheet.FormulaEngine.VariableExists("x").Should().BeTrue();
+    }
+
+    [Test]
+    public void Invalidated_Named_Range_Remains_Discoverable_And_Can_Be_Cleared()
+    {
+        _sheet.NamedRanges.Set("r", "A1");
+
+        _sheet.Rows.RemoveAt(0);
+
+        _sheet.NamedRanges.IsNamedRange("r").Should().BeTrue();
+        _sheet.NamedRanges.GetNames().Should().Contain("r");
+        _sheet.NamedRanges.GetRangeString("r").Should().Be("#REF!");
+
+        _sheet.NamedRanges.Clear("r");
+        _sheet.FormulaEngine.VariableExists("r").Should().BeFalse();
+    }
+
+    [Test]
+    public void Variable_Info_Is_Detached_From_Engine()
+    {
+        _sheet.Cells.SetValue(0, 0, 1);
+        _sheet.Cells.SetValue(1, 0, 2);
+        _sheet.NamedRanges.Set("r", "A1:B2");
+        var info = _sheet.FormulaEngine.GetVariableInfo("r")!;
+        info.References[0].Shift(5, 5);
+        info.Region!.Shift(5, 5);
+        info.Value.GetValue<CellValue[][]>()![0][0] = CellValue.Number(99);
+
+        var again = _sheet.FormulaEngine.GetVariableInfo("r")!;
+        again.Formula.Should().Be("=Sheet1!A1:B2");
+        again.Region.Should().BeEquivalentTo(new Region(0, 1, 0, 1));
+        again.Value.GetValue<CellValue[][]>()![0][0].GetValue<double>().Should().Be(1);
+        _sheet.NamedRanges.GetRangeString("r").Should().Be("Sheet1!A1:B2");
+    }
+
+    [Test]
+    public void Named_Ranges_Are_Workbook_Wide()
+    {
+        var sheet2 = _workbook.AddSheet(10, 10);
+        _sheet.NamedRanges.Set("r", "A1:B2");
+
+        _workbook.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+        sheet2.NamedRanges.GetRangeString("r").Should().Be("Sheet1!A1:B2");
+        sheet2.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+
+        // sheet-scoped views only list ranges on their own sheet and only match regions on their own sheet
+        _sheet.NamedRanges.GetAll().Select(x => x.Name).Should().BeEquivalentTo("r");
+        sheet2.NamedRanges.GetAll().Should().BeEmpty();
+        _sheet.NamedRanges.GetRegionName(new Region(0, 1, 0, 1)).Should().Be("r");
+        sheet2.NamedRanges.GetRegionName(new Region(0, 1, 0, 1)).Should().BeNull();
+
+        // setting the same name from another sheet replaces it
+        sheet2.NamedRanges.Set("r", "C3");
+        _sheet.NamedRanges.GetRangeString("r").Should().Be("Sheet2!C3");
+        _workbook.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+        _workbook.NamedRanges.GetAll().Single().SheetName.Should().Be("Sheet2");
+    }
+
+    [Test]
+    public void Named_Range_Set_On_Workbook_Defaults_To_First_Sheet()
+    {
+        _workbook.NamedRanges.Set("r", "A1").Should().BeTrue();
+        _workbook.NamedRanges.GetRangeString("r").Should().Be("Sheet1!A1");
+        _workbook.NamedRanges.Set("bad", "A_1").Should().BeFalse();
+        _workbook.NamedRanges.Set("1bad", "A1").Should().BeFalse();
+    }
+
+    [Test]
+    public void Named_Ranges_Survive_Serialization_Round_Trip()
+    {
+        _sheet.NamedRanges.Set("r", "A1:B2");
+        _sheet.FormulaEngine.SetVariable("x", 5);
+
+        var json = new SheetJsonSerializer().Serialize(_workbook);
+        var restored = new SheetJsonDeserializer().Deserialize(json);
+
+        restored.NamedRanges.GetNames().Should().BeEquivalentTo("r");
+        restored.NamedRanges.GetRangeString("r").Should().Be("Sheet1!A1:B2");
+        restored.Sheets.First().NamedRanges.GetRegionName(new Region(0, 1, 0, 1)).Should().Be("r");
+        restored.GetFormulaEngine().GetVariableInfo("x")!.Kind.Should().Be(VariableKind.Value);
+    }
+}


### PR DESCRIPTION
Adds workbook-wide named range management and public formula-variable inspection APIs.
Named ranges can now be managed through Workbook.NamedRanges.

- Add Workbook.NamedRanges.
- Preserve the existing Sheet.NamedRanges public API and method signatures.
- Make named ranges workbook-wide across all sheets.
- Add FormulaEngine APIs to enumerate and inspect variables:
  - GetVariableNames()
  - VariableExists()
  - GetVariableInfo()
  - GetVariableInfos()
- Preserve named ranges and ordinary variables through serialization.