### PR TITLE
Focus handling improvements

### DIFF
--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Data/EventsExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Data/EventsExample.razor
@@ -1,11 +1,22 @@
 ﻿@using BlazorDatasheet.Core.Data
 @using BlazorDatasheet.Formula.Core
 
-<Datasheet Sheet="_sheet"/>
+<button @onclick="FocusSheet">Focus sheet</button>
+<Datasheet Sheet="_sheet" @ref="_datasheet"
+           OnSheetActiveChanged="@(e => Log($"Sheet active: {e.IsActive}"))"
+           OnFocusIn="@(_ => Log("Focus entered sheet"))"
+           OnFocusOut="@(_ => Log("Focus left sheet"))"/>
 
 <textarea style="width: 500px; height: 500px;" @bind="_log"></textarea>
 
 @code {
+
+    private Datasheet? _datasheet;
+
+    private async Task FocusSheet()
+    {
+        if (_datasheet != null) await _datasheet.FocusAsync();
+    }
 
     private string _log = string.Empty;
     private Sheet _sheet = null!;

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
@@ -53,7 +53,9 @@
     The sheet has multiple events that can be used to track changes to the sheet. This example shows important events.
     <code>OnFocusIn</code> and <code>OnFocusOut</code> report focus entering or leaving the entire datasheet,
     including browser window focus changes. Moving between cells and editors does not raise these events;
-    separately rendered menus are outside the focus boundary. Losing focus keeps pending edits open.
+    using a menu does not move focus away. By default losing focus keeps a pending edit open;
+    set <code>OnEditFocusLoss</code> to <code>Accept</code> or <code>Cancel</code> to finish the edit when focus moves
+    to another element on the page. Switching window or tab always keeps the edit open.
     <code>OnSheetActiveChanged</code> reports keyboard activation before the corresponding focus callback.
     <code>FocusAsync()</code> focuses the sheet without scrolling; <code>SetActiveAsync()</code> changes activation
     without moving browser focus. Neither intercepts input aimed at an external control.

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
@@ -57,6 +57,7 @@
     set <code>OnEditFocusLoss</code> to <code>Accept</code> or <code>Cancel</code> to finish the edit when focus moves
     to another element on the page. Switching window or tab always keeps the edit open.
     <code>OnSheetActiveChanged</code> reports keyboard activation before the corresponding focus callback.
+    Callbacks report the latest state: a transition superseded before its callback runs is dropped.
     <code>FocusAsync()</code> focuses the sheet without scrolling; <code>SetActiveAsync()</code> changes activation
     without moving browser focus. Neither intercepts input aimed at an external control.
 </div>

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/SimpleExample.razor
@@ -51,6 +51,12 @@
 
 <div class="block">
     The sheet has multiple events that can be used to track changes to the sheet. This example shows important events.
+    <code>OnFocusIn</code> and <code>OnFocusOut</code> report focus entering or leaving the entire datasheet,
+    including browser window focus changes. Moving between cells and editors does not raise these events;
+    separately rendered menus are outside the focus boundary. Losing focus keeps pending edits open.
+    <code>OnSheetActiveChanged</code> reports keyboard activation before the corresponding focus callback.
+    <code>FocusAsync()</code> focuses the sheet without scrolling; <code>SetActiveAsync()</code> changes activation
+    without moving browser focus. Neither intercepts input aimed at an external control.
 </div>
 
 <CodeExample ComponentType="typeof(EventsExample)"/>

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -22,7 +22,7 @@
                          Placement="@MenuPlacement.BottomRight">
 
             <div
-                @onmouseover="SetMouseOver" @onmouseout="SetMouseOut" class="@SheetClass"
+                tabindex="0" class="@SheetClass"
                 style="width:@(TotalViewWidth)px; height:@(TotalViewHeight)px;"
                 @ref="_sheetContainer">
                 <div class="bds-sheet-layout" style="display: flex; flex-direction: column; align-items:flex-start;">
@@ -317,8 +317,8 @@
 
     private void CreateCellRenderFragment() => CellRenderFragment = CreateComponent();
 
-    private void SetMouseOut() => IsMouseInsideSheet = false;
 
-    private void SetMouseOver() => IsMouseInsideSheet = true;
+
+
 
 }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -225,6 +225,9 @@
             if (!ShowRowHeadings)
                 classes.Add("bds-sheet-left-border");
 
+            if (!_hasFocus)
+                classes.Add("bds-sheet-unfocused");
+
             return string.Join(" ", classes);
         }
     }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -225,9 +225,6 @@
             if (!ShowRowHeadings)
                 classes.Add("bds-sheet-left-border");
 
-            if (!_hasFocus)
-                classes.Add("bds-sheet-unfocused");
-
             return string.Join(" ", classes);
         }
     }

--- a/src/BlazorDatasheet/Datasheet.razor
+++ b/src/BlazorDatasheet/Datasheet.razor
@@ -317,8 +317,4 @@
 
     private void CreateCellRenderFragment() => CellRenderFragment = CreateComponent();
 
-
-
-
-
 }

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -989,6 +989,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         var focused = focus.Focused;
         var focusChanged = _hasFocus != focused;
         _hasFocus = focused;
+        if (focusChanged)
+            StateHasChanged(); // the selection is drawn dimmed while focus is elsewhere
         await SetActiveAsync(focused);
         if (_isDisposing || !focusChanged || focus.Version != _browserFocusVersion) return;
         await (focused ? OnFocusIn : OnFocusOut).InvokeAsync(new FocusEventArgs

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -989,7 +989,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         var focused = focus.Focused;
         var focusChanged = _hasFocus != focused;
         _hasFocus = focused;
-        await SetActiveAsync(focused);
+        await SetActiveAsync(focus.Active);
         if (_isDisposing || !focusChanged || focus.Version != _browserFocusVersion) return;
         await (focused ? OnFocusIn : OnFocusOut).InvokeAsync(new FocusEventArgs
         {

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -989,8 +989,6 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         var focused = focus.Focused;
         var focusChanged = _hasFocus != focused;
         _hasFocus = focused;
-        if (focusChanged)
-            StateHasChanged(); // the selection is drawn dimmed while focus is elsewhere
         await SetActiveAsync(focused);
         if (_isDisposing || !focusChanged || focus.Version != _browserFocusVersion) return;
         await (focused ? OnFocusIn : OnFocusOut).InvokeAsync(new FocusEventArgs

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -83,6 +83,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
     /// <summary>
     /// Fired when the Datasheet becomes active or inactive (able to receive keyboard inputs).
+    /// Fires before the matching <see cref="OnFocusIn"/> or <see cref="OnFocusOut"/>. A change that is
+    /// superseded before its callback runs is dropped in favour of the newer one.
     /// </summary>
     [Parameter]
     public EventCallback<SheetActiveEventArgs> OnSheetActiveChanged { get; set; }
@@ -186,13 +188,15 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
     /// <summary>
     /// Raised when browser focus enters this sheet or its descendants, including window restoration.
-    /// Separately rendered menus are outside this focus boundary.
+    /// Using a menu keeps focus in the sheet. Transitions superseded before their callback runs are
+    /// dropped, so two consecutive focus-in events can occur without a focus-out between them.
     /// </summary>
     [Parameter] public EventCallback<FocusEventArgs> OnFocusIn { get; set; }
 
     /// <summary>
     /// Raised when browser focus leaves this sheet and its descendants, including window focus loss.
-    /// Moving between descendants does not raise this event. Pending edits remain open.
+    /// Moving between descendants does not raise this event. What happens to a pending edit is set by
+    /// <see cref="OnEditFocusLoss"/>. Superseded transitions are dropped, as for <see cref="OnFocusIn"/>.
     /// </summary>
     [Parameter] public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
 

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -175,14 +175,26 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     public ShortcutManager ShortcutManager { get; } = new();
 
     /// <summary>
-    /// Whether the user is focused on the datasheet.
+    /// Whether the datasheet is active for keyboard input. Browser focus is tracked separately.
     /// </summary>
     private bool IsDataSheetActive { get; set; }
 
+    private bool _hasFocus;
+    private long _inputRevision;
+    private long _activationRevision;
+    private long _browserFocusVersion;
+
     /// <summary>
-    /// Whether the mouse is located inside/over the sheet.
+    /// Raised when browser focus enters this sheet or its descendants, including window restoration.
+    /// Separately rendered menus are outside this focus boundary.
     /// </summary>
-    private bool IsMouseInsideSheet { get; set; }
+    [Parameter] public EventCallback<FocusEventArgs> OnFocusIn { get; set; }
+
+    /// <summary>
+    /// Raised when browser focus leaves this sheet and its descendants, including window focus loss.
+    /// Moving between descendants does not raise this event. Pending edits remain open.
+    /// </summary>
+    [Parameter] public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
 
     /// <summary>
     /// Whether the row and column headers are sticky
@@ -223,7 +235,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     private SheetPointerInputService? _sheetPointerInputService;
 
     /// <summary>
-    /// The whole sheet container, useful for checking whether mouse is inside the sheet
+    /// The sheet container used to track focus and pointer ownership.
     /// </summary>
     private ElementReference _sheetContainer = default!;
 
@@ -473,7 +485,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
     private async Task AddWindowEventsAsync()
     {
-        await _windowEventService.RegisterMouseEvent("mousedown", HandleWindowMouseDown);
+        await _windowEventService.ConfigureFocus(_sheetContainer, HandleFocusChanged);
         await _windowEventService.RegisterKeyEvent("keydown", HandleWindowKeyDown);
         await _windowEventService.RegisterClipboardEvent("paste", HandleWindowPaste);
         await _windowEventService.RegisterClipboardEvent("copy", HandleWindowCopy);
@@ -543,12 +555,13 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     private async void EditorOnEditFinished(object? sender, EditFinishedEventArgs e)
     {
         _pendingEditorKeys = string.Empty;
-        await _windowEventService.PreventDefault("keydown");
+        await UpdateInputStateAsync(editing: false);
+        await _windowEventService.RestoreFocus();
     }
 
     private async void EditorOnEditBegin(object? sender, EditBeginEventArgs e)
     {
-        await _windowEventService.CancelPreventDefault("keydown");
+        await UpdateInputStateAsync();
     }
 
 
@@ -662,9 +675,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
         // A printable key can arrive after the edit has begun but before the editor input has been
         // focused in the browser - that's at least one interop round trip later, which is easily longer
-        // than the gap between two keystrokes on a high latency connection. The sheet container isn't
-        // focusable, so if the browser isn't going to insert the character itself it has nowhere to go
-        // and would be silently dropped.
+        // than the gap between two keystrokes on a high latency connection. If the browser isn't going to
+        // insert the character itself it has nowhere to go and would be silently dropped.
         if (e.Key.Length == 1 && _sheet.Editor.IsEditing && IsDataSheetActive &&
             !e.MetaKey &&
             e is SheetKeyboardEventArgs { IsEditableTarget: false } sheetEvent &&
@@ -709,12 +721,6 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
             return true;
         }
 
-        return false;
-    }
-
-    private async Task<bool> HandleWindowMouseDown(MouseEventArgs e)
-    {
-        await SetActiveAsync(IsMouseInsideSheet);
         return false;
     }
 
@@ -962,19 +968,33 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     /// <param name="active"></param>
     public async Task SetActiveAsync(bool active = true)
     {
-        if (active == IsDataSheetActive)
+        if (_isDisposing || active == IsDataSheetActive)
             return;
 
-        if (!_sheet.Editor.IsEditing)
-        {
-            if (active)
-                await _windowEventService.PreventDefault("keydown");
-            else
-                await _windowEventService.CancelPreventDefault("keydown");
-        }
-
         IsDataSheetActive = active;
-        await OnSheetActiveChanged.InvokeAsync(new SheetActiveEventArgs(this, active));
+        var revision = ++_activationRevision;
+        await UpdateInputStateAsync();
+        if (!_isDisposing && revision == _activationRevision)
+            await OnSheetActiveChanged.InvokeAsync(new SheetActiveEventArgs(this, active));
+    }
+
+    private Task UpdateInputStateAsync(bool? editing = null) => _isDisposing ? Task.CompletedTask :
+        _windowEventService.SetInputState(IsDataSheetActive, editing ?? _sheet.Editor.IsEditing,
+            ++_inputRevision, _browserFocusVersion);
+
+    internal async Task HandleFocusChanged(SheetFocusEventArgs focus)
+    {
+        if (_isDisposing || focus.Version <= _browserFocusVersion) return;
+        _browserFocusVersion = focus.Version;
+        var focused = focus.Focused;
+        var focusChanged = _hasFocus != focused;
+        _hasFocus = focused;
+        await SetActiveAsync(focused);
+        if (_isDisposing || !focusChanged || focus.Version != _browserFocusVersion) return;
+        await (focused ? OnFocusIn : OnFocusOut).InvokeAsync(new FocusEventArgs
+        {
+            Type = focused ? "focusin" : "focusout"
+        });
     }
 
 
@@ -983,7 +1003,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     /// </summary>
     public async Task FocusAsync()
     {
-        await _sheetContainer.FocusAsync();
+        if (_isDisposing) return;
+        await _sheetContainer.FocusAsync(preventScroll: true);
         await SetActiveAsync();
     }
 

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -197,6 +197,12 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
     [Parameter] public EventCallback<FocusEventArgs> OnFocusOut { get; set; }
 
     /// <summary>
+    /// What happens to an open edit when focus moves from the sheet to another element on the page.
+    /// Defaults to keeping the edit open. Focus leaving the window or tab always keeps it open.
+    /// </summary>
+    [Parameter] public EditFocusLossAction OnEditFocusLoss { get; set; } = EditFocusLossAction.KeepEditing;
+
+    /// <summary>
     /// Whether the row and column headers are sticky
     /// </summary>
     [Parameter]
@@ -989,6 +995,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         var focused = focus.Focused;
         var focusChanged = _hasFocus != focused;
         _hasFocus = focused;
+        if (focusChanged && !focused && !focus.FromWindow)
+            FinishEditOnFocusLoss();
         await SetActiveAsync(focus.Active);
         if (_isDisposing || !focusChanged || focus.Version != _browserFocusVersion) return;
         await (focused ? OnFocusIn : OnFocusOut).InvokeAsync(new FocusEventArgs
@@ -997,6 +1005,21 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         });
     }
 
+
+    private void FinishEditOnFocusLoss()
+    {
+        if (!_sheet.Editor.IsEditing)
+            return;
+        switch (OnEditFocusLoss)
+        {
+            case EditFocusLossAction.Accept:
+                _sheet.Editor.AcceptEdit();
+                break;
+            case EditFocusLossAction.Cancel:
+                _sheet.Editor.CancelEdit();
+                break;
+        }
+    }
 
     /// <summary>
     /// Sets the document focus to the sheet container and sets the sheet as active.

--- a/src/BlazorDatasheet/Edit/DefaultComponents/HighlightedInput.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/HighlightedInput.razor
@@ -36,6 +36,11 @@
     [Parameter] public double CellWidth { get; set; }
     [Parameter] public double CellHeight { get; set; }
     [Parameter] public bool SoftEdit { get; set; }
+
+    /// <summary>Delays initial focus until the owning editor has supplied its starting value.</summary>
+    [Parameter] public bool ReadyToFocus { get; set; } = true;
+    private bool _initialFocusRequested;
+    private bool _highlighterReady;
     [Parameter] public string? Style { get; set; }
 
     private ElementReference _highlightInputEl;
@@ -55,6 +60,7 @@
             await SetInputTextAsync(_value);
             await SetHighlightTextAsync();
         }
+        await RequestInitialFocusAsync();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -108,6 +114,19 @@
         // so it will never be re-applied. Flush it here.
         if (_value != initialText)
             await SetInputTextAsync(_value);
+
+        // Do not accept native input while the initial key/buffer is still being applied.
+        // Otherwise the first input event can replace that value with text typed into an empty editor.
+        _highlighterReady = true;
+        await RequestInitialFocusAsync();
+    }
+
+    private async Task RequestInitialFocusAsync()
+    {
+        if (!ReadyToFocus || !_highlighterReady || _isDisposing || _initialFocusRequested)
+            return;
+        _initialFocusRequested = true;
+        await InvokeHighlighterAsync("focusAndMoveCursorToEnd", true);
     }
 
     /// <summary>
@@ -117,6 +136,7 @@
     [JSInvokable]
     public async Task HandleInput(string input)
     {
+        if (_isDisposing) return;
         _value = input;
         await ValueChanged.InvokeAsync(input);
         await SetHighlightTextAsync();
@@ -169,12 +189,14 @@
     [JSInvokable]
     public async Task HandleCaretPositionUpdate(int position)
     {
+        if (_isDisposing) return;
         await CaretPositionChanged.InvokeAsync(position);
     }
 
     [JSInvokable]
     public async Task HandleInputSizeChanged(Size size)
     {
+        if (_isDisposing) return;
         await InputSizeChanged.InvokeAsync(size);
     }
 

--- a/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
+++ b/src/BlazorDatasheet/Edit/DefaultComponents/TextEditorComponent.razor
@@ -25,6 +25,7 @@
         InputSizeChanged="HighlightInputSizeChanged"
         CaretPositionChanged="OnCaretPositionChanged"
         SoftEdit="_isSoftEdit"
+        ReadyToFocus="_hasBegunEdit"
         @bind-Value:set="OnInput"
         @bind-Value:get="CurrentValue"/>
 </div>
@@ -62,6 +63,7 @@
     private FormulaOptions _formulaOptions = null!;
     private HighlightedInput _highlightedInput = default!;
     private bool _isSoftEdit;
+    private bool _hasBegunEdit;
     private int _currentCaretPosition;
     private double _highlightInputHeight;
     private string _currentSnapshot = string.Empty;
@@ -187,6 +189,7 @@
 
     public override void BeginEdit(EditEntryMode entryMode, string? editValue, string key)
     {
+        _hasBegunEdit = true;
         if (entryMode == EditEntryMode.Key && !String.IsNullOrEmpty(key) && key.Length == 1)
         {
             CurrentValue = key;
@@ -197,6 +200,7 @@
         }
 
         HandleInputChanged();
+        StateHasChanged();
     }
 
     private void OnCaretPositionChanged(int position)

--- a/src/BlazorDatasheet/Edit/EditFocusLossAction.cs
+++ b/src/BlazorDatasheet/Edit/EditFocusLossAction.cs
@@ -1,0 +1,17 @@
+﻿namespace BlazorDatasheet.Edit;
+
+/// <summary>
+/// What happens to an open cell edit when browser focus moves from the sheet to another element on
+/// the page. Focus leaving the window or tab always keeps the edit open.
+/// </summary>
+public enum EditFocusLossAction
+{
+    /// <summary>The edit stays open and continues when focus returns.</summary>
+    KeepEditing,
+
+    /// <summary>The edit is accepted. If the value is invalid the edit stays open.</summary>
+    Accept,
+
+    /// <summary>The edit is cancelled and the cell keeps its previous value.</summary>
+    Cancel
+}

--- a/src/BlazorDatasheet/Edit/EditorLayer.razor
+++ b/src/BlazorDatasheet/Edit/EditorLayer.razor
@@ -16,7 +16,7 @@
     <div id="editor" class="bds-editor-overlay"
          @onclick="HandleEditorOverlayClick"
          style="@GetEditorSizeStyling()">
-        <DynamicComponent
+        <DynamicComponent @key="_editVersion"
             Type="@ActiveEditorType"
             Parameters="@GetDynamicEditorParameters()"
             @ref="ActiveEditorContainer"/>
@@ -37,6 +37,7 @@
 
     /// The current cell editor component
     private BaseEditor? _activeCellEditor;
+    private long _editVersion;
 
     private bool BeginningEdit { get; set; }
 
@@ -105,6 +106,8 @@
         if (Disabled)
             return;
 
+        ActiveEditorContainer = null;
+        _editVersion++;
         ActiveEditorType = GetEditorType(e.Type);
         BeginningEdit = true;
         IsEditing = true;
@@ -142,18 +145,19 @@
     {
         if (BeginningEdit)
         {
-            // always consume the flag, even if the edit stopped before we got here, otherwise the
-            // next unrelated render re-runs the begin-edit body.
-            BeginningEdit = false;
-
             if (!_sheet.Editor.IsEditing)
+            {
+                BeginningEdit = false;
+                return;
+            }
+
+            // A focus callback can trigger a parent render while the editor is being created.
+            // Keep initialization pending until the dynamic component reference is available.
+            if (ActiveEditorContainer?.Instance is not BaseEditor editor)
                 return;
 
-            if (ActiveEditorContainer?.Instance == null)
-                return;
-            _activeCellEditor = (BaseEditor)(ActiveEditorContainer.Instance);
-            if (_activeCellEditor == null)
-                return;
+            BeginningEdit = false;
+            _activeCellEditor = editor;
 
             _activeCellEditor.ResetAutoScrollActive();
             AttachEditorAutoScroll(_activeCellEditor);
@@ -255,6 +259,7 @@
         // "editing" forever and GetActiveEditorLayer keeps picking it.
         IsEditing = false;
         BeginningEdit = false;
+        ActiveEditorContainer = null;
         StateHasChanged();
     }
 

--- a/src/BlazorDatasheet/Render/CaretButton.razor
+++ b/src/BlazorDatasheet/Render/CaretButton.razor
@@ -1,7 +1,8 @@
-@inherits SheetComponentBase
+﻿@inherits SheetComponentBase
 
 <button 
     tabindex="-1" 
+    data-bds-chrome
     class="bds-sheet-dropper" 
     @onclick="HandleClick" 
     @onmousedown="HandleMousePress">

--- a/src/BlazorDatasheet/Services/IWindowEventService.cs
+++ b/src/BlazorDatasheet/Services/IWindowEventService.cs
@@ -5,6 +5,10 @@ namespace BlazorDatasheet.Services;
 
 internal interface IWindowEventService : IAsyncDisposable
 {
+    Task ConfigureFocus(Microsoft.AspNetCore.Components.ElementReference container, Func<SheetFocusEventArgs, Task> handler);
+    Task SetInputState(bool active, bool editing, long revision, long focusVersion);
+    Task RestoreFocus();
+
     /// <summary>
     /// Registers a window mouse event.
     /// </summary>

--- a/src/BlazorDatasheet/Services/IWindowEventService.cs
+++ b/src/BlazorDatasheet/Services/IWindowEventService.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Components.Web;
+﻿using Microsoft.AspNetCore.Components.Web;
 using ClipboardEventArgs = BlazorDatasheet.Core.Events.ClipboardEventArgs;
 
 namespace BlazorDatasheet.Services;
@@ -33,18 +33,4 @@ internal interface IWindowEventService : IAsyncDisposable
     /// <param name="handler"></param>
     /// <returns></returns>
     Task RegisterClipboardEvent(string eventType, Func<ClipboardEventArgs, Task<bool>> handler);
-
-    /// <summary>
-    /// Causes the window events to prevent the default behaviour for type <paramref name="eventType"/>
-    /// </summary>
-    /// <param name="eventType">The type of events to prevent default behaviour for.</param>
-    /// <returns></returns>
-    Task PreventDefault(string eventType);
-
-    /// <summary>
-    /// Stops the effect of <seealso cref="PreventDefault"/>
-    /// </summary>
-    /// <param name="eventType"></param>
-    /// <returns></returns>
-    Task CancelPreventDefault(string eventType);
 }

--- a/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
+++ b/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
@@ -1,8 +1,12 @@
-namespace BlazorDatasheet.Services;
+﻿namespace BlazorDatasheet.Services;
 
-/// <summary>Browser focus ownership and its monotonically increasing transition version.</summary>
+/// <summary>Browser focus ownership, keyboard activation and their monotonically increasing transition version.</summary>
 public class SheetFocusEventArgs
 {
-	public bool Focused { get; set; }
-	public long Version { get; set; }
+    public bool Focused { get; set; }
+
+    /// <summary>Whether the sheet should handle keyboard input. Usually follows <see cref="Focused"/>.</summary>
+    public bool Active { get; set; }
+
+    public long Version { get; set; }
 }

--- a/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
+++ b/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
@@ -8,5 +8,11 @@ public class SheetFocusEventArgs
     /// <summary>Whether the sheet should handle keyboard input. Usually follows <see cref="Focused"/>.</summary>
     public bool Active { get; set; }
 
+    /// <summary>
+    /// True when the change came from the window or tab losing or regaining focus, rather than
+    /// focus moving between elements on the page.
+    /// </summary>
+    public bool FromWindow { get; set; }
+
     public long Version { get; set; }
 }

--- a/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
+++ b/src/BlazorDatasheet/Services/SheetFocusEventArgs.cs
@@ -1,0 +1,8 @@
+namespace BlazorDatasheet.Services;
+
+/// <summary>Browser focus ownership and its monotonically increasing transition version.</summary>
+public class SheetFocusEventArgs
+{
+	public bool Focused { get; set; }
+	public long Version { get; set; }
+}

--- a/src/BlazorDatasheet/Services/WindowEventService.cs
+++ b/src/BlazorDatasheet/Services/WindowEventService.cs
@@ -26,35 +26,65 @@ public class WindowEventService : IWindowEventService
         _js = js;
     }
 
+    private Func<SheetFocusEventArgs, Task>? _focusHandler;
+
+    public async Task ConfigureFocus(Microsoft.AspNetCore.Components.ElementReference container, Func<SheetFocusEventArgs, Task> handler)
+    {
+        await CreateDotnetHelperIfNotExists();
+        if (_isDisposed || _windowEventObj == null) return;
+        _focusHandler = handler;
+        await _windowEventObj.InvokeVoidAsync("configureFocus", container, nameof(HandleFocusChanged));
+    }
+
+    [JSInvokable]
+    public Task HandleFocusChanged(SheetFocusEventArgs focus) =>
+        !_isDisposed && _focusHandler != null ? _focusHandler(focus) : Task.CompletedTask;
+
+    public async Task SetInputState(bool active, bool editing, long revision, long focusVersion)
+    {
+        await CreateDotnetHelperIfNotExists();
+        if (!_isDisposed && _windowEventObj != null)
+            await _windowEventObj.InvokeVoidAsync("setInputState", active, editing, revision, focusVersion);
+    }
+
+    public async Task RestoreFocus()
+    {
+        if (!_isDisposed && _windowEventObj != null)
+            await _windowEventObj.InvokeVoidAsync("restoreFocus");
+    }
+
     public async Task RegisterMouseEvent(string eventType, Func<MouseEventArgs, Task<bool>> handler,
         int throttleInMs = 0)
     {
         await CreateDotnetHelperIfNotExists();
+        if (_isDisposed) return;
         _mouseEventListeners ??= new();
-        _mouseEventListeners.TryAdd(eventType, handler);
+        _mouseEventListeners[eventType] = handler;
         await AddWindowEvent(eventType, nameof(HandleWindowMouseEvent), throttleInMs);
     }
 
     public async Task RegisterKeyEvent(string eventType, Func<KeyboardEventArgs, Task<bool>> handler)
     {
         await CreateDotnetHelperIfNotExists();
+        if (_isDisposed) return;
         _keyEventListeners ??= new();
-        _keyEventListeners.TryAdd(eventType, handler);
+        _keyEventListeners[eventType] = handler;
         await AddWindowEvent(eventType, nameof(HandleWindowKeyEvent));
     }
 
     public async Task RegisterClipboardEvent(string eventType, Func<ClipboardEventArgs, Task<bool>> handler)
     {
         await CreateDotnetHelperIfNotExists();
+        if (_isDisposed) return;
         _clipboardEventListeners ??= new();
-        _clipboardEventListeners.TryAdd(eventType, handler);
+        _clipboardEventListeners[eventType] = handler;
         await AddWindowEvent(eventType, nameof(HandleWindowClipboardEvent));
     }
 
     public async Task PreventDefault(string eventType)
     {
         await CreateDotnetHelperIfNotExists();
-        if (_windowEventObj == null)
+        if (_isDisposed || _windowEventObj == null)
             return;
         await _windowEventObj.InvokeVoidAsync("preventDefault", eventType);
     }
@@ -62,7 +92,7 @@ public class WindowEventService : IWindowEventService
     public async Task CancelPreventDefault(string eventType)
     {
         await CreateDotnetHelperIfNotExists();
-        if (_windowEventObj == null)
+        if (_isDisposed || _windowEventObj == null)
             return;
         await _windowEventObj.InvokeVoidAsync("cancelPreventDefault", eventType);
     }
@@ -112,7 +142,7 @@ public class WindowEventService : IWindowEventService
 
     private async ValueTask AddWindowEvent(string evType, string jsInvokableName, int throttleInMs = 0)
     {
-        if (_windowEventObj == null)
+        if (_isDisposed || _windowEventObj == null)
             return;
 
         await _windowEventObj.InvokeVoidAsync("registerEvent", evType, jsInvokableName, throttleInMs);
@@ -121,7 +151,7 @@ public class WindowEventService : IWindowEventService
     [JSInvokable]
     public async Task<bool> HandleWindowMouseEvent(MouseEventArgs e)
     {
-        if (_mouseEventListeners == null)
+        if (_isDisposed || _mouseEventListeners == null)
             return false;
 
         var hasListener = _mouseEventListeners.TryGetValue(e.Type, out var listener);
@@ -135,7 +165,7 @@ public class WindowEventService : IWindowEventService
     [JSInvokable]
     public async Task<bool> HandleWindowKeyEvent(SheetKeyboardEventArgs e)
     {
-        if (_keyEventListeners == null)
+        if (_isDisposed || _keyEventListeners == null)
             return false;
 
         var hasListener = _keyEventListeners.TryGetValue(e.Type, out var listener);
@@ -149,7 +179,7 @@ public class WindowEventService : IWindowEventService
     [JSInvokable]
     public async Task<bool> HandleWindowClipboardEvent(ClipboardEventArgs e)
     {
-        if (_clipboardEventListeners == null)
+        if (_isDisposed || _clipboardEventListeners == null)
             return false;
 
         var hasListener = _clipboardEventListeners.TryGetValue(e.Type, out var listener);

--- a/src/BlazorDatasheet/Services/WindowEventService.cs
+++ b/src/BlazorDatasheet/Services/WindowEventService.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Components.Web;
+﻿using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using ClipboardEventArgs = BlazorDatasheet.Core.Events.ClipboardEventArgs;
 using static BlazorDatasheet.Util.JsInteropHelper;
@@ -79,22 +79,6 @@ public class WindowEventService : IWindowEventService
         _clipboardEventListeners ??= new();
         _clipboardEventListeners[eventType] = handler;
         await AddWindowEvent(eventType, nameof(HandleWindowClipboardEvent));
-    }
-
-    public async Task PreventDefault(string eventType)
-    {
-        await CreateDotnetHelperIfNotExists();
-        if (_isDisposed || _windowEventObj == null)
-            return;
-        await _windowEventObj.InvokeVoidAsync("preventDefault", eventType);
-    }
-
-    public async Task CancelPreventDefault(string eventType)
-    {
-        await CreateDotnetHelperIfNotExists();
-        if (_isDisposed || _windowEventObj == null)
-            return;
-        await _windowEventObj.InvokeVoidAsync("cancelPreventDefault", eventType);
     }
 
     // Cached so that callers arriving while initialisation is in flight wait for it to

--- a/src/BlazorDatasheet/wwwroot/js/highlighter.js
+++ b/src/BlazorDatasheet/wwwroot/js/highlighter.js
@@ -1,4 +1,4 @@
-class Highligher {
+﻿class Highligher {
     #inputEl;
     #highlightResultEl;
     #caretToEndPending = false;
@@ -101,8 +101,11 @@ class Highligher {
 
         this.focusAndMoveCursorToEnd = function (onlyIfWithinSheet = false) {
             const sheet = options.inputEl.closest('.bds-sheet');
+            // A sheet activated from code without browser focus leaves the active element on body,
+            // and the editor may still take focus from there. An external control keeps it.
             const canFocus = () => !this.#disposed && (!onlyIfWithinSheet || !sheet ||
-                (document.hasFocus() && sheet.contains(document.activeElement)));
+                (document.hasFocus() && (sheet.contains(document.activeElement) ||
+                    document.activeElement === document.body)));
             if (!canFocus()) return;
             options.inputEl.focus()
 

--- a/src/BlazorDatasheet/wwwroot/js/highlighter.js
+++ b/src/BlazorDatasheet/wwwroot/js/highlighter.js
@@ -3,6 +3,10 @@ class Highligher {
     #highlightResultEl;
     #caretToEndPending = false;
     #onFocusMoveCaret;
+    #disposed = false;
+    #onKeyDown;
+    #onMouseDown;
+    #onInput;
 
     constructor(options) {
         if (!options.inputEl)
@@ -16,20 +20,17 @@ class Highligher {
         this.#highlightResultEl = options.highlightResultEl
         this.#highlightResultEl.innerHTML = options.initialHtml
 
-        this.#inputEl.addEventListener('keydown', this.onKeyDown.bind(this))
-        this.#inputEl.addEventListener('mousedown', this.onMouseDown.bind(this))
-
-        this.#inputEl.addEventListener('input', e => {
-            if (!options.dotnetHelper)
-                return
-
-            options.dotnetHelper.invokeMethodAsync("HandleInput", e.target.textContent)
-        })
+        this.#onKeyDown = this.onKeyDown.bind(this)
+        this.#onMouseDown = this.onMouseDown.bind(this)
+        this.#onInput = e => this.invoke("HandleInput", e.target.textContent)
+        this.#inputEl.addEventListener('keydown', this.#onKeyDown)
+        this.#inputEl.addEventListener('mousedown', this.#onMouseDown)
+        this.#inputEl.addEventListener('input', this.#onInput)
 
         this.resizeObserver = new ResizeObserver((entries) => {
             for (const entry of entries) {
                 if (entry.target === this.#inputEl) {
-                    options.dotnetHelper.invokeMethodAsync("HandleInputSizeChanged", entry.target.getBoundingClientRect())
+                    this.invoke("HandleInputSizeChanged", entry.target.getBoundingClientRect())
                 }
             }
         })
@@ -43,6 +44,8 @@ class Highligher {
 
         this.updateCaretPosition = function () {
             let sel = window.getSelection()
+            if (!sel?.focusNode)
+                return
             let isSelectionInside = sel.focusNode.parentElement === options.inputEl ||
                 sel.focusNode === options.inputEl
             let len = sel.toString().length
@@ -51,7 +54,7 @@ class Highligher {
             if (isSelectionInside && len === 0)
                 caretPosition = sel.focusOffset
 
-            options.dotnetHelper.invokeMethodAsync("HandleCaretPositionUpdate", caretPosition)
+            self.invoke("HandleCaretPositionUpdate", caretPosition)
         }
 
         this.moveCursorToEnd = function (el) {
@@ -96,12 +99,17 @@ class Highligher {
             this.#caretToEndPending = false
         }
 
-        this.focusAndMoveCursorToEnd = function () {
+        this.focusAndMoveCursorToEnd = function (onlyIfWithinSheet = false) {
+            const sheet = options.inputEl.closest('.bds-sheet');
+            const canFocus = () => !this.#disposed && (!onlyIfWithinSheet || !sheet ||
+                (document.hasFocus() && sheet.contains(document.activeElement)));
+            if (!canFocus()) return;
             options.inputEl.focus()
 
             if (document.activeElement !== options.inputEl) {
                 // Retry once on the next frame - a webview may not have been able to take focus yet.
                 requestAnimationFrame(() => {
+                    if (!canFocus()) return;
                     options.inputEl.focus()
                     this.moveCursorToEnd(options.inputEl)
                 })
@@ -111,9 +119,16 @@ class Highligher {
             this.moveCursorToEnd(options.inputEl)
         }
 
-        setTimeout(this.focusAndMoveCursorToEnd.bind(this), 0);
+        // HighlightedInput requests focus after its latest initial value has reached the DOM.
 
         document.addEventListener('selectionchange', this.updateCaretPosition)
+    }
+
+    invoke(method, value) {
+        if (this.#disposed || !this.options.dotnetHelper) return;
+        return this.options.dotnetHelper.invokeMethodAsync(method, value).catch(error => {
+            if (!this.#disposed) console.error('Datasheet editor event failed', error);
+        });
     }
 
     onResize(e) {
@@ -147,9 +162,12 @@ class Highligher {
     }
 
     dispose() {
+        if (this.#disposed) return;
+        this.#disposed = true;
         if (this.#inputEl) {
-            this.#inputEl.removeEventListener('keydown', this.onKeyDown)
-            this.#inputEl.removeEventListener('mousedown', this.onMouseDown)
+            this.#inputEl.removeEventListener('keydown', this.#onKeyDown)
+            this.#inputEl.removeEventListener('mousedown', this.#onMouseDown)
+            this.#inputEl.removeEventListener('input', this.#onInput)
             if (this.#onFocusMoveCaret) {
                 this.#inputEl.removeEventListener('focus', this.#onFocusMoveCaret)
                 this.#onFocusMoveCaret = undefined

--- a/src/BlazorDatasheet/wwwroot/js/menu.js
+++ b/src/BlazorDatasheet/wwwroot/js/menu.js
@@ -1,4 +1,4 @@
-class MenuService {
+﻿class MenuService {
 
     constructor(dotnetHelper) {
         this.menus = [];
@@ -78,6 +78,10 @@ class MenuService {
         if (this.isActive(menuEl))
             return
 
+        // Whatever had focus when the menu was requested gets it back when the menu closes,
+        // unless the user has already moved focus somewhere else in the meantime.
+        const opener = document.activeElement
+
         // run with set timeout to allow the updated menu to be structured based on context
         setTimeout(() => {
             menuEl.showPopover()
@@ -90,6 +94,7 @@ class MenuService {
                     self.activeMenuEls.push(event.target)
                 } else {
                     self.activeMenuEls.splice(self.activeMenuEls.indexOf(event.target), 1)
+                    self.restoreFocus(event.target, opener)
                     await self.dotnetHelper.invokeMethodAsync("OnMenuClose", event.target.id)
                     event.target.removeEventListener('toggle', onToggle)
                 }
@@ -107,6 +112,13 @@ class MenuService {
                 this.positionMenu(menuEl, targetRect, options.margin, options.placement)
             }
         }, 1)
+    }
+
+    restoreFocus(menuEl, opener) {
+        const active = document.activeElement
+        const focusIsOrphaned = !active || active === document.body || menuEl.contains(active)
+        if (focusIsOrphaned && opener?.isConnected && opener !== document.body && opener !== menuEl)
+            opener.focus({preventScroll: true})
     }
 
     positionMenu(menuEl, targetRect, margin, placement, flipCount = 0) {

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -9,7 +9,6 @@
         this.policyRevision = -1;
         this.focusVersion = 0;
         this.preventDefaultMap = {}
-        this.preventExclusionsMap = {}
     }
 
     listen(target, name, fn, capture = false) {
@@ -151,17 +150,6 @@
             return !control || !!control.closest('.bds-editor-overlay');
         }
         return this.active && (e.target === document.body || e.target === document.documentElement);
-    }
-
-    preventDefault(eventName, exclusions) {
-        this.preventDefaultMap[eventName] = true;
-        this.preventExclusionsMap[eventName] = exclusions;
-
-    }
-
-    cancelPreventDefault(eventType) {
-        this.preventDefaultMap[eventType] = false;
-        this.preventExclusionsMap[eventType] = []
     }
 
     /**

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -49,7 +49,7 @@
                 container.dataset.pointerFocus = '';
                 container.focus({ preventScroll: true });
             }
-            if (!inside) this.active = false;
+            if (!inside) this.setActive(false);
             this.reconcileFocus();
             if (inside && this.focused) this.setFocused(true, true);
         }, true);
@@ -95,7 +95,20 @@
         }
         // Browser ownership changes immediately, before any server round trip.
         this.preventDefaultMap.keydown = focused;
-        this.dispatch(this.focusHandler, { focused, version: ++this.focusVersion });
+        this.dispatchFocus();
+    }
+
+    // Deactivation without a focus change, e.g. a pointerdown outside the sheet on something that
+    // keeps browser focus where it is. .NET needs to hear about it or the two sides diverge.
+    setActive(active) {
+        if (this.disposed || active === this.active) return;
+        this.active = active;
+        this.preventDefaultMap.keydown = active;
+        this.dispatchFocus();
+    }
+
+    dispatchFocus() {
+        this.dispatch(this.focusHandler, { focused: this.focused, active: this.active, version: ++this.focusVersion });
     }
 
     setInputState(active, editing, revision, focusVersion) {

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -2,23 +2,113 @@
     constructor(dotnetHelper) {
         this.dotnetHelper = dotnetHelper;
         this.handlerMap = {}
+        this.listeners = new Map();
+        this.disposed = false;
+        this.focused = false;
+        this.active = false;
+        this.policyRevision = -1;
+        this.focusVersion = 0;
         this.preventDefaultMap = {}
         this.preventExclusionsMap = {}
     }
 
+    listen(target, name, fn, capture = false) {
+        const key = name + ':' + capture;
+        const previous = this.listeners.get(key);
+        if (previous) previous.target.removeEventListener(name, previous.fn, capture);
+        target.addEventListener(name, fn, capture);
+        this.listeners.set(key, { target, fn, name, capture });
+    }
+
     registerEvent(eventName, handlerName, throttleInMs = 0) {
-        try {
-            if (this.handlerMap[eventName])
-                window.removeEventListener(eventName, this.handleWindowEvent)
+        if (this.disposed) return;
+        this.handlerMap[eventName] = handlerName;
+        const handler = this.handleWindowEvent.bind(this);
+        this.listen(window, eventName, throttleInMs ? this.throttle(handler, throttleInMs) : handler);
+    }
 
-            this.handlerMap[eventName] = handlerName;
-            let fn = throttleInMs === 0 ?
-                this.handleWindowEvent.bind(this) : this.throttle(this.handleWindowEvent.bind(this), throttleInMs)
-            window.addEventListener(eventName, fn)
-        } catch (ex) {
-            return false
+    dispatch(handler, value) {
+        if (this.disposed) return;
+        // Invoke in browser event order, but do not wait for earlier callbacks: waiting delays
+        // buffered keys past native editor input and can overwrite newer characters.
+        return this.dotnetHelper.invokeMethodAsync(handler, value).catch(error => {
+            if (!this.disposed) console.error('Datasheet event failed', error);
+        });
+    }
+
+    configureFocus(container, handler) {
+        if (this.disposed) return;
+        this.container = container;
+        this.focusHandler = handler;
+        this.listen(window, 'pointerdown', e => {
+            const inside = this.contains(e.target);
+            const control = e.target.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
+            if (inside && (!control || control === container)) {
+                container.focus({ preventScroll: true });
+            }
+            if (!inside) this.active = false;
+            this.reconcileFocus();
+            if (inside && this.focused) this.setFocused(true, true);
+        }, true);
+        this.listen(window, 'focusin', e => {
+            this.reconcileFocus();
+        }, true);
+        this.listen(window, 'focusout', e => {
+            if (e.relatedTarget) this.setFocused(this.contains(e.relatedTarget));
+            else queueMicrotask(() => {
+                // Removing an editor can move focus to body without an external focus destination.
+                if (this.focused && e.target.closest?.('.bds-editor-overlay') && !e.target.isConnected)
+                    this.restoreFocus();
+                this.reconcileFocus();
+            });
+        }, true);
+        this.listen(window, 'blur', () => this.setFocused(false));
+        this.listen(window, 'focus', () => this.reconcileFocus());
+        this.listen(document, 'visibilitychange', () => this.reconcileFocus());
+        this.reconcileFocus();
+    }
+
+    contains(target) {
+        return !!target && this.container.contains(target) && target.closest?.('.bds-sheet') === this.container;
+    }
+
+    reconcileFocus() {
+        if (!this.disposed)
+            this.setFocused(document.visibilityState !== 'hidden' && document.hasFocus() && this.contains(document.activeElement));
+    }
+
+    setFocused(focused, activate = false) {
+        if (this.disposed || (focused === this.focused && !(activate && focused && !this.active))) return;
+        this.focused = focused;
+        this.active = focused;
+        // Browser ownership changes immediately, before any server round trip.
+        this.preventDefaultMap.keydown = focused;
+        this.dispatch(this.focusHandler, { focused, version: ++this.focusVersion });
+    }
+
+    setInputState(active, editing, revision, focusVersion) {
+        if (this.disposed || revision < this.policyRevision || focusVersion !== this.focusVersion) return;
+        this.policyRevision = revision;
+        this.active = active;
+        this.preventDefaultMap.keydown = active && !editing;
+    }
+
+    restoreFocus() {
+        if (!this.disposed && this.focused && document.hasFocus() &&
+            (this.contains(document.activeElement) || document.activeElement === document.body))
+            this.container.focus({ preventScroll: true });
+    }
+
+    ownsInput(e) {
+        if (!this.container) return true;
+        if (document.visibilityState === 'hidden' || !document.hasFocus()) return false;
+        if (this.contains(e.target)) {
+            if (!this.active) return false;
+            // Embedded controls own their input; cell editors still use sheet shortcuts.
+            const control = e.target.closest?.('input, textarea, select, button, a[href], [contenteditable]');
+            return !control || !!control.closest('.bds-editor-overlay');
         }
-
+        return this.active && (e.target === document.body || e.target === document.documentElement);
     }
 
     preventDefault(eventName, exclusions) {
@@ -37,10 +127,16 @@
      * @param e {KeyboardEvent}
      */
     async handleWindowEvent(e) {
-        if (e.isComposing)
+        if (this.disposed || e.isComposing)
             return
 
+        if (['keydown', 'copy', 'paste'].includes(e.type) && !this.ownsInput(e)) return;
+
         if (this.handlerMap[e.type]) {
+            if (this.container && e.type === 'keydown' && e.key === 'Tab' &&
+                e.target.closest?.('.bds-editor-overlay'))
+                e.preventDefault();
+
             // Never suppress the browser default while the event is going into an editable element -
             // that's the cell editor receiving input. The preventDefault flag is toggled from .NET, so
             // it always lags the real edit state by an interop round trip; suppressing on the stale flag
@@ -58,7 +154,7 @@
 
             // Nothing can be prevented past this point - the event has finished dispatching by the time
             // the interop call resolves - so the handler's return value is only used by .NET.
-            await this.dotnetHelper.invokeMethodAsync(this.handlerMap[e.type], this.serialize(e));
+            this.dispatch(this.handlerMap[e.type], this.serialize(e));
         }
     }
 
@@ -79,10 +175,12 @@
     }
 
     async dispose() {
-        for (let eventName in this.handlerMap) {
-            window.removeEventListener(eventName, this.handleWindowEvent)
-        }
-        this.handlerMap = {}
+        this.disposed = true;
+        for (const { target, name, fn, capture } of this.listeners.values())
+            target.removeEventListener(name, fn, capture);
+        this.listeners.clear();
+        this.handlerMap = {};
+        this.preventDefaultMap = {};
     }
 
     serialize(e) {

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -42,16 +42,21 @@
         this.focusHandler = handler;
         this.listen(window, 'pointerdown', e => {
             const inside = this.contains(e.target);
-            const control = e.target.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
+            const control = this.controlOf(e.target);
             if (inside && (!control || control === container)) {
                 // Chrome treats this scripted focus as keyboard focus, so mark it as pointer
                 // driven and let the css drop the focus ring for it.
                 container.dataset.pointerFocus = '';
                 container.focus({ preventScroll: true });
             }
-            if (!inside) this.setActive(false);
+            if (!inside && !this.inMenu(e.target)) this.setActive(false);
             this.reconcileFocus();
             if (inside && this.focused) this.setFocused(true, true);
+        }, true);
+        this.listen(window, 'mousedown', e => {
+            // Menus render outside the sheet, so clicking an item would hand focus to body and
+            // deactivate the sheet. Items act on mouseup, so keeping focus where it is costs nothing.
+            if (this.focused && this.inMenu(e.target) && !this.controlOf(e.target)) e.preventDefault();
         }, true);
         this.listen(window, 'focusin', e => {
             this.reconcileFocus();
@@ -69,6 +74,14 @@
         this.listen(window, 'focus', () => this.reconcileFocus());
         this.listen(document, 'visibilitychange', () => this.reconcileFocus());
         this.reconcileFocus();
+    }
+
+    controlOf(target) {
+        return target?.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
+    }
+
+    inMenu(target) {
+        return !!target?.closest?.('.bds-sheet-popover');
     }
 
     contains(target) {

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -44,6 +44,9 @@
             const inside = this.contains(e.target);
             const control = e.target.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
             if (inside && (!control || control === container)) {
+                // Chrome treats this scripted focus as keyboard focus, so mark it as pointer
+                // driven and let the css drop the focus ring for it.
+                container.dataset.pointerFocus = '';
                 container.focus({ preventScroll: true });
             }
             if (!inside) this.active = false;
@@ -81,6 +84,7 @@
         if (this.disposed || (focused === this.focused && !(activate && focused && !this.active))) return;
         this.focused = focused;
         this.active = focused;
+        if (!focused && this.container) delete this.container.dataset.pointerFocus;
         // Browser ownership changes immediately, before any server round trip.
         this.preventDefaultMap.keydown = focused;
         this.dispatch(this.focusHandler, { focused, version: ++this.focusVersion });

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -84,7 +84,15 @@
         if (this.disposed || (focused === this.focused && !(activate && focused && !this.active))) return;
         this.focused = focused;
         this.active = focused;
-        if (!focused && this.container) delete this.container.dataset.pointerFocus;
+        if (this.container) {
+            // Focus state is painted from here so the selection dims the instant focus leaves,
+            // without waiting on a render round trip.
+            if (focused) this.container.dataset.focused = '';
+            else {
+                delete this.container.dataset.focused;
+                delete this.container.dataset.pointerFocus;
+            }
+        }
         // Browser ownership changes immediately, before any server round trip.
         this.preventDefaultMap.keydown = focused;
         this.dispatch(this.focusHandler, { focused, version: ++this.focusVersion });

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -114,12 +114,17 @@
     }
 
     // Deactivation without a focus change, e.g. a pointerdown outside the sheet on something that
-    // keeps browser focus where it is. .NET needs to hear about it or the two sides diverge.
+    // keeps browser focus where it is. .NET needs to hear about it or the two sides diverge. The
+    // report waits a tick: if the click does move focus away, the focus-out carries it instead, so
+    // .NET sees one transition with activation reported before focus, as documented.
     setActive(active) {
         if (this.disposed || active === this.active) return;
         this.active = active;
         this.preventDefaultMap.keydown = active;
-        this.dispatchFocus();
+        const version = this.focusVersion;
+        setTimeout(() => {
+            if (!this.disposed && this.focusVersion === version && this.active === active) this.dispatchFocus();
+        }, 0);
     }
 
     dispatchFocus(fromWindow = false) {

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -75,8 +75,12 @@
         this.reconcileFocus();
     }
 
+    // Finds the interactive element a pointer or key event is aimed at. The sheet's own chrome
+    // (data-bds-chrome, e.g. the heading dropdown button) is not a control: clicking it should
+    // leave focus on the sheet so keys keep working afterwards.
     controlOf(target) {
-        return target?.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
+        const control = target?.closest?.('input, textarea, select, button, a[href], [contenteditable], [tabindex]');
+        return control?.hasAttribute?.('data-bds-chrome') ? null : control;
     }
 
     inMenu(target) {
@@ -152,7 +156,7 @@
             if (!this.active) return false;
             // Embedded controls own their input; cell editors still use sheet shortcuts.
             const control = e.target.closest?.('input, textarea, select, button, a[href], [contenteditable]');
-            return !control || !!control.closest('.bds-editor-overlay');
+            return !control || control.hasAttribute?.('data-bds-chrome') || !!control.closest('.bds-editor-overlay');
         }
         return this.active && (e.target === document.body || e.target === document.documentElement);
     }

--- a/src/BlazorDatasheet/wwwroot/js/window-events.js
+++ b/src/BlazorDatasheet/wwwroot/js/window-events.js
@@ -70,9 +70,9 @@
                 this.reconcileFocus();
             });
         }, true);
-        this.listen(window, 'blur', () => this.setFocused(false));
-        this.listen(window, 'focus', () => this.reconcileFocus());
-        this.listen(document, 'visibilitychange', () => this.reconcileFocus());
+        this.listen(window, 'blur', () => this.setFocused(false, false, true));
+        this.listen(window, 'focus', () => this.reconcileFocus(true));
+        this.listen(document, 'visibilitychange', () => this.reconcileFocus(true));
         this.reconcileFocus();
     }
 
@@ -88,12 +88,15 @@
         return !!target && this.container.contains(target) && target.closest?.('.bds-sheet') === this.container;
     }
 
-    reconcileFocus() {
+    reconcileFocus(fromWindow = false) {
         if (!this.disposed)
-            this.setFocused(document.visibilityState !== 'hidden' && document.hasFocus() && this.contains(document.activeElement));
+            this.setFocused(document.visibilityState !== 'hidden' && document.hasFocus() && this.contains(document.activeElement),
+                false, fromWindow);
     }
 
-    setFocused(focused, activate = false) {
+    // fromWindow marks a change caused by the window or tab losing or regaining focus, as opposed
+    // to focus moving between elements on the page. .NET treats the two differently while editing.
+    setFocused(focused, activate = false, fromWindow = false) {
         if (this.disposed || (focused === this.focused && !(activate && focused && !this.active))) return;
         this.focused = focused;
         this.active = focused;
@@ -108,7 +111,7 @@
         }
         // Browser ownership changes immediately, before any server round trip.
         this.preventDefaultMap.keydown = focused;
-        this.dispatchFocus();
+        this.dispatchFocus(fromWindow);
     }
 
     // Deactivation without a focus change, e.g. a pointerdown outside the sheet on something that
@@ -120,8 +123,9 @@
         this.dispatchFocus();
     }
 
-    dispatchFocus() {
-        this.dispatch(this.focusHandler, { focused: this.focused, active: this.active, version: ++this.focusVersion });
+    dispatchFocus(fromWindow = false) {
+        this.dispatch(this.focusHandler,
+            { focused: this.focused, active: this.active, fromWindow, version: ++this.focusVersion });
     }
 
     setInputState(active, editing, revision, focusVersion) {

--- a/src/BlazorDatasheet/wwwroot/sheet-styles.css
+++ b/src/BlazorDatasheet/wwwroot/sheet-styles.css
@@ -539,7 +539,10 @@
     display: grid;
 }
 
-.bds-cell-has-flags { position: relative; }
+.bds-cell-has-flags {
+    position: relative;
+}
+
 .bds-cell-corner-flag {
     position: absolute;
     width: var(--bds-flag-size, 8px);
@@ -549,7 +552,27 @@
     background-color: var(--bds-flag-color, currentColor);
     pointer-events: none;
 }
-.bds-cell-corner-top-left { top: 0; left: 0; clip-path: polygon(0 0, 100% 0, 0 100%); }
-.bds-cell-corner-top-right { top: 0; right: 0; clip-path: polygon(0 0, 100% 0, 100% 100%); }
-.bds-cell-corner-bottom-left { bottom: 0; left: 0; clip-path: polygon(0 0, 0 100%, 100% 100%); }
-.bds-cell-corner-bottom-right { bottom: 0; right: 0; clip-path: polygon(100% 0, 0 100%, 100% 100%); }
+
+.bds-cell-corner-top-left {
+    top: 0;
+    left: 0;
+    clip-path: polygon(0 0, 100% 0, 0 100%);
+}
+
+.bds-cell-corner-top-right {
+    top: 0;
+    right: 0;
+    clip-path: polygon(0 0, 100% 0, 100% 100%);
+}
+
+.bds-cell-corner-bottom-left {
+    bottom: 0;
+    left: 0;
+    clip-path: polygon(0 0, 0 100%, 100% 100%);
+}
+
+.bds-cell-corner-bottom-right {
+    bottom: 0;
+    right: 0;
+    clip-path: polygon(100% 0, 0 100%, 100% 100%);
+}

--- a/src/BlazorDatasheet/wwwroot/sheet-styles.css
+++ b/src/BlazorDatasheet/wwwroot/sheet-styles.css
@@ -4,6 +4,7 @@
     --sheet-font-family: "Segoe UI Variable", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, "Helvetica Neue", Arial, sans-serif;
     --selection-border-thickness: 2px;
     --sheet-border-width: 1px;
+    --sheet-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
     --sheet-cell-padding-vertical: 3px;
     --sheet-cell-padding-horizontal: 6px;
     /* The selection border straddles the cell edge, so it eats half its thickness into the
@@ -28,6 +29,10 @@
     --invalid-cell-foreground-color: #dc2626;
     --selection-bg-color: rgba(37, 99, 235, 0.14);
     --selection-border-color: #2563eb;
+    --selection-bg-color-unfocused: rgba(100, 116, 139, 0.10);
+    --selection-border-color-unfocused: #94a3b8;
+    --head-selection-bg-color-unfocused: #e8edf5;
+    --sheet-focus-ring-color: rgba(37, 99, 235, 0.40);
     --cell-highlight-bg-color: #a9e5b6;
     --num-highlight-color: #18688f;
     --string-highlight-color: #256b3e;
@@ -67,6 +72,10 @@
     --invalid-cell-foreground-color: #d71b1b;
     --selection-bg-color: rgba(83, 101, 121, 0.18);
     --selection-border-color: #1c6f9a;
+    --selection-bg-color-unfocused: rgba(83, 101, 121, 0.09);
+    --selection-border-color-unfocused: #4d5761;
+    --head-selection-bg-color-unfocused: rgb(45, 48, 51);
+    --sheet-focus-ring-color: rgba(56, 141, 189, 0.55);
     --cell-highlight-bg-color: #456b4d;
     --num-highlight-color: #d4d6ec;
     --string-highlight-color: #79a16a;
@@ -98,8 +107,31 @@
     contain: style;
     line-height: 1.35;
     border-radius: 8px;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    box-shadow: var(--sheet-shadow);
     position: relative;
+}
+
+/* The UA outline is replaced with a themed ring that follows the sheet's corner radius. It
+   only shows for keyboard focus - a pointer user just clicked the cell they're looking at. */
+.bds-sheet:focus {
+    outline: none;
+}
+
+.bds-sheet:focus-visible {
+    box-shadow: var(--sheet-shadow), 0 0 0 2px var(--sheet-focus-ring-color);
+}
+
+/* Focus moved by our own pointerdown handler still matches :focus-visible in chrome. */
+.bds-sheet[data-pointer-focus]:focus-visible {
+    box-shadow: var(--sheet-shadow);
+}
+
+/* The selection carries focus state: with browser focus elsewhere it dims, so that it doesn't
+   claim keyboard input that won't arrive. */
+.bds-sheet-unfocused {
+    --selection-bg-color: var(--selection-bg-color-unfocused);
+    --selection-border-color: var(--selection-border-color-unfocused);
+    --head-selection-bg-color: var(--head-selection-bg-color-unfocused);
 }
 
 .bds-sheet-top-border::before,

--- a/src/BlazorDatasheet/wwwroot/sheet-styles.css
+++ b/src/BlazorDatasheet/wwwroot/sheet-styles.css
@@ -126,9 +126,9 @@
     box-shadow: var(--sheet-shadow);
 }
 
-/* The selection carries focus state: with browser focus elsewhere it dims, so that it doesn't
-   claim keyboard input that won't arrive. */
-.bds-sheet-unfocused {
+/* The selection follows browser focus, as in excel: while focus is elsewhere it dims. The
+   attribute is set from window-events.js the moment focus changes. */
+.bds-sheet:not([data-focused]) {
     --selection-bg-color: var(--selection-bg-color-unfocused);
     --selection-border-color: var(--selection-border-color-unfocused);
     --head-selection-bg-color: var(--head-selection-bg-color-unfocused);

--- a/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
@@ -40,11 +40,26 @@ public class DatasheetFocusTests
             .Add(x => x.OnFocusIn, _ => events.Add("in"))
             .Add(x => x.OnFocusOut, _ => events.Add("out")));
         component.Find(".bds-sheet").GetAttribute("tabindex").Should().Be("0");
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Active = false, Version = 2 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
         events.Should().Equal("active:True", "in", "active:False", "out");
+    }
+
+    [Test]
+    public async Task Deactivation_Without_Focus_Change_Is_Reported_Without_Focus_Out()
+    {
+        using var context = CreateContext();
+        var events = new List<string>();
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
+            .Add(x => x.OnSheetActiveChanged, e => events.Add("active:" + e.IsActive))
+            .Add(x => x.OnFocusOut, _ => events.Add("out")));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = false, Version = 2 }));
+        events.Should().Equal("active:True", "active:False");
+        var state = context.JSInterop.Invocations.Where(x => x.Identifier == "setInputState").Last();
+        state.Arguments[0].Should().Be(false);
     }
 
     [Test]
@@ -68,9 +83,9 @@ public class DatasheetFocusTests
         using var context = CreateContext();
         var sheet = new Sheet(2, 2);
         var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, sheet));
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
         await component.InvokeAsync(() => sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "a"));
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Active = false, Version = 2 }));
         sheet.Editor.IsEditing.Should().BeTrue();
         await component.InvokeAsync(() => sheet.Editor.CancelEdit());
         var state = context.JSInterop.Invocations.Where(x => x.Identifier == "setInputState").Last();
@@ -92,9 +107,9 @@ public class DatasheetFocusTests
             }))
             .Add(x => x.OnFocusIn, _ => events.Add("in"))
             .Add(x => x.OnFocusOut, _ => events.Add("out")));
-        var first = component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        var first = component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
         await entered.Task;
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Active = false, Version = 2 }));
         release.SetResult();
         await first;
         events.Should().Equal("out");
@@ -108,7 +123,7 @@ public class DatasheetFocusTests
         var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
             .Add(x => x.OnFocusIn, _ => count++));
         await component.InvokeAsync(() => component.Instance.DisposeAsync().AsTask());
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
         count.Should().Be(0);
     }
     [Test]

--- a/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
@@ -9,6 +9,7 @@ using BlazorDatasheet.Core.Edit;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.Extensions;
 using BlazorDatasheet.Services;
+using BlazorDatasheet.Edit;
 using BlazorDatasheet.Edit.DefaultComponents;
 using Bunit;
 using FluentAssertions;
@@ -91,6 +92,41 @@ public class DatasheetFocusTests
         var state = context.JSInterop.Invocations.Where(x => x.Identifier == "setInputState").Last();
         state.Arguments[0].Should().Be(false);
         state.Arguments[1].Should().Be(false);
+    }
+
+    [TestCase(EditFocusLossAction.Accept, "typed")]
+    [TestCase(EditFocusLossAction.Cancel, "old")]
+    [TestCase(EditFocusLossAction.KeepEditing, "old")]
+    public async Task Focus_Loss_To_Another_Element_Finishes_The_Edit_As_Configured(EditFocusLossAction action,
+        string cellValueAfter)
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(2, 2);
+        sheet.Cells.SetValue(0, 0, "old");
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, sheet)
+            .Add(x => x.OnEditFocusLoss, action));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
+        await component.InvokeAsync(() =>
+        {
+            sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "t");
+            sheet.Editor.EditValue = "typed";
+        });
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Active = false, Version = 2 }));
+        sheet.Editor.IsEditing.Should().Be(action == EditFocusLossAction.KeepEditing);
+        sheet.Cells.GetValue(0, 0).Should().Be(cellValueAfter);
+    }
+
+    [Test]
+    public async Task Focus_Leaving_The_Window_Keeps_The_Edit_Open_Even_When_Accepting_On_Focus_Loss()
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(2, 2);
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, sheet)
+            .Add(x => x.OnEditFocusLoss, EditFocusLossAction.Accept));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Active = true, Version = 1 }));
+        await component.InvokeAsync(() => sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "a"));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Active = false, FromWindow = true, Version = 2 }));
+        sheet.Editor.IsEditing.Should().BeTrue();
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using BlazorDatasheet.Events;
+using Microsoft.AspNetCore.Components;
+using System.Linq;
+using System.Threading.Tasks;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Edit;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Extensions;
+using BlazorDatasheet.Services;
+using BlazorDatasheet.Edit.DefaultComponents;
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using TestContext = Bunit.TestContext;
+
+namespace BlazorDatasheet.Test.Render;
+
+public class DatasheetFocusTests
+{
+    private static TestContext CreateContext()
+    {
+        var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.JSInterop.SetupModule(x => x.Identifier == "getVirtualiser")
+            .Setup<Rect>(x => x.Identifier == "calculateViewRect").SetResult(new Rect(0, 0, 500, 500));
+        context.JSInterop.SetupModule(x => x.Identifier == "createWindowEventsService");
+        context.Services.AddBlazorDatasheet();
+        return context;
+    }
+
+    [Test]
+    public async Task Focus_Transitions_Notify_Activation_First_And_Ignore_Duplicates_And_Stale_Events()
+    {
+        using var context = CreateContext();
+        var events = new List<string>();
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
+            .Add(x => x.OnSheetActiveChanged, e => events.Add("active:" + e.IsActive))
+            .Add(x => x.OnFocusIn, _ => events.Add("in"))
+            .Add(x => x.OnFocusOut, _ => events.Add("out")));
+        component.Find(".bds-sheet").GetAttribute("tabindex").Should().Be("0");
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        events.Should().Equal("active:True", "in", "active:False", "out");
+    }
+
+    [Test]
+    public async Task Manual_Activation_Does_Not_Claim_Browser_Focus()
+    {
+        using var context = CreateContext();
+        var focusCount = 0;
+        var activeCount = 0;
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
+            .Add(x => x.OnSheetActiveChanged, _ => activeCount++)
+            .Add(x => x.OnFocusIn, _ => focusCount++));
+        await component.InvokeAsync(() => component.Instance.SetActiveAsync());
+        await component.InvokeAsync(() => component.Instance.SetActiveAsync());
+        activeCount.Should().Be(1);
+        focusCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Focus_Loss_Preserves_Edit_And_Finishing_Inactive_Edit_Does_Not_Suppress_Keys()
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(2, 2);
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, sheet));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await component.InvokeAsync(() => sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "a"));
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        sheet.Editor.IsEditing.Should().BeTrue();
+        await component.InvokeAsync(() => sheet.Editor.CancelEdit());
+        var state = context.JSInterop.Invocations.Where(x => x.Identifier == "setInputState").Last();
+        state.Arguments[0].Should().Be(false);
+        state.Arguments[1].Should().Be(false);
+    }
+
+    [Test]
+    public async Task Focus_Loss_During_Activation_Callback_Drops_Obsolete_Focus_In()
+    {
+        using var context = CreateContext();
+        var entered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        var events = new List<string>();
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
+            .Add(x => x.OnSheetActiveChanged, EventCallback.Factory.Create<SheetActiveEventArgs>(this, async e =>
+            {
+                if (e.IsActive) { entered.SetResult(); await release.Task; }
+            }))
+            .Add(x => x.OnFocusIn, _ => events.Add("in"))
+            .Add(x => x.OnFocusOut, _ => events.Add("out")));
+        var first = component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        await entered.Task;
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        release.SetResult();
+        await first;
+        events.Should().Equal("out");
+    }
+
+    [Test]
+    public async Task Disposed_Component_Ignores_Late_Focus_Notifications()
+    {
+        using var context = CreateContext();
+        var count = 0;
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2))
+            .Add(x => x.OnFocusIn, _ => count++));
+        await component.InvokeAsync(() => component.Instance.DisposeAsync().AsTask());
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        count.Should().Be(0);
+    }
+    [Test]
+    public async Task Consecutive_Edits_Initialize_The_Current_Editor_With_Their_Own_Entry_Key()
+    {
+        using var context = CreateContext();
+        var sheet = new Sheet(3, 3);
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, sheet));
+        await component.InvokeAsync(() =>
+        {
+            component.Instance.ForceReRender();
+            sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "A");
+        });
+        var first = component.FindComponent<TextEditorComponent>().Instance;
+        first.CurrentValue.Should().Be("A");
+        await component.InvokeAsync(() =>
+        {
+            sheet.Editor.CancelEdit();
+            sheet.Editor.BeginEdit(1, 0, true, EditEntryMode.Key, "B");
+        });
+        var second = component.FindComponent<TextEditorComponent>().Instance;
+        second.Should().NotBeSameAs(first);
+        second.CurrentValue.Should().Be("B");
+    }
+
+}

--- a/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using BlazorDatasheet.Events;
 using Microsoft.AspNetCore.Components;
@@ -45,18 +45,6 @@ public class DatasheetFocusTests
         await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
         await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
         events.Should().Equal("active:True", "in", "active:False", "out");
-    }
-
-    [Test]
-    public async Task Selection_Dims_While_Browser_Focus_Is_Elsewhere()
-    {
-        using var context = CreateContext();
-        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2)));
-        component.Find(".bds-sheet").ClassList.Should().Contain("bds-sheet-unfocused");
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
-        component.Find(".bds-sheet").ClassList.Should().NotContain("bds-sheet-unfocused");
-        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
-        component.Find(".bds-sheet").ClassList.Should().Contain("bds-sheet-unfocused");
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/DatasheetFocusTests.cs
@@ -48,6 +48,18 @@ public class DatasheetFocusTests
     }
 
     [Test]
+    public async Task Selection_Dims_While_Browser_Focus_Is_Elsewhere()
+    {
+        using var context = CreateContext();
+        var component = context.RenderComponent<Datasheet>(p => p.Add(x => x.Sheet, new Sheet(2, 2)));
+        component.Find(".bds-sheet").ClassList.Should().Contain("bds-sheet-unfocused");
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = true, Version = 1 }));
+        component.Find(".bds-sheet").ClassList.Should().NotContain("bds-sheet-unfocused");
+        await component.InvokeAsync(() => component.Instance.HandleFocusChanged(new() { Focused = false, Version = 2 }));
+        component.Find(".bds-sheet").ClassList.Should().Contain("bds-sheet-unfocused");
+    }
+
+    [Test]
     public async Task Manual_Activation_Does_Not_Claim_Browser_Focus()
     {
         using var context = CreateContext();

--- a/test/BlazorDatasheet.Test/Render/EditorInitializationTests.cs
+++ b/test/BlazorDatasheet.Test/Render/EditorInitializationTests.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using System.Threading.Tasks;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Edit;
+using BlazorDatasheet.Edit;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Render;
+
+public class EditorInitializationTests
+{
+    [Test]
+    public async Task Parent_Render_Before_Dynamic_Editor_Exists_Keeps_Initialization_Pending()
+    {
+        var sheet = new Sheet(1, 1);
+        sheet.Editor.BeginEdit(0, 0, true, EditEntryMode.Key, "a");
+        var layer = new RenderProbe();
+        var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        typeof(EditorLayer).GetField("_sheet", flags)!.SetValue(layer, sheet);
+        var pending = typeof(EditorLayer).GetProperty("BeginningEdit", flags)!;
+        pending.SetValue(layer, true);
+
+        await layer.AfterRender();
+        pending.GetValue(layer).Should().Be(true);
+
+        sheet.Editor.CancelEdit();
+        await layer.AfterRender();
+        pending.GetValue(layer).Should().Be(false, "a finished edit must not initialize on a later render");
+    }
+
+    private sealed class RenderProbe : EditorLayer
+    {
+        public Task AfterRender() => base.OnAfterRenderAsync(false);
+    }
+}

--- a/test/BlazorDatasheet.Test/Render/HighlightedInputFocusTests.cs
+++ b/test/BlazorDatasheet.Test/Render/HighlightedInputFocusTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using BlazorDatasheet.Edit.DefaultComponents;
+using BlazorDatasheet.Formula.Core.Interpreter;
+using Bunit;
+using FluentAssertions;
+using NUnit.Framework;
+using TestContext = Bunit.TestContext;
+
+namespace BlazorDatasheet.Test.Render;
+
+public class HighlightedInputFocusTests
+{
+    [Test]
+    public void Initial_Focus_Is_Requested_After_Highlighter_Creation_With_Ownership_Check()
+    {
+        using var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.JSInterop.SetupModule(x => x.Identifier == "createHighlighter");
+        context.RenderComponent<HighlightedInput>(p => p
+            .Add(x => x.Value, "InitialKey")
+            .Add(x => x.FormulaOptions, new FormulaOptions()));
+        var calls = context.JSInterop.Invocations.ToList();
+        var created = calls.FindIndex(x => x.Identifier == "createHighlighter");
+        var focused = calls.FindIndex(x => x.Identifier == "focusAndMoveCursorToEnd");
+        created.Should().BeGreaterThanOrEqualTo(0);
+        focused.Should().BeGreaterThan(created);
+        calls[focused].Arguments.Should().Equal(true);
+    }
+    [Test]
+    public void Editor_Readiness_Applies_Initial_Key_Before_Requesting_Focus()
+    {
+        using var context = new TestContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.JSInterop.SetupModule(x => x.Identifier == "createHighlighter");
+        var input = context.RenderComponent<HighlightedInput>(p => p
+            .Add(x => x.Value, "")
+            .Add(x => x.ReadyToFocus, false)
+            .Add(x => x.FormulaOptions, new FormulaOptions()));
+        context.JSInterop.Invocations.Should().NotContain(x => x.Identifier == "focusAndMoveCursorToEnd");
+        input.SetParametersAndRender(p => p.Add(x => x.Value, "H").Add(x => x.ReadyToFocus, true));
+        var calls = context.JSInterop.Invocations.ToList();
+        calls.FindIndex(x => x.Identifier == "setInputText").Should().BeLessThan(
+            calls.FindIndex(x => x.Identifier == "focusAndMoveCursorToEnd"));
+        context.JSInterop.Invocations.Count(x => x.Identifier == "focusAndMoveCursorToEnd").Should().Be(1);
+    }
+
+}

--- a/test/BlazorDatasheet.Test/Render/WindowEventServiceTests.cs
+++ b/test/BlazorDatasheet.Test/Render/WindowEventServiceTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BlazorDatasheet.Services;
+using FluentAssertions;
+using Microsoft.JSInterop;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.Render;
+
+public class WindowEventServiceTests
+{
+    [Test]
+    public async Task Disposal_During_Import_Disposes_Module_Without_Registering_Listeners()
+    {
+        var runtime = new DelayedRuntime();
+        var service = new WindowEventService(runtime);
+        var calls = 0;
+        var initialization = service.ConfigureFocus(default, _ => { calls++; return Task.CompletedTask; });
+        await service.DisposeAsync();
+        var module = new Module();
+        runtime.Completion.SetResult(module);
+        await initialization;
+        await service.HandleFocusChanged(new SheetFocusEventArgs { Focused = true, Version = 1 });
+        module.Disposed.Should().BeTrue();
+        module.Invocations.Should().Be(0);
+        calls.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Registering_An_Event_Again_Replaces_The_Previous_Handler()
+    {
+        using var context = new Bunit.TestContext();
+        context.JSInterop.Mode = Bunit.JSRuntimeMode.Loose;
+        await using var service = new WindowEventService(context.JSInterop.JSRuntime);
+        var oldCalls = 0;
+        var newCalls = 0;
+        await service.RegisterKeyEvent("keydown", _ => { oldCalls++; return Task.FromResult(false); });
+        await service.RegisterKeyEvent("keydown", _ => { newCalls++; return Task.FromResult(false); });
+        await service.HandleWindowKeyEvent(new SheetKeyboardEventArgs { Type = "keydown" });
+        oldCalls.Should().Be(0);
+        newCalls.Should().Be(1);
+    }
+
+    private sealed class DelayedRuntime : IJSRuntime
+    {
+        public TaskCompletionSource<IJSObjectReference> Completion { get; } = new();
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, default, args);
+        public async ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args) =>
+            (TValue)await Completion.Task;
+    }
+
+    private sealed class Module : IJSObjectReference
+    {
+        public bool Disposed { get; private set; }
+        public int Invocations { get; private set; }
+        public ValueTask DisposeAsync() { Disposed = true; return ValueTask.CompletedTask; }
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args) =>
+            InvokeAsync<TValue>(identifier, default, args);
+        public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            Invocations++;
+            throw new InvalidOperationException("A disposed service must not invoke its module.");
+        }
+    }
+}

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -1,0 +1,9 @@
+Run the browser event regression tests from the repository root:
+
+```sh
+node --test test/js/*.test.mjs
+```
+
+These use Node's built-in test runner and lightweight DOM event fixtures, with no npm dependencies.
+They cover input ownership, focus transitions, stale interop updates, editor focus readiness,
+and listener disposal. Real browser validation is also needed for native focus and editor behavior.

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -5,5 +5,5 @@ node --test test/js/*.test.mjs
 ```
 
 These use Node's built-in test runner and lightweight DOM event fixtures, with no npm dependencies.
-They cover input ownership, focus transitions, stale interop updates, editor focus readiness,
+They cover input ownership, focus transitions, stale interop updates, editor focus readiness, menu focus return,
 and listener disposal. Real browser validation is also needed for native focus and editor behavior.

--- a/test/js/menu.test.mjs
+++ b/test/js/menu.test.mjs
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+const source = await readFile(new URL('../../src/BlazorDatasheet/wwwroot/js/menu.js', import.meta.url), 'utf8');
+const { getMenuService } = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+
+function setup() {
+    globalThis.window = new EventTarget();
+    globalThis.document = { body: {} };
+    const service = getMenuService({ invokeMethodAsync: async () => {} });
+    const menu = { id: 'menu', contains: t => t?.menu === menu };
+    const opener = { isConnected: true, focus() { this.focused = true; } };
+    return { service, menu, opener };
+}
+
+test('closing a menu returns focus to the opener when focus was left on body or inside the menu', () => {
+    const { service, menu, opener } = setup();
+    document.activeElement = document.body;
+    service.restoreFocus(menu, opener);
+    assert.equal(opener.focused, true);
+    opener.focused = false;
+    document.activeElement = { menu };
+    service.restoreFocus(menu, opener);
+    assert.equal(opener.focused, true);
+});
+
+test('closing a menu leaves focus alone when the user moved it elsewhere or the opener is gone', () => {
+    const { service, menu, opener } = setup();
+    document.activeElement = { tagName: 'INPUT' };
+    service.restoreFocus(menu, opener);
+    assert.equal(opener.focused, undefined);
+    document.activeElement = document.body;
+    opener.isConnected = false;
+    service.restoreFocus(menu, opener);
+    assert.equal(opener.focused, undefined);
+});

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -142,6 +142,21 @@ test('a pointerdown outside that keeps browser focus still reports deactivation'
     assert.equal(calls.at(-1)[1].active, true);
 });
 
+test('clicking a menu item keeps the sheet focused and active', async () => {
+    const { service, container, calls } = setup();
+    const item = { closest: selector => selector === '.bds-sheet-popover' ? {} : null };
+    service.listeners.get('pointerdown:true').fn({ target: item });
+    const mousedown = { target: item, preventDefault() { this.prevented = true; } };
+    service.listeners.get('mousedown:true').fn(mousedown);
+    assert.equal(mousedown.prevented, true);
+    assert.deepEqual(calls.map(c => c[0]), ['focus']);
+    assert.equal(service.active, true);
+    const input = { tagName: 'INPUT', closest: selector => selector === '.bds-sheet-popover' ? {} : selector.includes('input') ? input : null };
+    const inputDown = { target: input, preventDefault() { this.prevented = true; } };
+    service.listeners.get('mousedown:true').fn(inputDown);
+    assert.equal(inputDown.prevented, undefined);
+});
+
 test('focus restoration never steals focus from an external control', () => {
     const { service, container } = setup();
     let focused = 0;

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -214,6 +214,9 @@ test('text editor takes initial focus only after text is applied and never steal
     document.activeElement = outside;
     highlighter.focusAndMoveCursorToEnd(true);
     assert.equal(document.activeElement, outside);
+    document.activeElement = document.body;
+    highlighter.focusAndMoveCursorToEnd(true);
+    assert.equal(document.activeElement, input);
     let rejectPending;
     highlighter.options.dotnetHelper.invokeMethodAsync = () => new Promise((_, reject) => { rejectPending = reject; });
     const pending = highlighter.invoke('HandleInput', 'late');

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -130,6 +130,8 @@ test('a pointerdown outside that keeps browser focus still reports deactivation'
     const { service, container, calls } = setup();
     const toolbarButton = { closest: () => null };
     service.listeners.get('pointerdown:true').fn({ target: toolbarButton });
+    assert.equal(calls.length, 1);
+    await new Promise(resolve => setTimeout(resolve, 0));
     const last = calls.at(-1)[1];
     assert.deepEqual({ focused: last.focused, active: last.active }, { focused: true, active: false });
     assert.equal('focused' in container.dataset, true);
@@ -140,6 +142,15 @@ test('a pointerdown outside that keeps browser focus still reports deactivation'
     container.focus = () => {};
     service.listeners.get('pointerdown:true').fn({ target: container });
     assert.equal(calls.at(-1)[1].active, true);
+});
+
+test('a pointerdown outside that moves focus away reports one transition, not two', async () => {
+    const { service, container, calls } = setup();
+    const external = { tagName: 'INPUT', closest: () => null };
+    service.listeners.get('pointerdown:true').fn({ target: external });
+    service.listeners.get('focusout:true').fn({ target: container, relatedTarget: external });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    assert.deepEqual(calls.slice(1).map(c => [c[1].focused, c[1].active]), [[false, false]]);
 });
 
 test('clicking a menu item keeps the sheet focused and active', async () => {

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -153,6 +153,19 @@ test('a pointerdown outside that moves focus away reports one transition, not tw
     assert.deepEqual(calls.slice(1).map(c => [c[1].focused, c[1].active]), [[false, false]]);
 });
 
+test('the sheet\'s own chrome buttons hand focus to the sheet rather than keeping it', async () => {
+    const { service, container, calls } = setup();
+    let focusedContainer = false;
+    container.focus = () => { focusedContainer = true; };
+    const dropper = { sheet: container, tagName: 'BUTTON', hasAttribute: name => name === 'data-bds-chrome',
+        closest: selector => selector === '.bds-sheet' ? container : selector.includes('button') ? dropper : null };
+    service.listeners.get('pointerdown:true').fn({ target: dropper });
+    assert.equal(focusedContainer, true);
+    const e = key(dropper);
+    await service.handleWindowEvent(e);
+    assert.equal(calls.at(-1)[0], 'key');
+});
+
 test('clicking a menu item keeps the sheet focused and active', async () => {
     const { service, container, calls } = setup();
     const item = { closest: selector => selector === '.bds-sheet-popover' ? {} : null };

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -13,7 +13,7 @@ function setup() {
     globalThis.window = new Surface();
     globalThis.document = new Surface();
     Object.assign(document, { visibilityState: 'visible', hasFocus: () => true, body: {}, documentElement: {} });
-    const container = { contains: t => t === container || t?.sheet === container, closest: () => container };
+    const container = { dataset: {}, contains: t => t === container || t?.sheet === container, closest: () => container };
     document.activeElement = container;
     const calls = [];
     const service = createWindowEventsService({ invokeMethodAsync: async (...args) => calls.push(args) });
@@ -106,6 +106,15 @@ test('clicking a manually deactivated focused sheet reactivates it', () => {
     service.setFocused(true, true);
     assert.equal(service.active, true);
     assert.equal(calls.at(-1)[1].version, 2);
+});
+
+test('pointer focus is flagged so the focus ring stays a keyboard-only affordance', () => {
+    const { service, container } = setup();
+    container.focus = () => {};
+    service.listeners.get('pointerdown:true').fn({ target: container });
+    assert.equal('pointerFocus' in container.dataset, true);
+    service.setFocused(false);
+    assert.equal('pointerFocus' in container.dataset, false);
 });
 
 test('focus restoration never steals focus from an external control', () => {

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -1,0 +1,168 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+const source = await readFile(new URL('../../src/BlazorDatasheet/wwwroot/js/window-events.js', import.meta.url), 'utf8');
+const { createWindowEventsService } = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`);
+
+class Surface extends EventTarget {
+    constructor() { super(); this.listeners = new Set(); }
+    addEventListener(name, fn, capture) { super.addEventListener(name, fn, capture); this.listeners.add(fn); }
+    removeEventListener(name, fn, capture) { super.removeEventListener(name, fn, capture); this.listeners.delete(fn); }
+}
+function setup() {
+    globalThis.window = new Surface();
+    globalThis.document = new Surface();
+    Object.assign(document, { visibilityState: 'visible', hasFocus: () => true, body: {}, documentElement: {} });
+    const container = { contains: t => t === container || t?.sheet === container, closest: () => container };
+    document.activeElement = container;
+    const calls = [];
+    const service = createWindowEventsService({ invokeMethodAsync: async (...args) => calls.push(args) });
+    service.configureFocus(container, 'focus');
+    service.registerEvent('keydown', 'key');
+    return { service, container, calls };
+}
+function key(target) {
+    return { type: 'keydown', key: 'a', code: 'KeyA', target, getModifierState: () => false,
+        preventDefault() { this.prevented = true; } };
+}
+
+test('replacement and disposal remove the exact listeners, including throttled handlers', async () => {
+    const { service } = setup();
+    const count = window.listeners.size;
+    service.registerEvent('keydown', 'replacement', 10);
+    assert.equal(window.listeners.size, count);
+    await service.dispose();
+    assert.equal(window.listeners.size, 0);
+    assert.equal(document.listeners.size, 0);
+});
+
+test('focus ownership suppresses the first key synchronously and delivers focus before keys', async () => {
+    const { service, container, calls } = setup();
+    const e = key(container);
+    await service.handleWindowEvent(e);
+    assert.equal(e.prevented, true);
+    assert.deepEqual(calls.map(c => c[0]), ['focus', 'key']);
+});
+
+test('external inputs, another sheet, and embedded controls keep native keys and clipboard', async () => {
+    const { service, container, calls } = setup();
+    const external = { tagName: 'INPUT', closest: () => null };
+    const other = { closest: () => other };
+    const control = { sheet: container, tagName: 'INPUT', closest: selector => selector === '.bds-sheet' ? container : selector === '.bds-editor-overlay' ? null : control };
+    service.registerEvent('paste', 'paste');
+    for (const target of [external, other, control]) {
+        const e = key(target);
+        await service.handleWindowEvent(e);
+        assert.equal(e.prevented, undefined);
+        await service.handleWindowEvent({ type: 'paste', target });
+    }
+    assert.deepEqual(calls.map(c => c[0]), ['focus']);
+});
+
+test('editable cell editor receives native input while sheet shortcuts are forwarded', async () => {
+    const { service, container, calls } = setup();
+    const editor = { sheet: container, tagName: 'INPUT', closest: selector => selector === '.bds-sheet' ? container : editor };
+    const e = key(editor);
+    await service.handleWindowEvent(e);
+    assert.equal(e.prevented, undefined);
+    assert.equal(calls.at(-1)[1].isEditableTarget, true);
+});
+
+test('stale server state cannot reactivate after browser focus leaves', async () => {
+    const { service } = setup();
+    service.setFocused(false);
+    service.setInputState(true, false, 10, 1);
+    assert.equal(service.active, false);
+    assert.equal(service.preventDefaultMap.keydown, false);
+    service.setInputState(true, false, 11, 2);
+    assert.equal(service.active, true); // explicit activation at the current browser version
+    service.setInputState(false, false, 9, 2);
+    assert.equal(service.active, true);
+});
+
+test('duplicate focus and deferred reconciliation do not emit spurious transitions', async () => {
+    const { service, calls } = setup();
+    service.reconcileFocus();
+    service.reconcileFocus();
+    assert.equal(calls.length, 1);
+    document.visibilityState = 'hidden';
+    service.reconcileFocus();
+    service.reconcileFocus();
+    assert.equal(calls.length, 2);
+    assert.equal(calls[1][1].focused, false);
+});
+
+test('late callbacks are dropped on disposal', async () => {
+    const { service, container, calls } = setup();
+    calls.length = 0;
+    await service.dispose();
+    service.handleWindowEvent(key(container));
+    assert.equal(calls.length, 0);
+});
+
+test('clicking a manually deactivated focused sheet reactivates it', () => {
+    const { service, calls } = setup();
+    service.setInputState(false, false, 1, 1);
+    service.setFocused(true, true);
+    assert.equal(service.active, true);
+    assert.equal(calls.at(-1)[1].version, 2);
+});
+
+test('focus restoration never steals focus from an external control', () => {
+    const { service, container } = setup();
+    let focused = 0;
+    container.focus = () => focused++;
+    document.activeElement = { tagName: 'INPUT' };
+    service.restoreFocus();
+    assert.equal(focused, 0);
+    document.activeElement = document.body;
+    service.restoreFocus();
+    assert.equal(focused, 1);
+    service.setFocused(false);
+    service.restoreFocus();
+    assert.equal(focused, 1);
+});
+
+test('Tab in an editor stays within sheet navigation instead of moving native focus', async () => {
+    const { service, container } = setup();
+    const editor = { sheet: container, tagName: 'INPUT', closest: selector => selector === '.bds-sheet' ? container : editor };
+    service.setInputState(true, true, 1, 1);
+    const e = { ...key(editor), key: 'Tab', code: 'Tab' };
+    await service.handleWindowEvent(e);
+    assert.equal(e.prevented, true);
+});
+
+test('text editor takes initial focus only after text is applied and never steals external focus', async () => {
+    const { container } = setup();
+    globalThis.ResizeObserver = class { observe() {} disconnect() {} };
+    document.createRange = () => ({ selectNodeContents() {}, collapse() {} });
+    document.getSelection = () => ({ removeAllRanges() {}, addRange() {} });
+    const input = new Surface();
+    Object.assign(input, {
+        closest: () => container,
+        focus() { document.activeElement = input; input.dispatchEvent(new Event('focus')); }
+    });
+    const highlighterSource = await readFile(new URL('../../src/BlazorDatasheet/wwwroot/js/highlighter.js', import.meta.url), 'utf8');
+    const { createHighlighter } = await import(`data:text/javascript;base64,${Buffer.from(highlighterSource).toString('base64')}`);
+    const highlighter = createHighlighter({ inputEl: input, highlightResultEl: {}, initialText: '', initialHtml: '',
+        dotnetHelper: { invokeMethodAsync: async () => {} } });
+    assert.equal(document.activeElement, container);
+    highlighter.setInputText('InitialKey');
+    highlighter.focusAndMoveCursorToEnd(true);
+    assert.equal(input.textContent, 'InitialKey');
+    assert.equal(document.activeElement, input);
+    const outside = {};
+    document.activeElement = outside;
+    highlighter.focusAndMoveCursorToEnd(true);
+    assert.equal(document.activeElement, outside);
+    let rejectPending;
+    highlighter.options.dotnetHelper.invokeMethodAsync = () => new Promise((_, reject) => { rejectPending = reject; });
+    const pending = highlighter.invoke('HandleInput', 'late');
+    highlighter.dispose();
+    rejectPending(new Error('The .NET reference was disposed'));
+    await pending;
+    assert.equal(input.listeners.size, 0);
+    document.activeElement = container;
+    highlighter.focusAndMoveCursorToEnd(true);
+    assert.equal(document.activeElement, container);
+});

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -157,6 +157,16 @@ test('clicking a menu item keeps the sheet focused and active', async () => {
     assert.equal(inputDown.prevented, undefined);
 });
 
+test('window focus changes are distinguished from focus moving between elements', () => {
+    const { service, container, calls } = setup();
+    service.listeners.get('blur:false').fn({});
+    assert.deepEqual([calls.at(-1)[1].focused, calls.at(-1)[1].fromWindow], [false, true]);
+    service.listeners.get('focus:false').fn({});
+    assert.deepEqual([calls.at(-1)[1].focused, calls.at(-1)[1].fromWindow], [true, true]);
+    service.listeners.get('focusout:true').fn({ target: container, relatedTarget: { closest: () => null } });
+    assert.deepEqual([calls.at(-1)[1].focused, calls.at(-1)[1].fromWindow], [false, false]);
+});
+
 test('focus restoration never steals focus from an external control', () => {
     const { service, container } = setup();
     let focused = 0;

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+﻿import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 const source = await readFile(new URL('../../src/BlazorDatasheet/wwwroot/js/window-events.js', import.meta.url), 'utf8');
@@ -115,6 +115,15 @@ test('pointer focus is flagged so the focus ring stays a keyboard-only affordanc
     assert.equal('pointerFocus' in container.dataset, true);
     service.setFocused(false);
     assert.equal('pointerFocus' in container.dataset, false);
+});
+
+test('the container is marked focused synchronously so the selection dims without a round trip', () => {
+    const { service, container } = setup();
+    assert.equal('focused' in container.dataset, true);
+    service.setFocused(false);
+    assert.equal('focused' in container.dataset, false);
+    service.setFocused(true);
+    assert.equal('focused' in container.dataset, true);
 });
 
 test('focus restoration never steals focus from an external control', () => {

--- a/test/js/window-events.test.mjs
+++ b/test/js/window-events.test.mjs
@@ -126,6 +126,22 @@ test('the container is marked focused synchronously so the selection dims withou
     assert.equal('focused' in container.dataset, true);
 });
 
+test('a pointerdown outside that keeps browser focus still reports deactivation', async () => {
+    const { service, container, calls } = setup();
+    const toolbarButton = { closest: () => null };
+    service.listeners.get('pointerdown:true').fn({ target: toolbarButton });
+    const last = calls.at(-1)[1];
+    assert.deepEqual({ focused: last.focused, active: last.active }, { focused: true, active: false });
+    assert.equal('focused' in container.dataset, true);
+    const e = key(container);
+    await service.handleWindowEvent(e);
+    assert.equal(e.prevented, undefined);
+    assert.equal(calls.at(-1)[0], 'focus');
+    container.focus = () => {};
+    service.listeners.get('pointerdown:true').fn({ target: container });
+    assert.equal(calls.at(-1)[1].active, true);
+});
+
 test('focus restoration never steals focus from an external control', () => {
     const { service, container } = setup();
     let focused = 0;


### PR DESCRIPTION
## Focus handling

Makes browser focus the source of truth for the datasheet's keyboard ownership, and
brings the selection and menus in line with Excel's focus behaviour.

### Behaviour
- The sheet container is focusable (`tabindex="0"`). Keyboard input is only handled while
  the sheet owns browser focus, or while it has been activated from code with
  `SetActiveAsync()` and nothing else on the page has focus.
- The selection dims while browser focus is elsewhere. A themed focus ring shows for
  keyboard focus only.
- Using a menu (context menu, heading dropdown, column filters) no longer moves focus
  away from the sheet. Focus returns to the opener when a menu closes.
- Losing focus keeps a pending edit open by default. New `OnEditFocusLoss` parameter
  (`KeepEditing`, `Accept`, `Cancel`) controls what happens when focus moves to another
  element on the page. Switching window or tab always keeps the edit open.
- Embedded controls in cells and external inputs keep their native keys and clipboard.

### API
- `OnFocusIn` / `OnFocusOut` callbacks on `Datasheet`, raised when focus enters or leaves
  the whole sheet. `OnSheetActiveChanged` fires before them.
- `OnEditFocusLoss` parameter, see above.
- `FocusAsync()` no longer scrolls.
- CSS variables for the unfocused selection colours and the focus ring colour.

### Internals
- Focus, activation and keyboard prevent-default are owned by `window-events.js` and
  applied synchronously in the browser, with versioned interop so stale .NET updates are
  dropped. Menu focus return lives in `menu.js`.
- Editor initial focus waits for the entry key to be applied and never steals focus
  from an external control.
- Unused `PreventDefault`/`CancelPreventDefault` interop removed.