### PR TITLE
Fixes some screen updating issues

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/CommandGroup.cs
+++ b/src/BlazorDatasheet.Core/Commands/CommandGroup.cs
@@ -37,8 +37,7 @@ public class CommandGroup : BaseCommand, IUndoableCommand
     {
         _successfulCommands.Clear();
 
-        sheet.ScreenUpdating = false;
-        sheet.BatchUpdates();
+        using var updates = sheet.SuspendUpdates();
         foreach (var command in _commands)
         {
             var run = sheet.Commands.ExecuteCommand(command, isRedo: false, useUndo: false);
@@ -52,29 +51,22 @@ public class CommandGroup : BaseCommand, IUndoableCommand
                 _successfulCommands.Add(command);
         }
 
-        sheet.EndBatchUpdates();
-        sheet.ScreenUpdating = true;
-
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
+        using var updates = sheet.SuspendUpdates();
         var undo = true;
         var undoCommands =
             _successfulCommands
                 .Where(cmd => cmd is IUndoableCommand).Cast<IUndoableCommand>().ToList();
 
         undoCommands.Reverse();
-        sheet.BatchUpdates();
         foreach (var command in undoCommands)
         {
             undo &= command.Undo(sheet);
         }
-
-        sheet.EndBatchUpdates();
-        sheet.ScreenUpdating = true;
 
         return undo;
     }

--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValueCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValueCommand.cs
@@ -32,20 +32,16 @@ public class SetCellValueCommand : BaseCommand, IUndoableCommand
 
     public override bool Execute(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
-        sheet.BatchUpdates();
+        using var updates = sheet.SuspendUpdates();
         _restoreData = sheet.Cells.SetValueImpl(Row, Col, Value);
         sheet.MarkDirty(Row, Col);
-        sheet.EndBatchUpdates();
-        sheet.ScreenUpdating = true;
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
+        using var updates = sheet.SuspendUpdates();
         sheet.Cells.Restore(_restoreData);
-        sheet.ScreenUpdating = true;
         return true;
     }
 }

--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
@@ -57,11 +57,8 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
 
     public override bool Execute(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
-        sheet.BatchUpdates();
+        using var updates = sheet.SuspendUpdates();
         ExecuteSetCellValueData(sheet);
-        sheet.EndBatchUpdates();
-        sheet.ScreenUpdating = true;
 
         return true;
     }
@@ -100,11 +97,8 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
 
     public bool Undo(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
-        sheet.BatchUpdates();
+        using var updates = sheet.SuspendUpdates();
         sheet.Cells.Restore(_restoreData);
-        sheet.EndBatchUpdates();
-        sheet.ScreenUpdating = true;
         return true;
     }
 }

--- a/src/BlazorDatasheet.Core/Commands/RowCols/InsertRowsColsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/InsertRowsColsCommand.cs
@@ -42,12 +42,11 @@ internal class InsertRowsColsCommand : BaseCommand, IUndoableCommand
 
     public override bool Execute(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
+        using var updates = sheet.SuspendUpdates();
         sheet.Add(_axis, _count);
         _validatorRestoreData = sheet.Validators.Store.InsertRowColAt(_index, _count, _axis);
         _cellStoreRestoreData = sheet.Cells.InsertRowColAt(_index, _count, _axis);
         _cfRestoreData = sheet.ConditionalFormats.InsertRowColAt(_index, _count, _axis);
-        _rowColInfoRestoreData = sheet.GetRowColStore(_axis).InsertImpl(_index, _count);
         _metaDataStore = sheet.Cells.GetMetaDataStore().InsertRowColAt(_index, _count, _axis);
 
         if (_axis == Axis.Col)
@@ -55,28 +54,28 @@ internal class InsertRowsColsCommand : BaseCommand, IUndoableCommand
             _filterRestoreData = sheet.Columns.Filters.Store.InsertAt(_index, _count);
         }
 
-        sheet.ScreenUpdating = true;
+        _rowColInfoRestoreData = sheet.GetRowColStore(_axis).InsertImpl(_index, _count);
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
-        sheet.ScreenUpdating = false;
+        using var updates = sheet.SuspendUpdates();
         sheet.Remove(_axis, _count);
         sheet.Validators.Store.Restore(_validatorRestoreData);
         sheet.Cells.GetMetaDataStore().Restore(_metaDataStore);
         sheet.Cells.Restore(_cellStoreRestoreData);
         sheet.ConditionalFormats.Restore(_cfRestoreData);
         sheet.GetRowColStore(_axis).Restore(_rowColInfoRestoreData);
-        sheet.GetRowColStore(_axis).EmitRemoved(_index, _count);
         if (_axis == Axis.Col)
             sheet.Columns.Filters.Store.Restore(_filterRestoreData);
+
+        sheet.GetRowColStore(_axis).EmitRemoved(_index, _count);
 
         IRegion dirtyRegion = _axis == Axis.Col
             ? new ColumnRegion(_index, sheet.NumCols)
             : new RowRegion(_index, sheet.NumRows);
         sheet.MarkDirty(dirtyRegion);
-        sheet.ScreenUpdating = true;
         return true;
     }
 }

--- a/src/BlazorDatasheet.Core/Commands/RowCols/RemoveRowColsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/RemoveRowColsCommand.cs
@@ -57,11 +57,11 @@ public class RemoveRowColsCommand : BaseCommand, IUndoableCommand
         if (_count <= 0)
             return false;
 
+        using var updates = sheet.SuspendUpdates();
         _nRemoved = Math.Min(sheet.GetSize(_axis) - _index, _count);
         sheet.Remove(_axis, _nRemoved);
 
         _cellStoreRestoreData = sheet.Cells.RemoveRowColAt(_index, _nRemoved, _axis);
-        _rowColInfoRestore = sheet.GetRowColStore(_axis).RemoveImpl(_index, _index + _nRemoved - 1);
         _validatorRestoreData = sheet.Validators.Store.RemoveRowColAt(_index, _nRemoved, _axis);
         _cfRestoreData = sheet.ConditionalFormats.RemoveRowColAt(_index, _nRemoved, _axis);
         _metaDataRestoreData = sheet.Cells.GetMetaDataStore().RemoveRowColAt(_index, _nRemoved, _axis);
@@ -69,20 +69,23 @@ public class RemoveRowColsCommand : BaseCommand, IUndoableCommand
         if (_axis == Axis.Col)
             _filterRestoreData = sheet.Columns.Filters.Store.Delete(_index, _index + _nRemoved - 1);
 
+        _rowColInfoRestore = sheet.GetRowColStore(_axis).RemoveImpl(_index, _index + _nRemoved - 1);
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
+        using var updates = sheet.SuspendUpdates();
         sheet.Add(_axis, _nRemoved);
         sheet.Validators.Store.Restore(_validatorRestoreData);
         sheet.Cells.Restore(_cellStoreRestoreData);
         sheet.GetRowColStore(_axis).Restore(_rowColInfoRestore);
         sheet.ConditionalFormats.Restore(_cfRestoreData);
         sheet.Cells.GetMetaDataStore().Restore(_metaDataRestoreData);
-        sheet.GetRowColStore(_axis).EmitInserted(_index, _nRemoved);
         if (_axis == Axis.Col)
             sheet.Columns.Filters.Store.Restore(_filterRestoreData);
+
+        sheet.GetRowColStore(_axis).EmitInserted(_index, _nRemoved);
 
         IRegion dirtyRegion = _axis == Axis.Col
             ? new ColumnRegion(_index, sheet.NumCols)

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.Events.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.Events.cs
@@ -40,13 +40,18 @@ public partial class CellStore
 
     internal void EndBatchChanges()
     {
-        if (_cellsChanged.Count > 0 || _regionsChanged.Count > 0 && _isBatchingChanges)
+        try
         {
-            var args = new CellDataChangedEventArgs(_regionsChanged, _cellsChanged);
-            CellsChanged?.Invoke(this, args);
+            if (_isBatchingChanges && (_cellsChanged.Count > 0 || _regionsChanged.Count > 0))
+            {
+                var args = new CellDataChangedEventArgs(_regionsChanged, _cellsChanged);
+                CellsChanged?.Invoke(this, args);
+            }
         }
-
-        _isBatchingChanges = false;
+        finally
+        {
+            _isBatchingChanges = false;
+        }
     }
 
     /// <summary>

--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -141,6 +141,8 @@ public class Sheet
             {
                 _screenUpdating = value;
                 ScreenUpdatingChanged?.Invoke(this, new SheetScreenUpdatingEventArgs(value));
+                if (value)
+                    EmitSheetDirty();
             }
         }
     }
@@ -444,6 +446,9 @@ public class Sheet
 
     private void EmitSheetDirty()
     {
+        if (!ScreenUpdating || _isBatchingChanges || !_dirtyRows.Any())
+            return;
+
         SheetDirty?.Invoke(this, new()
         {
             DirtyRows = _dirtyRows,
@@ -465,7 +470,7 @@ public class Sheet
     /// <summary>
     /// Batches dirty cell and region additions, as well as cell value changes to emit events once rather
     /// than every time a cell is dirty or a value is changed.
-    /// <returns>Returns false if the sheet was already batching, true otherwise.</returns>
+    /// Nested calls must each be paired with a call to EndBatchUpdates.
     /// </summary>
     public void BatchUpdates()
     {
@@ -474,7 +479,6 @@ public class Sheet
         if (_isBatchingChanges)
             return;
 
-        ClearDirty();
         Cells.BatchChanges();
         _isBatchingChanges = true;
     }
@@ -503,19 +507,66 @@ public class Sheet
     /// </summary>
     public void EndBatchUpdates()
     {
-        _batchRequestNo--;
-
-        if (_batchRequestNo > 0)
+        if (_batchRequestNo == 0)
             return;
 
-        Cells.EndBatchChanges();
+        if (_batchRequestNo > 1)
+        {
+            _batchRequestNo--;
+            return;
+        }
 
-        // Checks for batching changes here, because the cells changed event
-        // may start batching more dirty changes again from subscribers of that event.
-        if (_dirtyRows.Any() && _isBatchingChanges)
+        // Keep the outer batch active while cell-change subscribers perform nested work.
+        try
+        {
+            Cells.EndBatchChanges();
+        }
+        finally
+        {
+            _batchRequestNo--;
+            _isBatchingChanges = _batchRequestNo > 0;
             EmitSheetDirty();
+        }
+    }
 
-        _isBatchingChanges = false;
+    /// <summary>
+    /// Defers rendering for a command, preserving any enclosing batch and screen-update state.
+    /// </summary>
+    internal IDisposable SuspendUpdates() => new UpdateScope(this);
+
+    private sealed class UpdateScope : IDisposable
+    {
+        private readonly Sheet _sheet;
+        private readonly bool _screenUpdating;
+
+        internal UpdateScope(Sheet sheet)
+        {
+            _sheet = sheet;
+            _screenUpdating = sheet.ScreenUpdating;
+            // Notify before starting the batch so a throwing subscriber cannot leave it open.
+            try
+            {
+                sheet.ScreenUpdating = false;
+                sheet.BatchUpdates();
+            }
+            catch
+            {
+                sheet.ScreenUpdating = _screenUpdating;
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _sheet.EndBatchUpdates();
+            }
+            finally
+            {
+                _sheet.ScreenUpdating = _screenUpdating;
+            }
+        }
     }
 
     /// <summary>

--- a/src/BlazorDatasheet.DataStructures/Geometry/AllRegion.cs
+++ b/src/BlazorDatasheet.DataStructures/Geometry/AllRegion.cs
@@ -11,4 +11,15 @@ public class AllRegion : Region
     public AllRegion() : base(0, int.MaxValue, 0, int.MaxValue)
     {
     }
+
+    public override IRegion Clone() => new AllRegion();
+
+    public override IRegion Copy() => new AllRegion();
+
+    // Whole-sheet coverage is independent of changes to row and column indices.
+    public override void Shift(int dRow, int dCol) { }
+
+    public override void Shift(int dRowStart, int dRowEnd, int dColStart, int dColEnd) { }
+
+    public override void Expand(Edge edges, int amount) { }
 }

--- a/test/BlazorDatasheet.Test/Render/DatasheetIconRenderingTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetIconRenderingTests.cs
@@ -51,6 +51,139 @@ public class DatasheetIconRenderingTests
     }
 
     [Test]
+    public async Task Suspended_Metadata_Changes_Render_Together_When_Updating_Resumes()
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(3, 3);
+        ApplyMetadataFormat(sheet);
+        var component = RenderSheet(context, sheet);
+        await component.InvokeAsync(() =>
+        {
+            sheet.ScreenUpdating = false;
+            sheet.Cells.SetCellMetaData(0, 0, "status", "ready");
+            sheet.Commands.BeginCommandGroup();
+            sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+            sheet.Commands.EndCommandGroup();
+        });
+        sheet.Cells.GetMetaData(0, 0, "status").Should().Be("ready");
+        sheet.Cells.GetMetaData(1, 1, "status").Should().Be("ready");
+        component.FindAll("[data-test-icon]").Should().BeEmpty();
+        await component.InvokeAsync(() => sheet.ScreenUpdating = true);
+        AssertMetadataAppearance(component, sheet, 0, 0, true);
+        AssertMetadataAppearance(component, sheet, 1, 1, true);
+    }
+
+    [Test]
+    public async Task Grouped_Metadata_Edit_Undo_Redo_Refreshes_Rendered_Cells()
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(3, 3);
+        ApplyMetadataFormat(sheet);
+        var component = RenderSheet(context, sheet);
+        await component.InvokeAsync(() =>
+        {
+            sheet.Commands.BeginCommandGroup();
+            sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+            sheet.Commands.EndCommandGroup();
+        });
+        AssertMetadataAppearance(component, sheet, 1, 1, true);
+        await component.InvokeAsync(() => sheet.Commands.Undo());
+        AssertMetadataAppearance(component, sheet, 1, 1, false);
+        await component.InvokeAsync(() => sheet.Commands.Redo());
+        AssertMetadataAppearance(component, sheet, 1, 1, true);
+    }
+
+    [TestCase(Axis.Row, false)]
+    [TestCase(Axis.Col, false)]
+    [TestCase(Axis.Row, true)]
+    [TestCase(Axis.Col, true)]
+    public async Task Structural_Edit_Undo_Redo_Refreshes_Metadata_Appearance(Axis axis, bool remove)
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(4, 4);
+        ApplyMetadataFormat(sheet);
+        sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+        sheet.Cells.SetValue(1, 1, "marker");
+        var component = RenderSheet(context, sheet);
+        var row = axis == Axis.Row ? (remove ? 0 : 2) : 1;
+        var col = axis == Axis.Col ? (remove ? 0 : 2) : 1;
+        await component.InvokeAsync(() =>
+        {
+            if (remove) sheet.GetRowColStore(axis).RemoveAt(0);
+            else sheet.GetRowColStore(axis).InsertAt(0);
+        });
+        AssertMetadataAppearance(component, sheet, row, col, true);
+        AssertMetadataAppearance(component, sheet, 1, 1, false);
+        sheet.Cells[row, col].Value.Should().Be("marker");
+        await component.InvokeAsync(() => sheet.Commands.Undo());
+        AssertMetadataAppearance(component, sheet, 1, 1, true);
+        AssertMetadataAppearance(component, sheet, row, col, false);
+        sheet.Cells[1, 1].Value.Should().Be("marker");
+        await component.InvokeAsync(() => sheet.Commands.Redo());
+        AssertMetadataAppearance(component, sheet, row, col, true);
+        AssertMetadataAppearance(component, sheet, 1, 1, false);
+    }
+
+    [TestCase(Axis.Row, 0)]
+    [TestCase(Axis.Row, 2)]
+    [TestCase(Axis.Col, 0)]
+    [TestCase(Axis.Col, 2)]
+    public async Task AllRegion_Covers_Every_Cell_After_Structural_Edit_And_History(Axis axis, int index)
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(4, 4);
+        sheet.ConditionalFormats.Apply(new AllRegion(), new ConditionalFormat((_, _) => true,
+            _ => new CellFormat { Icon = "tick" }));
+        var component = RenderSheet(context, sheet);
+        void AssertCoverage()
+        {
+            for (var r = 0; r < sheet.NumRows; r++)
+            for (var c = 0; c < sheet.NumCols; c++)
+                (sheet.ConditionalFormats.GetFormatResult(r, c)?.Icon).Should().Be("tick");
+            for (var row = 0; row < sheet.NumRows; row++)
+            for (var col = 0; col < sheet.NumCols; col++)
+            {
+                (sheet.ConditionalFormats.GetFormatResult(row, col)?.Icon).Should().Be("tick");
+                component.FindAll($"[data-row='{row}'][data-col='{col}'] [data-test-icon]")
+                    .Should().ContainSingle($"cell ({row}, {col}) must show its conditional icon");
+            }
+            var region = sheet.ConditionalFormats.GetAllFormats().Should().ContainSingle().Subject.Region;
+            region.Should().BeOfType<AllRegion>();
+            region.Top.Should().Be(0);
+            region.Left.Should().Be(0);
+            region.Bottom.Should().Be(int.MaxValue);
+            region.Right.Should().Be(int.MaxValue);
+        }
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.GetRowColStore(axis).InsertAt(index));
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.Commands.Undo());
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.Commands.Redo());
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.GetRowColStore(axis).RemoveAt(index));
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.Commands.Undo());
+        AssertCoverage();
+        await component.InvokeAsync(() => sheet.Commands.Redo());
+        AssertCoverage();
+    }
+
+    private static void ApplyMetadataFormat(Sheet sheet) =>
+        sheet.ConditionalFormats.Apply(new Region(0, 20, 0, 20), new ConditionalFormat(
+            (position, currentSheet) => Equals(currentSheet.Cells.GetMetaData(position.row, position.col, "status"), "ready"),
+            _ => new CellFormat { Icon = "tick", IconColor = "green" }));
+
+    private static void AssertMetadataAppearance(IRenderedComponent<Datasheet> component, Sheet sheet,
+        int row, int col, bool ready)
+    {
+        sheet.Cells.GetMetaData(row, col, "status").Should().Be(ready ? "ready" : null);
+        var icons = component.FindAll($"[data-row='{row}'][data-col='{col}'] [data-test-icon]");
+        icons.Should().HaveCount(ready ? 1 : 0);
+        if (ready) icons[0].ParentElement!.GetAttribute("style").Should().Contain("color: green");
+    }
+
+    [Test]
     public void Registered_Icon_Is_Rendered_In_The_Cell_With_Its_Icon_Color()
     {
         using var context = CreateContext();
@@ -117,6 +250,9 @@ public class DatasheetIconRenderingTests
     {
         var context = new BunitTestContext();
         context.JSInterop.Mode = JSRuntimeMode.Loose;
+        var virtualiser = context.JSInterop.SetupModule(x => x.Identifier == "getVirtualiser");
+        virtualiser.Setup<Rect>(x => x.Identifier == "calculateViewRect")
+            .SetResult(new Rect(0, 0, 500, 500));
         context.Services.AddBlazorDatasheet();
         return context;
     }

--- a/test/BlazorDatasheet.Test/SheetTests/DirtyRegionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/DirtyRegionTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BlazorDatasheet.Core.Commands;
+using BlazorDatasheet.Core.Commands.Data;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Events.Data;
 using BlazorDatasheet.Core.Events.Visual;
@@ -32,6 +34,126 @@ public class DirtyRegionTests
         sheet.SheetDirty += (_, e) =>
             captured.Add(new DirtySnapshot(e.DirtyRows.GetAllIntervals(), e.DirtyColStart, e.DirtyColEnd));
         return captured;
+    }
+
+    [Test]
+    public void Suspended_Dirty_Regions_Survive_A_Later_Batch_And_Flush_On_Resume()
+    {
+        var sheet = new Sheet(5, 5) { ScreenUpdating = false };
+        var captured = Capture(sheet);
+        sheet.Cells.SetCellMetaData(0, 0, "status", "ready");
+        sheet.BatchUpdates();
+        sheet.Cells.SetCellMetaData(3, 3, "status", "ready");
+        sheet.EndBatchUpdates();
+        captured.Should().BeEmpty();
+        sheet.ScreenUpdating = true;
+        var dirty = captured.Should().ContainSingle().Subject;
+        dirty.Rows.SelectMany(x => Enumerable.Range(x.Start, x.Size)).Should().Contain(new[] { 0, 3 });
+        dirty.ColStart.Should().Be(0);
+        dirty.ColEnd.Should().Be(3);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Nested_Commands_Preserve_Outer_Update_State(bool screenUpdating)
+    {
+        var sheet = new Sheet(5, 5) { ScreenUpdating = screenUpdating };
+        var captured = Capture(sheet);
+        sheet.BatchUpdates();
+        sheet.Commands.BeginCommandGroup();
+        sheet.Cells.SetValue(1, 1, "value");
+        sheet.Rows.InsertAt(0);
+        sheet.Cells.SetValues(new Region(3, 4, 3, 4), "bulk");
+        sheet.Commands.EndCommandGroup();
+        sheet.ScreenUpdating.Should().Be(screenUpdating);
+        sheet.Commands.Undo();
+        sheet.ScreenUpdating.Should().Be(screenUpdating);
+        sheet.Commands.Redo();
+        sheet.ScreenUpdating.Should().Be(screenUpdating);
+        captured.Should().BeEmpty();
+        sheet.EndBatchUpdates();
+        if (!screenUpdating) captured.Should().BeEmpty();
+        sheet.ScreenUpdating = true;
+        captured.Should().ContainSingle();
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Failed_Group_Restores_Batching_And_Screen_State(bool throws)
+    {
+        var sheet = new Sheet(5, 5);
+        var group = new CommandGroup(new SetMetaDataCommand(0, 0, "status", "ready"), new FailingCommand(throws));
+        if (throws)
+            Assert.Throws<InvalidOperationException>(() => sheet.Commands.ExecuteCommand(group));
+        else
+        {
+            sheet.Commands.ExecuteCommand(group).Should().BeFalse();
+            sheet.Cells.GetMetaData(0, 0, "status").Should().BeNull();
+        }
+        sheet.ScreenUpdating.Should().BeTrue();
+        var captured = Capture(sheet);
+        sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+        captured.Should().ContainSingle();
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Group_Undo_Failure_Restores_Caller_Update_State(bool screenUpdating)
+    {
+        var sheet = new Sheet(3, 3) { ScreenUpdating = screenUpdating };
+        var command = new ThrowingUndoCommand();
+        sheet.Commands.ExecuteCommand(new CommandGroup(command));
+        Assert.Throws<InvalidOperationException>(() => sheet.Commands.Undo());
+        sheet.ScreenUpdating.Should().Be(screenUpdating);
+        var captured = Capture(sheet);
+        sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+        sheet.ScreenUpdating = true;
+        captured.Should().ContainSingle();
+    }
+
+    private sealed class ThrowingUndoCommand : BaseCommand, IUndoableCommand
+    {
+        public override bool CanExecute(Sheet sheet) => true;
+        public override bool Execute(Sheet sheet) => true;
+        public bool Undo(Sheet sheet) => throw new InvalidOperationException();
+    }
+
+    private sealed class FailingCommand(bool throws) : BaseCommand
+    {
+        public override bool CanExecute(Sheet sheet) => true;
+        public override bool Execute(Sheet sheet) => throws ? throw new InvalidOperationException() : false;
+    }
+
+    [Test]
+    public void Failed_Cell_Change_Subscriber_Does_Not_Leak_The_Previous_Batch()
+    {
+        var sheet = new Sheet(3, 3);
+        EventHandler<CellDataChangedEventArgs> handler = (_, _) => throw new InvalidOperationException();
+        sheet.Cells.CellsChanged += handler;
+        Assert.Throws<InvalidOperationException>(() => sheet.Cells.SetValue(0, 0, "first"));
+        sheet.Cells.CellsChanged -= handler;
+        sheet.ScreenUpdating.Should().BeTrue();
+        var positions = new List<CellPosition>();
+        sheet.Cells.CellsChanged += (_, args) => positions.AddRange(args.Positions);
+        sheet.Cells.SetValue(1, 1, "second");
+        positions.Should().Equal(new CellPosition(1, 1));
+    }
+
+    [Test]
+    public void Nested_Batch_From_Cell_Change_Subscriber_Flushes_Once()
+    {
+        var sheet = new Sheet(3, 3);
+        var captured = Capture(sheet);
+        sheet.Cells.CellsChanged += (_, _) =>
+        {
+            sheet.BatchUpdates();
+            sheet.Cells.SetCellMetaData(2, 2, "status", "ready");
+            sheet.EndBatchUpdates();
+        };
+        sheet.Cells.SetValue(0, 0, "value");
+        var dirty = captured.Should().ContainSingle().Subject;
+        dirty.Rows.SelectMany(x => Enumerable.Range(x.Start, x.Size)).Should().Contain(new[] { 0, 2 });
+        sheet.ScreenUpdating.Should().BeTrue();
     }
 
     [TestCase("set")]
@@ -107,12 +229,15 @@ public class DirtyRegionTests
                 sheet.EndBatchUpdates();
             }
 
+            captured.Should().BeEmpty();
+            sheet.ScreenUpdating.Should().BeFalse();
+            sheet.ScreenUpdating = true;
             var snapshot = captured.Should().ContainSingle().Subject;
             snapshot.Rows.SelectMany(interval => Enumerable.Range(interval.Start, interval.Size))
                 .Should().BeEquivalentTo(new[] { 2, 3, 4 });
             snapshot.ColStart.Should().Be(3);
             snapshot.ColEnd.Should().Be(5);
-            sheet.ScreenUpdating.Should().BeFalse();
+            sheet.ScreenUpdating = false;
         }
         valueChanges.Should().Be(0);
     }

--- a/test/BlazorDatasheet.Test/SheetTests/MetaDataTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/MetaDataTests.cs
@@ -43,6 +43,36 @@ public class MetaDataTests
         }
     }
 
+    [TestCase(Axis.Row, false)]
+    [TestCase(Axis.Col, false)]
+    [TestCase(Axis.Row, true)]
+    [TestCase(Axis.Col, true)]
+    public void Structural_Notifications_Observe_Updated_Metadata_And_Values(Axis axis, bool remove)
+    {
+        var sheet = new Sheet(4, 4);
+        sheet.Cells.SetValue(1, 1, "marker");
+        sheet.Cells.SetCellMetaData(1, 1, "status", "ready");
+        var store = sheet.GetRowColStore(axis);
+        var snapshots = new List<(int Row, int Col)>();
+        void Observe()
+        {
+            var positions = sheet.Range(sheet.Region).Positions
+                .Where(p => Equals(sheet.Cells.GetMetaData(p.row, p.col, "status"), "ready")).ToList();
+            var position = positions.Should().ContainSingle().Subject;
+            sheet.Cells[position.row, position.col].Value.Should().Be("marker");
+            snapshots.Add((position.row, position.col));
+        }
+        store.Inserted += (_, _) => Observe();
+        store.Removed += (_, _) => Observe();
+        var moved = remove ? 0 : 2;
+        var expected = axis == Axis.Row ? (moved, 1) : (1, moved);
+        if (remove) store.RemoveAt(0);
+        else store.InsertAt(0);
+        sheet.Commands.Undo();
+        sheet.Commands.Redo();
+        snapshots.Should().Equal(expected, (1, 1), expected);
+    }
+
     [Test]
     public void Region_MetaData_Events_Report_Each_Cells_Old_And_New_Value_On_Execute_Undo_And_Redo()
     {

--- a/test/BlazorDatasheet.Test/Store/RegionStoreTests.cs
+++ b/test/BlazorDatasheet.Test/Store/RegionStoreTests.cs
@@ -8,6 +8,43 @@ namespace BlazorDatasheet.Test.Store;
 
 public class RegionStoreTests
 {
+    [TestCase(Axis.Row, 0, true)]
+    [TestCase(Axis.Row, 2, true)]
+    [TestCase(Axis.Col, 0, true)]
+    [TestCase(Axis.Col, 2, true)]
+    [TestCase(Axis.Row, 0, false)]
+    [TestCase(Axis.Row, 2, false)]
+    [TestCase(Axis.Col, 0, false)]
+    [TestCase(Axis.Col, 2, false)]
+    public void AllRegion_Preserves_Coverage_Through_Store_Transforms(Axis axis, int index, bool expandAfter)
+    {
+        var store = new RegionDataStore<string>(expandWhenInsertAfter: expandAfter);
+        store.Add(new AllRegion().Clone(), "all");
+        store.Add(new Region(3, 4, 3, 4), "bounded");
+        void AssertAll()
+        {
+            var region = store.GetAllDataRegions().Single(x => x.Data == "all").Region;
+            region.Should().BeOfType<AllRegion>();
+            region.Top.Should().Be(0);
+            region.Left.Should().Be(0);
+            region.Bottom.Should().Be(int.MaxValue);
+            region.Right.Should().Be(int.MaxValue);
+            store.GetData(0, 0).Should().Contain("all");
+            store.GetData(int.MaxValue - 1, int.MaxValue - 1).Should().Contain("all");
+        }
+        var insert = store.InsertRowColAt(index, 2, axis);
+        AssertAll();
+        store.GetAllDataRegions().Single(x => x.Data == "bounded").Region.GetLeadingEdgeOffset(axis)
+            .Should().Be(5);
+        store.Restore(insert);
+        AssertAll();
+        var remove = store.RemoveRowColAt(index, 2, axis);
+        AssertAll();
+        store.Restore(remove);
+        AssertAll();
+        store.GetAllDataRegions().Single(x => x.Data == "bounded").Region.Should().BeEquivalentTo(new Region(3, 4, 3, 4));
+    }
+
     [Test]
     public void Add_And_Retrieve_Region_Data_Correct()
     {


### PR DESCRIPTION
- Preserved AllRegion cloning and transformation semantics without changing bounded-region movement.
- Retained dirty regions during suspension and flushed them on resume.
- Preserved nested update state and restored it on failure.
- Moved structural notifications after metadata and other stores finish updating.