### PR TITLE
Add sheet protection

### DIFF
--- a/src/BlazorDatasheet.Core/Commands/BaseCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/BaseCommand.cs
@@ -1,16 +1,52 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
 
 namespace BlazorDatasheet.Core.Commands;
 
 /// <summary>
-/// Chainable command
+/// Chainable command.
+/// <para>
+/// Sheet protection is checked in a single place - <see cref="Execute"/> and <see cref="CanExecute"/> run
+/// <see cref="SheetProtection.CanExecute"/> before delegating to <see cref="ExecuteCore"/>/<see cref="CanExecuteCore"/>.
+/// Commands declare what they need by overriding <see cref="CanExecuteProtected"/>; they must not repeat the check.
+/// </para>
 /// </summary>
-public abstract class BaseCommand : ICommand
+public abstract class BaseCommand : ICommand, IProtectedCommand
 {
     private readonly List<ICommand> _chainedAfterCommands = new();
     private readonly List<ICommand> _chainedBeforeCommands = new();
-    public abstract bool Execute(Sheet sheet);
-    public abstract bool CanExecute(Sheet sheet);
+
+    /// <summary>
+    /// Declares the command's protection requirements. Must be side-effect free.
+    /// Commands without a declaration are denied while protection is enforced.
+    /// </summary>
+    public virtual bool CanExecuteProtected(Sheet sheet) => false;
+
+    public bool Execute(Sheet sheet)
+    {
+        if (!sheet.Protection.CanExecute(this))
+            return false;
+
+        return ExecuteCore(sheet);
+    }
+
+    public bool CanExecute(Sheet sheet)
+    {
+        if (!sheet.Protection.CanExecute(this))
+            return false;
+
+        return CanExecuteCore(sheet);
+    }
+
+    /// <summary>
+    /// Performs the command. Protection has already been checked.
+    /// </summary>
+    protected abstract bool ExecuteCore(Sheet sheet);
+
+    /// <summary>
+    /// Any non-protection pre-conditions for the command. Protection has already been checked.
+    /// </summary>
+    protected virtual bool CanExecuteCore(Sheet sheet) => true;
 
     public void AttachAfter(ICommand command)
     {

--- a/src/BlazorDatasheet.Core/Commands/CommandGroup.cs
+++ b/src/BlazorDatasheet.Core/Commands/CommandGroup.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 
 namespace BlazorDatasheet.Core.Commands;
@@ -28,12 +29,14 @@ public class CommandGroup : BaseCommand, IUndoableCommand
         _commands.Add(command);
     }
 
-    public override bool CanExecute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => _commands.All(sheet.Protection.CanExecute);
+
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         return _commands.All(x => x.CanExecute(sheet));
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _successfulCommands.Clear();
 

--- a/src/BlazorDatasheet.Core/Commands/CommandManager.cs
+++ b/src/BlazorDatasheet.Core/Commands/CommandManager.cs
@@ -1,4 +1,4 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Events.Commands;
 using BlazorDatasheet.Core.Selecting;
 using BlazorDatasheet.Core.Util;
@@ -11,6 +11,9 @@ public class CommandManager
     private readonly MaxStack<ICommand> _redos;
     private readonly Sheet _sheet;
     private CommandGroup? _currentCommandGroup;
+    private int _executionDepth;
+
+    internal bool IsExecuting => _executionDepth > 0;
 
     /// <summary>
     /// Invoked before a command is run. If cancel is true in <see cref="BeforeCommandRunEventArgs"/>, the command is not run.
@@ -58,6 +61,13 @@ public class CommandManager
     /// <returns></returns>
     public bool ExecuteCommand(ICommand command, bool isRedo = false, bool useUndo = true)
     {
+        _executionDepth++;
+        try { return ExecuteCommandCore(command, isRedo, useUndo); }
+        finally { _executionDepth--; }
+    }
+
+    private bool ExecuteCommandCore(ICommand command, bool isRedo, bool useUndo)
+    {
         if (_isCollectingCommands)
         {
             _currentCommandGroup!.AddCommand(command);
@@ -70,6 +80,12 @@ public class CommandManager
         if (beforeArgs.Cancel)
             return false;
 
+        if (!_sheet.Protection.CanExecute(command))
+        {
+            CommandNotExecuted?.Invoke(this, new CommandNotExecutedEventArgs(command));
+            return false;
+        }
+
         var chainedBeforeResult = ExecuteCommands(command.GetChainedBeforeCommands(), isRedo: false, useUndo: false);
 
         if (!chainedBeforeResult)
@@ -77,39 +93,57 @@ public class CommandManager
 
         if (!command.CanExecute(_sheet))
         {
+            RollbackCommands(command.GetChainedBeforeCommands());
             CommandNotExecuted?.Invoke(this, new CommandNotExecutedEventArgs(command));
             return false;
         }
 
+        var protectionRevision = _sheet.Protection.Revision;
         var result = command.Execute(_sheet);
 
         CommandRun?.Invoke(this, new CommandRunEventArgs(command, _sheet, result));
+        if (!result)
+        {
+            RollbackCommands(command.GetChainedBeforeCommands());
+            return false;
+        }
 
         var chainedAfterResult = ExecuteCommands(command.GetChainedAfterCommands(), isRedo: false, useUndo: false);
         if (!chainedAfterResult && command is IUndoableCommand undoableCommand)
         {
             undoableCommand.Undo(_sheet);
+            RollbackCommands(command.GetChainedBeforeCommands());
             return false;
         }
 
-        if (result)
+        var addedToHistory = false;
+        if (!HistoryPaused && useUndo && protectionRevision == _sheet.Protection.Revision &&
+            command is IUndoableCommand undoCommand)
         {
-            if (!HistoryPaused && useUndo && command is IUndoableCommand undoCommand)
+            _history.Push(new UndoCommandData()
             {
-                _history.Push(new UndoCommandData()
-                {
-                    Command = undoCommand,
-                    SelectionSnapshot = _sheet.Selection.GetSelectionSnapshot()
-                });
-            }
+                Command = undoCommand,
+                SelectionSnapshot = _sheet.Selection.GetSelectionSnapshot()
+            });
+            addedToHistory = true;
         }
 
         // Clear the redo stack because otherwise we will be redoing changes to the sheet with a changed
         // model from the original time the commands were run.
-        if (!isRedo)
+        // The children of a command being redone are run with isRedo false, but they are never added
+        // to the history - so anything that does get added to the history is a new change and must
+        // invalidate the redo stack, even if it was run from a handler in the middle of a redo.
+        if (!isRedo && (addedToHistory || _executionDepth == 1))
             _redos.Clear();
 
         return result;
+    }
+
+    private void RollbackCommands(IReadOnlyList<ICommand> commands)
+    {
+        foreach (var command in commands.Reverse())
+            if (command is IUndoableCommand undoable)
+                UndoCommand(undoable);
     }
 
     /// <summary>
@@ -225,8 +259,15 @@ public class CommandManager
         if (_redos.Peek() == null)
             return false;
 
-        var command = _redos.Pop()!;
-        return ExecuteCommand(command, isRedo: true);
+        var command = _redos.Peek()!;
+        var result = ExecuteCommand(command, isRedo: true);
+
+        // drop the entry whether or not it succeeded, otherwise a command that can no longer be
+        // run would block every redo behind it.
+        if (ReferenceEquals(_redos.Peek(), command))
+            _redos.Pop();
+
+        return result;
     }
 
     /// <summary>
@@ -235,6 +276,7 @@ public class CommandManager
     public void ClearHistory()
     {
         _history.Clear();
+        _redos.Clear();
     }
 
     /// <summary>

--- a/src/BlazorDatasheet.Core/Commands/Data/AutoFillCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/AutoFillCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Interfaces;
 using BlazorDatasheet.Core.Patterns;
@@ -9,42 +10,57 @@ public class AutoFillCommand : BaseCommand, IUndoableCommand
 {
     private IRegion _fromRegion;
     private IRegion _toRegion;
-    private CommandGroup _expandCommands = new();
+
+    /// <summary>
+    /// The commands that were run by the last successful execution, kept so that we can undo them.
+    /// </summary>
+    private CommandGroup? _expandCommands;
 
     public AutoFillCommand(IRegion fromRegion, IRegion toRegion)
     {
         _fromRegion = fromRegion;
         _toRegion = toRegion;
+    }
 
+    /// <summary>
+    /// Builds the commands that perform the fill, based on the current contents of the sheet.
+    /// Side effect free - called both when checking protection and when executing.
+    /// </summary>
+    private CommandGroup BuildFillCommands(Sheet sheet)
+    {
+        var commands = new CommandGroup();
         var clearRegions = _fromRegion.Contains(_toRegion)
             ? _fromRegion.Break(_toRegion)
             : _toRegion.Break(_fromRegion);
-
-        this.AttachBefore(new ClearCellsCommand(clearRegions));
+        commands.AddCommand(new ClearCellsCommand(clearRegions));
+        if (!_fromRegion.Contains(_toRegion))
+            ExpandContent(sheet, commands);
+        return commands;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
-        // Shrink/cut the content if the new region is smaller than the selection
-        if (_fromRegion.Contains(_toRegion))
-            ShrinkContent(sheet);
-        else
-            ExpandContent(sheet);
+        // built here (rather than up-front) so that the fill always samples the current cell contents,
+        // e.g. when this command is part of a group that has already modified the source cells.
+        var commands = BuildFillCommands(sheet);
+        if (!sheet.Commands.ExecuteCommand(commands, useUndo: false))
+            return false;
 
+        _expandCommands = commands;
         sheet.Selection.Set(_toRegion);
         return true;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) =>
+        sheet.Protection.CanExecute(BuildFillCommands(sheet));
 
-    private void ExpandContent(Sheet sheet)
+    private void ExpandContent(Sheet sheet, CommandGroup expandCommands)
     {
         var fillDirection = GetFillDirection();
         // will always be only one region
         var fillRegion = _toRegion.Break(_fromRegion).First()!;
         var fillSize = GetOrthogonalSize(fillDirection, fillRegion);
 
-        _expandCommands = new CommandGroup();
         for (int i = 0; i < fillSize; i++)
         {
             // figure out what patterns to apply
@@ -68,7 +84,7 @@ public class AutoFillCommand : BaseCommand, IUndoableCommand
                         var cellPosition =
                             GetCellPositionFromOffset(lastCellPosition, fillDirection, rowColOffsetFromEnd + 1);
 
-                        _expandCommands.AddCommand(
+                        expandCommands.AddCommand(
                             pattern.GetCommand(offset - pattern.Offsets.First(), repeatNo, cells[offset],
                                 cellPosition));
                         repeatNo++;
@@ -78,9 +94,6 @@ public class AutoFillCommand : BaseCommand, IUndoableCommand
                 }
             }
         }
-
-
-        _expandCommands.Execute(sheet);
     }
 
     private CellPosition GetCellPositionFromOffset(CellPosition cellPosition, Direction direction, int offset)
@@ -193,14 +206,9 @@ public class AutoFillCommand : BaseCommand, IUndoableCommand
         return Direction.None;
     }
 
-    private void ShrinkContent(Sheet sheet)
-    {
-    }
-
     public bool Undo(Sheet sheet)
     {
         _expandCommands?.Undo(sheet);
-
         return true;
     }
 }

--- a/src/BlazorDatasheet.Core/Commands/Data/ClearCellsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/ClearCellsCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.DataStructures.Geometry;
 
@@ -22,13 +23,15 @@ public class ClearCellsCommand : BaseCommand, IUndoableCommand
         _regions = new List<IRegion> { region.Clone() };
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.Cells.ClearCellsImpl(_regions);
         return true;
     }
 
-    public override bool CanExecute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => _regions.All(sheet.Protection.CanEdit);
+
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         foreach (var region in _regions)
         {

--- a/src/BlazorDatasheet.Core/Commands/Data/ClearMetaDataCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/ClearMetaDataCommand.cs
@@ -15,9 +15,9 @@ public class ClearMetaDataCommand : BaseCommand, IUndoableCommand
         _col = col;
     }
 
-    public override bool CanExecute(Sheet sheet) => sheet.Region.Contains(_row, _col);
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.Region.Contains(_row, _col));
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _oldMetaData = sheet.Cells.GetCellMetaData(_row, _col)?.Clone();
         sheet.Cells.ClearMetaDataImpl(_row, _col);

--- a/src/BlazorDatasheet.Core/Commands/Data/CopyRangeCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/CopyRangeCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.DataStructures.Geometry;
@@ -10,7 +11,7 @@ public class CopyRangeCommand : BaseCommand, IUndoableCommand
     private readonly SheetRange[] _toRanges;
     private readonly CopyOptions _copyOptions;
 
-    private CellStoreRestoreData _cellStoreRestore = null!;
+    private readonly List<CellStoreRestoreData> _restoreData = new();
 
     /// <summary>
     /// Copies data from one range to another. The from range must only have a single region.
@@ -38,27 +39,41 @@ public class CopyRangeCommand : BaseCommand, IUndoableCommand
         _toRanges = new[] { toRange };
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
+        _restoreData.Clear();
         foreach (var range in _toRanges)
             Copy(_fromRange.Region, range.Region, sheet);
 
         return true;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => _toRanges.All(x =>
+        ((!_copyOptions.CopyValues && !_copyOptions.CopyFormula) ||
+         sheet.Protection.CanEdit(GetAffectedRegion(sheet, x.Region))) &&
+        (!_copyOptions.CopyFormat || sheet.Protection.CanFormat(GetAffectedRegion(sheet, x.Region))));
 
     private void Copy(IRegion fromRegion, IRegion toRegion, Sheet sheet)
     {
-        _cellStoreRestore = sheet.Cells.CopyImpl(fromRegion, toRegion, _copyOptions);
+        _restoreData.Add(sheet.Cells.CopyImpl(fromRegion, GetAffectedRegion(sheet, toRegion), _copyOptions));
+    }
+
+    private IRegion GetAffectedRegion(Sheet sheet, IRegion target)
+    {
+        var source = _fromRange.Region.GetIntersection(sheet.Region);
+        if (source == null)
+            return target;
+        return new Region(target.Top, Math.Max(target.Bottom, target.Top + source.Height - 1),
+            target.Left, Math.Max(target.Right, target.Left + source.Width - 1));
     }
 
     public bool Undo(Sheet sheet)
     {
-        foreach (var toRange in _toRanges)
+        for (var i = _restoreData.Count - 1; i >= 0; i--)
         {
-            sheet.Cells.ClearCellsImpl(new List<IRegion>() { toRange.Region });
-            sheet.Cells.Restore(_cellStoreRestore);
+            if (_copyOptions.CopyValues || _copyOptions.CopyFormula)
+                sheet.Cells.ClearCellsImpl(new[] { GetAffectedRegion(sheet, _toRanges[i].Region) });
+            sheet.Cells.Restore(_restoreData[i]);
         }
 
         return true;

--- a/src/BlazorDatasheet.Core/Commands/Data/MergeCellsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/MergeCellsCommand.cs
@@ -21,7 +21,7 @@ public class MergeCellsCommand : BaseCommand, IUndoableCommand
         _region = region.Clone();
     }
 
-    public override bool CanExecute(Sheet sheet)
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         var existingMerges = sheet.Cells.GetMerges(_region).ToList();
         if (!existingMerges.All(x => _region.Contains(x)))
@@ -29,7 +29,7 @@ public class MergeCellsCommand : BaseCommand, IUndoableCommand
         return true;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         sheet.BatchUpdates();
         _overridenMergedRegions.Clear();

--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValueCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValueCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.DataStructures.Geometry;
@@ -25,12 +26,14 @@ public class SetCellValueCommand : BaseCommand, IUndoableCommand
         Value = value;
     }
 
-    public override bool CanExecute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.CanEdit(Row, Col);
+
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         return sheet.ContainsPosition(Row, Col);
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         using var updates = sheet.SuspendUpdates();
         _restoreData = sheet.Cells.SetValueImpl(Row, Col, Value);

--- a/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetCellValuesCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.Formula.Core;
@@ -53,9 +54,12 @@ public class SetCellValuesCommand : BaseCommand, IUndoableCommand
             .ToArray();
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) =>
+        _cellValues.Select((values, offset) => values.Length == 0 ||
+            sheet.Protection.CanEdit(new Region(_row + offset, _row + offset, _col, _col + values.Length - 1)))
+        .All(x => x);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         using var updates = sheet.SuspendUpdates();
         ExecuteSetCellValueData(sheet);

--- a/src/BlazorDatasheet.Core/Commands/Data/SetMetaDataCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetMetaDataCommand.cs
@@ -10,7 +10,7 @@ public class SetMetaDataCommand : BaseCommand, IUndoableCommand
     private readonly object? _value;
     private object? _oldValue;
 
-    public override bool CanExecute(Sheet sheet) => sheet.Region.Contains(_row, _col);
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.Region.Contains(_row, _col));
 
     public SetMetaDataCommand(int row, int col, string name, object? value)
     {
@@ -20,7 +20,7 @@ public class SetMetaDataCommand : BaseCommand, IUndoableCommand
         _value = value;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _oldValue = sheet.Cells.GetMetaData(_row, _col, _name);
         sheet.Cells.SetMetaDataImpl(_row, _col, _name, _value);

--- a/src/BlazorDatasheet.Core/Commands/Data/SetParsedFormulaCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetParsedFormulaCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.Formula.Core.Interpreter;
 
@@ -18,9 +19,11 @@ internal class SetParsedFormulaCommand : BaseCommand, IUndoableCommand
         _formula = formula;
     }
 
-    public override bool CanExecute(Sheet sheet) => sheet.ContainsPosition(_row, _col);
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.CanEdit(_row, _col);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.ContainsPosition(_row, _col));
+
+    protected override bool ExecuteCore(Sheet sheet)
     {
         // see SetCellValueCommand - unbatched, each call triggers its own recalculation pass.
         sheet.BatchUpdates();

--- a/src/BlazorDatasheet.Core/Commands/Data/SetRegionMetaDataCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SetRegionMetaDataCommand.cs
@@ -22,9 +22,9 @@ public class SetRegionMetaDataCommand : BaseCommand, IUndoableCommand
         _value = value;
     }
 
-    public override bool CanExecute(Sheet sheet) => sheet.Region.Contains(_region);
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.Region.Contains(_region));
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         // Capture the whole region before emitting any metadata events while applying the write.
         _oldValues = new SheetRange(sheet, _region).Positions

--- a/src/BlazorDatasheet.Core/Commands/Data/SortRangeCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/SortRangeCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.Core.Metadata;
@@ -41,9 +42,9 @@ public class SortRangeCommand : BaseCommand, IUndoableCommand
         _sortOptions = new List<ColumnSortOptions> { sortOption };
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(SheetOperation.Sort, _region);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         var store = sheet.Cells.GetCellDataStore();
 

--- a/src/BlazorDatasheet.Core/Commands/Data/UnMergeCellsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Data/UnMergeCellsCommand.cs
@@ -1,4 +1,4 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.DataStructures.Geometry;
 
 namespace BlazorDatasheet.Core.Commands.Data;
@@ -19,7 +19,7 @@ public class UnMergeCellsCommand : BaseCommand, IUndoableCommand
         _region = region.Clone();
     }
 
-    public override bool CanExecute(Sheet sheet)
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         var existingMerges = sheet.Cells.GetMerges(_region).ToList();
         if (existingMerges.All(x => _region.Contains(x)))
@@ -27,7 +27,7 @@ public class UnMergeCellsCommand : BaseCommand, IUndoableCommand
         return false;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         sheet.BatchUpdates();
         _unMergesPerformed.Clear();

--- a/src/BlazorDatasheet.Core/Commands/Filters/ApplyColumnFiltersCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Filters/ApplyColumnFiltersCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Commands.RowCols;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Filter;
@@ -7,27 +8,27 @@ namespace BlazorDatasheet.Core.Commands.Filters;
 
 public class ApplyColumnFiltersCommand : BaseCommand, IUndoableCommand
 {
-    private IUndoableCommand _commandRun = null!;
-    public override bool CanExecute(Sheet sheet) => true;
+    private RowColInfoRestoreData _unhideRestore = null!;
+    private RowColInfoRestoreData _hideRestore = null!;
+    private List<BlazorDatasheet.DataStructures.Intervals.Interval> _previousFilteredRows = new();
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(SheetOperation.Filter);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
-        // 1. Un-hide all rows filtered by the current column filters
-        var unHideExistingCommand = new UnhideCommand(sheet.Columns.Filters.FilteredRows, Axis.Row);
         var columnFilters = sheet.Columns.Filters.GetAll();
-        var handler = new FilterHandler();
-        var hiddenRows = handler.GetHiddenRows(sheet, columnFilters);
-        var hideCommand = new HideCommand(hiddenRows, Axis.Row);
-
-        _commandRun = new CommandGroup(unHideExistingCommand, hideCommand);
-        _commandRun.Execute(sheet);
-
+        var hiddenRows = new FilterHandler().GetHiddenRows(sheet, columnFilters);
+        _previousFilteredRows = sheet.Columns.Filters.FilteredRows;
+        _unhideRestore = sheet.Rows.UnhideImpl(_previousFilteredRows);
+        _hideRestore = sheet.Rows.HideImpl(hiddenRows);
         sheet.Columns.Filters.FilteredRows = hiddenRows;
         return true;
     }
 
     public bool Undo(Sheet sheet)
     {
-        return _commandRun.Undo(sheet);
+        sheet.Rows.Restore(_hideRestore);
+        sheet.Rows.Restore(_unhideRestore);
+        sheet.Columns.Filters.FilteredRows = _previousFilteredRows;
+        return true;
     }
 }

--- a/src/BlazorDatasheet.Core/Commands/Filters/ClearFiltersCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Filters/ClearFiltersCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Filter;
 
@@ -28,9 +29,11 @@ public class ClearFiltersCommand : BaseCommand, IUndoableCommand
         _clearAllFilters = true;
     }
 
-    public override bool CanExecute(Sheet sheet) => sheet.Region.SpansCol(_columnIndex);
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(SheetOperation.Filter);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.Region.SpansCol(_columnIndex));
+
+    protected override bool ExecuteCore(Sheet sheet)
     {
         if (_clearAllFilters)
             _previousFilters = sheet.Columns.Filters.GetAll().ToList();

--- a/src/BlazorDatasheet.Core/Commands/Filters/SetColumnFilterCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Filters/SetColumnFilterCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Filter;
 
@@ -20,8 +21,10 @@ public class SetColumnFilterCommand : BaseCommand, IUndoableCommand
     {
     }
 
-    public override bool CanExecute(Sheet sheet) => sheet.Region.SpansCol(_columnIndex);
-    public override bool Execute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(SheetOperation.Filter);
+
+    protected override bool CanExecuteCore(Sheet sheet) => (sheet.Region.SpansCol(_columnIndex));
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _previousFilters = sheet.Columns.Filters.Get(_columnIndex).Filters.ToList();
         sheet.Columns.Filters.SetImpl(_columnIndex, _filters);

--- a/src/BlazorDatasheet.Core/Commands/Formatting/ClearFormatCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Formatting/ClearFormatCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.DataStructures.Geometry;
@@ -14,9 +15,9 @@ public class ClearFormatCommand : BaseCommand, IUndoableCommand
         Region = region.Clone();
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.CanFormat(Region);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         sheet.BatchUpdates();
         var region = sheet.Region.GetIntersection(Region);

--- a/src/BlazorDatasheet.Core/Commands/Formatting/SetFormatCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Formatting/SetFormatCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.Core.Formats;
@@ -31,9 +32,9 @@ public class SetFormatCommand : BaseCommand, IUndoableCommand
         Region = region.Clone();
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => !_cellFormat.SpecifiesLock && sheet.Protection.CanFormat(Region);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         sheet.BatchUpdates();
         _borderCommands = new();

--- a/src/BlazorDatasheet.Core/Commands/Formatting/SetTypeCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Formatting/SetTypeCommand.cs
@@ -20,9 +20,7 @@ public class SetTypeCommand : BaseCommand, IUndoableCommand
         _type = type;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
-
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.Cells.SetCellTypeImpl(_region, _type);
         return true;

--- a/src/BlazorDatasheet.Core/Commands/Formatting/SetValidatorCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/Formatting/SetValidatorCommand.cs
@@ -1,4 +1,4 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Interfaces;
 using BlazorDatasheet.DataStructures.Geometry;
 
@@ -15,9 +15,7 @@ public class SetValidatorCommand : BaseCommand, IUndoableCommand
         _validator = validator;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
-
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         sheet.Validators.AddImpl(_validator, _region);
         sheet.Cells.ValidateRegion(_region);
@@ -26,7 +24,7 @@ public class SetValidatorCommand : BaseCommand, IUndoableCommand
 
     public bool Undo(Sheet sheet)
     {
-        sheet.Validators.Clear(_validator, _region);
+        sheet.Validators.ClearImpl(_validator, _region);
         sheet.Cells.ValidateRegion(_region);
         return true;
     }

--- a/src/BlazorDatasheet.Core/Commands/ProxyCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/ProxyCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 
 namespace BlazorDatasheet.Core.Commands;
 
@@ -11,12 +12,14 @@ public class ProxyCommand : BaseCommand, IUndoableCommand
         _command = command;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         return _command.Execute(sheet);
     }
 
-    public override bool CanExecute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.CanExecute(_command);
+
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         return _command.CanExecute(sheet);
     }

--- a/src/BlazorDatasheet.Core/Commands/RowCols/ClearHeadingGroupsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/ClearHeadingGroupsCommand.cs
@@ -17,9 +17,9 @@ public class ClearHeadingGroupsCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => _indexStart <= _indexEnd;
+    protected override bool CanExecuteCore(Sheet sheet) => (_indexStart <= _indexEnd);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).ClearGroupsImpl(_indexStart, _indexEnd);
         return true;

--- a/src/BlazorDatasheet.Core/Commands/RowCols/FreezeRowColsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/FreezeRowColsCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 
 namespace BlazorDatasheet.Core.Commands.RowCols;
@@ -18,17 +19,14 @@ public class FreezeRowColsCommand : BaseCommand, IUndoableCommand
         _freezeRight = freezeRight;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _oldFreezeState = sheet.FreezeState;
         sheet.FreezeRowColsImpl(_freezeTop, _freezeBottom, _freezeLeft, _freezeRight);
         return true;
     }
 
-    public override bool CanExecute(Sheet sheet)
-    {
-        return true;
-    }
+    public override bool CanExecuteProtected(Sheet sheet) => true;
 
     public bool Undo(Sheet sheet)
     {

--- a/src/BlazorDatasheet.Core/Commands/RowCols/HideCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/HideCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Intervals;
@@ -24,9 +25,9 @@ public class HideCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(_axis == Axis.Row ? SheetOperation.FormatRows : SheetOperation.FormatColumns);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).HideImpl(_intervals);
         return true;

--- a/src/BlazorDatasheet.Core/Commands/RowCols/InsertRowsColsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/InsertRowsColsCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.Core.Data.Filter;
 using BlazorDatasheet.Core.Formats;
@@ -38,9 +39,9 @@ internal class InsertRowsColsCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(_axis == Axis.Row ? SheetOperation.InsertRows : SheetOperation.InsertColumns);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         using var updates = sheet.SuspendUpdates();
         sheet.Add(_axis, _count);

--- a/src/BlazorDatasheet.Core/Commands/RowCols/RemoveRowColsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/RemoveRowColsCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Data.Cells;
 using BlazorDatasheet.Core.Data.Filter;
@@ -38,7 +39,13 @@ public class RemoveRowColsCommand : BaseCommand, IUndoableCommand
         _count = count;
     }
 
-    public override bool CanExecute(Sheet sheet)
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(
+        _axis == Axis.Row ? SheetOperation.DeleteRows : SheetOperation.DeleteColumns,
+        _axis == Axis.Row
+            ? new RowRegion(_index, _index + _count - 1)
+            : new ColumnRegion(_index, _index + _count - 1));
+
+    protected override bool CanExecuteCore(Sheet sheet)
     {
         if (_index >= sheet.GetSize(_axis))
             return false;
@@ -49,7 +56,7 @@ public class RemoveRowColsCommand : BaseCommand, IUndoableCommand
         return true;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         if (_index >= sheet.GetSize(_axis))
             return false;

--- a/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingGroupCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingGroupCommand.cs
@@ -19,9 +19,9 @@ public class SetHeadingGroupCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => _indexStart <= _indexEnd;
+    protected override bool CanExecuteCore(Sheet sheet) => (_indexStart <= _indexEnd);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).SetGroupImpl(_indexStart, _indexEnd, _label);
         return true;

--- a/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingsCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/SetHeadingsCommand.cs
@@ -19,9 +19,7 @@ public class SetHeadingsCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
-
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).SetHeadingsImpl(_indexStart, _indexEnd, _heading);
         return true;

--- a/src/BlazorDatasheet.Core/Commands/RowCols/SetSizeCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/SetSizeCommand.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.DataStructures.Geometry;
 
@@ -19,9 +20,11 @@ public class SetSizeCommand : BaseCommand, IUndoableCommand
         _size = size;
     }
 
-    public override bool CanExecute(Sheet sheet) => _size >= 0;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(_axis == Axis.Row ? SheetOperation.FormatRows : SheetOperation.FormatColumns);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool CanExecuteCore(Sheet sheet) => (_size >= 0);
+
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).SetSizesImpl(_indexStart, _indexEnd, _size);
         IRegion dirtyRegion = _axis == Axis.Col

--- a/src/BlazorDatasheet.Core/Commands/RowCols/UnhideCommand.cs
+++ b/src/BlazorDatasheet.Core/Commands/RowCols/UnhideCommand.cs
@@ -1,4 +1,5 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Intervals;
 
@@ -23,9 +24,9 @@ public class UnhideCommand : BaseCommand, IUndoableCommand
         _axis = axis;
     }
 
-    public override bool CanExecute(Sheet sheet) => true;
+    public override bool CanExecuteProtected(Sheet sheet) => sheet.Protection.Can(_axis == Axis.Row ? SheetOperation.FormatRows : SheetOperation.FormatColumns);
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _restoreData = sheet.GetRowColStore(_axis).UnhideImpl(_intervals);
         return true;

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.Format.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.Format.cs
@@ -32,10 +32,15 @@ public partial class CellStore
 
     internal CellStoreRestoreData CutFormatImpl(IRegion region)
     {
-        return new CellStoreRestoreData()
-        {
-            FormatRestoreData = _formatStore.Clear(region)
-        };
+        var locks = Sheet.Protection.IsEnforced
+            ? _formatStore.GetDataRegions(region)
+                .Where(x => x.Data.IsLocked != null)
+                .Select(x => (Region: x.Region.GetIntersection(region)!, Locked: x.Data.IsLocked)).ToList()
+            : new();
+        var restore = new CellStoreRestoreData { FormatRestoreData = _formatStore.Clear(region) };
+        foreach (var item in locks)
+            restore.Merge(MergeFormatImpl(item.Region, new CellFormat { IsLocked = item.Locked }));
+        return restore;
     }
 
     /// <summary>

--- a/src/BlazorDatasheet.Core/Data/Cells/CellStore.cs
+++ b/src/BlazorDatasheet.Core/Data/Cells/CellStore.cs
@@ -184,7 +184,10 @@ public partial class CellStore
         var fixedFromRegion = fromRegion.GetIntersection(Sheet.Region) as Region;
         foreach (var position in fixedFromRegion!)
         {
-            emptyPalette.Add(new Region(position.row, position.col), Sheet.GetFormat(position.row, position.col));
+            var format = Sheet.GetFormat(position.row, position.col);
+            if (Sheet.Protection.IsEnforced)
+                format.RemoveLock();
+            emptyPalette.Add(new Region(position.row, position.col), format);
         }
 
         emptyPalette.Copy(fromRegion, toRegion.TopLeft);

--- a/src/BlazorDatasheet.Core/Data/Sheet.cs
+++ b/src/BlazorDatasheet.Core/Data/Sheet.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using BlazorDatasheet.Core.Commands;
 using BlazorDatasheet.Core.Commands.Data;
 using BlazorDatasheet.Core.Commands.Formatting;
@@ -54,6 +54,9 @@ public class Sheet
     /// Managers commands & undo/redo. Default is true.
     /// </summary>
     public CommandManager Commands { get; }
+
+    /// <summary>Controls editing and operations on a protected sheet.</summary>
+    public BlazorDatasheet.Core.Protection.SheetProtection Protection { get; }
 
     /// <summary>
     /// Manages sheet formula
@@ -229,6 +232,7 @@ public class Sheet
 
         Cells = values == null ? new CellStore(this) : new CellStore(this, values);
         Commands = new CommandManager(this);
+        Protection = new BlazorDatasheet.Core.Protection.SheetProtection(this);
         Editor = new Editor(this);
         Validators = new ValidationManager(this);
         Rows = new RowInfoStore(defaultHeight, this);
@@ -607,13 +611,13 @@ public class Sheet
         // It is possible that each line is of different cell lengths, so we return the max for all lines
         var maxEndCol = -1;
 
-        object[][] rowData = new object[lines.Length][];
+        object[][] rowData = new object[Math.Max(0, endRow - inputPosition.row + 1)][];
 
         int lineNo = 0;
         for (int row = inputPosition.row; row <= endRow; row++)
         {
             string[] lineSplit = lines[lineNo].Split('\t');
-            rowData[lineNo] = lineSplit;
+            rowData[lineNo] = lineSplit.Take(NumCols - inputPosition.col).ToArray();
 
             var endCol = Math.Min(inputPosition.col + lineSplit.Length - 1, NumCols - 1);
             maxEndCol = Math.Max(endCol, maxEndCol);
@@ -625,7 +629,8 @@ public class Sheet
         if (Cells.ContainsReadOnly(inputRegion))
             return null;
 
-        Cells.SetValues(inputPosition.row, inputPosition.col, rowData);
+        if (!Cells.SetValues(inputPosition.row, inputPosition.col, rowData))
+            return null;
 
         return inputRegion;
     }

--- a/src/BlazorDatasheet.Core/Data/SheetRange.cs
+++ b/src/BlazorDatasheet.Core/Data/SheetRange.cs
@@ -1,4 +1,5 @@
 using BlazorDatasheet.Core.Formats;
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.Core.Interfaces;
 using BlazorDatasheet.DataStructures.Geometry;
 
@@ -103,8 +104,15 @@ public class SheetRange
             Sheet.Cells.SetCellMetaData(region, name, value);
     }
 
+    /// <summary>
+    /// Clears all metadata in the range. This is a direct, non-undoable update and is denied
+    /// while the sheet is protected.
+    /// </summary>
     public void ClearMetaData()
     {
+        if (!Sheet.Protection.Can(SheetOperation.Configure))
+            return;
+
         Sheet.BatchUpdates();
         try
         {
@@ -135,8 +143,16 @@ public class SheetRange
         set => Sheet.SetFormat(Region, value);
     }
 
+    /// <summary>
+    /// Adds a validator to the range. This is a direct, non-undoable update (so that validators
+    /// set up when a sheet is built are not removed by the user's first undo) and is denied while
+    /// the sheet is protected.
+    /// </summary>
     public void AddValidator(IDataValidator validator)
     {
+        if (!Sheet.Protection.Can(SheetOperation.Configure))
+            return;
+
         Sheet.BatchUpdates();
         Sheet.Validators.AddImpl(validator, Region);
         Sheet.EndBatchUpdates();

--- a/src/BlazorDatasheet.Core/Edit/Editor.cs
+++ b/src/BlazorDatasheet.Core/Edit/Editor.cs
@@ -116,7 +116,7 @@ public class Editor
             return;
 
         var cell = Sheet.Cells.GetCell(row, col);
-        if (cell.Format.IsReadOnly == true)
+        if (cell.Format.IsReadOnly == true || !Sheet.Protection.CanEdit(row, col))
             return;
 
         // check if the cell is visible OR if the cell is merged, and part of the cell is visible
@@ -136,7 +136,7 @@ public class Editor
         var beforeEditArgs = new BeforeCellEditEventArgs(cell, cell.GetValue<string>(), cell.Type);
         this.BeforeCellEdit?.Invoke(this, beforeEditArgs);
 
-        if (beforeEditArgs.CancelEdit)
+        if (beforeEditArgs.CancelEdit || !Sheet.Protection.CanEdit(row, col))
             return;
 
         var isSoftEdit = forceSoftEdit ||
@@ -185,6 +185,12 @@ public class Editor
         if (EditCell == null || !IsEditing)
             return false;
 
+        if (!Sheet.Protection.CanEdit(EditCell.Row, EditCell.Col))
+        {
+            CancelEdit();
+            return false;
+        }
+
         // Determine if it's a formula, and calculate.
         CellFormula? parsedFormula = null;
         var isFormula = FormulaEngine.FormulaEngine.IsFormula(this.EditValue);
@@ -222,6 +228,16 @@ public class Editor
         var beforeAcceptEdit = new BeforeAcceptEditEventArgs(EditCell, editValue, parsedFormula, formulaString);
         BeforeEditAccepted?.Invoke(this, beforeAcceptEdit);
 
+        if (EditCell == null || !IsEditing)
+            return false;
+
+        // the callback may have protected the sheet
+        if (!Sheet.Protection.CanEdit(EditCell.Row, EditCell.Col))
+        {
+            CancelEdit();
+            return false;
+        }
+
         if (beforeAcceptEdit.AcceptEdit)
         {
             // run the validators that are strict. cancel edit if any fail
@@ -236,10 +252,30 @@ public class Editor
                 return false;
             }
 
-            if (isFormula && parsedFormula != null)
-                Sheet.Cells.SetFormula(EditCell.Row, EditCell.Col, parsedFormula);
-            else
-                Sheet.Cells.SetValue(EditCell.Row, EditCell.Col, editValue);
+            var editRow = EditCell.Row;
+            var editCol = EditCell.Col;
+
+            var accepted = isFormula && parsedFormula != null
+                ? Sheet.Commands.ExecuteCommand(
+                    new BlazorDatasheet.Core.Commands.Data.SetParsedFormulaCommand(editRow, editCol, parsedFormula))
+                : Sheet.Cells.SetValue(editRow, editCol, editValue);
+
+            if (!accepted)
+            {
+                // The write was rejected (protection, a cancelled command, or a chained command that
+                // failed). Close the editor rather than leaving the user stuck in an edit they can
+                // only escape from.
+                if (IsEditing)
+                {
+                    EditFinished?.Invoke(this, new EditFinishedEventArgs(editRow, editCol));
+                    ClearEdit();
+                }
+
+                return false;
+            }
+
+            if (EditCell == null)
+                return false;
 
             EditAccepted?.Invoke(
                 this,

--- a/src/BlazorDatasheet.Core/Formats/CellFormat.cs
+++ b/src/BlazorDatasheet.Core/Formats/CellFormat.cs
@@ -160,8 +160,16 @@ public class CellFormat : IMergeable<CellFormat>, IEquatable<CellFormat>, IReado
     }
 
     /// <summary>
-    /// Whether the cell's value can be modified by the user.
+    /// Whether the cell is locked when sheet protection is enabled. Null inherits the
+    /// column or row setting, with locked as the default. Ignored by conditional formatting.
     /// </summary>
+    public bool? IsLocked
+    {
+        get => GetStyleOrDefault<bool?>(nameof(IsLocked));
+        set => AddStyle(nameof(IsLocked), value);
+    }
+
+    /// <summary>Whether editing is always disabled by existing read-only controls.</summary>
     public bool? IsReadOnly
     {
         get => GetStyleOrDefault<bool?>(nameof(IsReadOnly));
@@ -227,6 +235,10 @@ public class CellFormat : IMergeable<CellFormat>, IEquatable<CellFormat>, IReado
         get => GetStyleOrDefault<TextWrapping>(nameof(TextWrapping));
         set => AddStyle(nameof(TextWrapping), value);
     }
+
+    internal void RemoveLock() => _styles?.Remove(nameof(IsLocked));
+
+    internal bool SpecifiesLock => _styles?.ContainsKey(nameof(IsLocked)) == true;
 
     private void AddStyle<T>(string key, T? value)
     {

--- a/src/BlazorDatasheet.Core/Formats/IReadonlyCellFormat.cs
+++ b/src/BlazorDatasheet.Core/Formats/IReadonlyCellFormat.cs
@@ -68,6 +68,9 @@ public interface IReadonlyCellFormat
     /// Whether the cell's value can be modified by the user.
     /// </summary>
     public bool? IsReadOnly { get; }
+
+    /// <summary>Whether the cell is locked when sheet protection is enabled.</summary>
+    public bool? IsLocked => null;
     
     /// <summary>
     /// The text wrapping style.

--- a/src/BlazorDatasheet.Core/Patterns/DefaultAutofillPattern.cs
+++ b/src/BlazorDatasheet.Core/Patterns/DefaultAutofillPattern.cs
@@ -20,7 +20,13 @@ public class DefaultAutofillPattern : IAutoFillPattern
     public ICommand GetCommand(int offset, int repeatNo, IReadOnlyCell cellData, CellPosition newDataPosition)
     {
         var beforeAutoFillEventArgs = _sheet.EmitBeforeAutoFill();
-        var options = new CopyOptions() { CopyFormat = beforeAutoFillEventArgs.CopyFormat };
+        var target = new Region(newDataPosition.row, newDataPosition.col);
+        // if formatting isn't permitted (e.g. the sheet is protected), degrade to a values-only fill
+        // rather than having the whole autofill rejected.
+        var options = new CopyOptions()
+        {
+            CopyFormat = beforeAutoFillEventArgs.CopyFormat && _sheet.Protection.CanFormat(target)
+        };
         if (cellData.HasFormula())
             options.CopyValues = false;
 

--- a/src/BlazorDatasheet.Core/Protection/IProtectedCommand.cs
+++ b/src/BlazorDatasheet.Core/Protection/IProtectedCommand.cs
@@ -1,0 +1,13 @@
+using BlazorDatasheet.Core.Data;
+
+namespace BlazorDatasheet.Core.Protection;
+
+/// <summary>
+/// Declares a command's protection requirements. Implementations must be side-effect free
+/// and check every region and operation they will modify using Sheet.Protection.
+/// Commands without a declaration are denied while protection is enforced.
+/// </summary>
+public interface IProtectedCommand
+{
+    bool CanExecuteProtected(Sheet sheet);
+}

--- a/src/BlazorDatasheet.Core/Protection/SheetProtection.cs
+++ b/src/BlazorDatasheet.Core/Protection/SheetProtection.cs
@@ -1,0 +1,157 @@
+using BlazorDatasheet.Core.Commands;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.DataStructures.Geometry;
+
+namespace BlazorDatasheet.Core.Protection;
+
+/// <summary>Sheet editing policy, independent of existing read-only settings.</summary>
+public sealed class SheetProtection
+{
+    private readonly Sheet _sheet;
+    private int _bypassDepth;
+    internal int Revision { get; private set; }
+    public bool IsProtected { get; private set; }
+    public SheetProtectionOptions Options { get; private set; } = new();
+    public event EventHandler? Changed;
+    internal bool IsEnforced => IsProtected && _bypassDepth == 0;
+
+    internal SheetProtection(Sheet sheet) => _sheet = sheet;
+
+    public void Protect(SheetProtectionOptions? options = null)
+    {
+        var next = options ?? new SheetProtectionOptions();
+        if (IsProtected && Options == next)
+            return;
+        IsProtected = true;
+        Options = next;
+        OnChanged();
+    }
+
+    public void Unprotect()
+    {
+        if (!IsProtected)
+            return;
+        IsProtected = false;
+        OnChanged();
+    }
+
+    private void OnChanged()
+    {
+        Revision++;
+        _sheet.Commands.ClearHistory();
+        if (_sheet.Editor.EditCell is { } cell && !CanEdit(cell.Row, cell.Col))
+            _sheet.Editor.CancelEdit();
+        Changed?.Invoke(this, EventArgs.Empty);
+        _sheet.MarkDirty(_sheet.Region);
+    }
+
+    /// <summary>
+    /// Runs a synchronous trusted update. Do not pass async delegates. Existing read-only
+    /// checks still apply. Trusted updates clear history so they cannot be replayed by users.
+    /// </summary>
+    public void RunUnprotected(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        RunUnprotected(() => { action(); return true; });
+    }
+
+    public T RunUnprotected<T>(Func<T> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        var outermost = _bypassDepth++ == 0;
+        try { return action(); }
+        finally
+        {
+            _bypassDepth--;
+            if (outermost && IsProtected)
+                OnChanged();
+        }
+    }
+
+    public bool IsLocked(int row, int col) =>
+        _sheet.Cells.GetFormat(row, col)?.IsLocked ??
+        _sheet.Columns.Formats.Get(col)?.IsLocked ??
+        _sheet.Rows.Formats.Get(row)?.IsLocked ?? true;
+
+    public bool CanEdit(int row, int col) => CanEdit(new Region(row, col));
+
+    public bool CanEdit(IRegion region)
+    {
+        if (!IsEnforced)
+            return true;
+        return !ContainsLocked(region) && _sheet.Cells.GetMerges(region).All(x => !ContainsLocked(x));
+    }
+
+    /// <summary>Queries protection only; bounds, validation and legacy read-only checks remain separate.</summary>
+    public bool Can(SheetOperation operation, IRegion? region = null)
+    {
+        if (!IsEnforced)
+            return true;
+        return operation switch
+        {
+            SheetOperation.EditCells => region != null && CanEdit(region),
+            SheetOperation.FormatCells => Options.AllowFormatCells,
+            SheetOperation.FormatRows => Options.AllowFormatRows,
+            SheetOperation.FormatColumns => Options.AllowFormatColumns,
+            SheetOperation.InsertRows => Options.AllowInsertRows,
+            SheetOperation.InsertColumns => Options.AllowInsertColumns,
+            SheetOperation.DeleteRows => Options.AllowDeleteRows && region != null && CanEdit(region),
+            SheetOperation.DeleteColumns => Options.AllowDeleteColumns && region != null && CanEdit(region),
+            SheetOperation.Sort => Options.AllowSort && region != null && CanEdit(region),
+            SheetOperation.Filter => Options.AllowFilter,
+            SheetOperation.Freeze => true,
+            _ => false
+        };
+    }
+
+    public bool CanFormat(IRegion region) => Can(region switch
+    {
+        RowRegion => SheetOperation.FormatRows,
+        ColumnRegion => SheetOperation.FormatColumns,
+        _ => SheetOperation.FormatCells
+    }, region);
+
+    /// <summary>Checks a command and all declared chained operations before mutation.</summary>
+    public bool CanExecute(ICommand command)
+    {
+        if (!IsEnforced)
+            return true;
+        return command is IProtectedCommand declaration && declaration.CanExecuteProtected(_sheet) &&
+               command.GetChainedBeforeCommands().All(CanExecute) &&
+               command.GetChainedAfterCommands().All(CanExecute);
+    }
+
+    /// <summary>Resolves sparse format regions in precedence order, without visiting individual cells.</summary>
+    public bool ContainsLocked(IRegion region)
+    {
+        var clipped = region.GetIntersection(_sheet.Region);
+        if (clipped == null)
+            return false;
+        var unresolved = new List<IRegion> { clipped };
+        var formats = _sheet.Cells.GetFormatData(clipped)
+            .Select(x => (x.Region, x.Data.IsLocked))
+            .Concat(_sheet.Columns.Formats.GetIntervals(clipped.Left, clipped.Right)
+                .Select(x => ((IRegion)new ColumnRegion(x.Start, x.End), x.Data.IsLocked)))
+            .Concat(_sheet.Rows.Formats.GetIntervals(clipped.Top, clipped.Bottom)
+                .Select(x => ((IRegion)new RowRegion(x.Start, x.End), x.Data.IsLocked)));
+        foreach (var (area, locked) in formats)
+        {
+            if (locked == null)
+                continue;
+            var remaining = new List<IRegion>();
+            foreach (var part in unresolved)
+            {
+                if (part.GetIntersection(area) == null)
+                    remaining.Add(part);
+                else if (locked.Value)
+                    return true;
+                else
+                    remaining.AddRange(part.Break(area));
+            }
+            unresolved = remaining;
+            if (unresolved.Count == 0)
+                return false;
+        }
+        return unresolved.Count != 0;
+    }
+}

--- a/src/BlazorDatasheet.Core/Protection/SheetProtection.cs
+++ b/src/BlazorDatasheet.Core/Protection/SheetProtection.cs
@@ -41,6 +41,7 @@ public sealed class SheetProtection
         _sheet.Commands.ClearHistory();
         if (_sheet.Editor.EditCell is { } cell && !CanEdit(cell.Row, cell.Col))
             _sheet.Editor.CancelEdit();
+        ConstrainSelectionToUnlocked();
         Changed?.Invoke(this, EventArgs.Empty);
         _sheet.MarkDirty(_sheet.Region);
     }
@@ -75,11 +76,78 @@ public sealed class SheetProtection
 
     public bool CanEdit(int row, int col) => CanEdit(new Region(row, col));
 
-    public bool CanEdit(IRegion region)
+    public bool CanEdit(IRegion region) => !IsEnforced || IsFullyUnlocked(region);
+
+    /// <summary>Whether locked cells are currently excluded from user selection.</summary>
+    internal bool RestrictsSelection => IsEnforced && !Options.AllowSelectLockedCells;
+
+    /// <summary>Whether the region may be selected by user input. Programmatic selection is unrestricted.</summary>
+    public bool CanSelect(IRegion region) => !RestrictsSelection || IsFullyUnlocked(region);
+
+    private bool IsFullyUnlocked(IRegion region) =>
+        !ContainsLocked(region) && _sheet.Cells.GetMerges(region).All(x => !ContainsLocked(x));
+
+    /// <summary>
+    /// The first unlocked cell in row-major order, or null when every cell is locked. Only regions
+    /// that some format marks unlocked are visited, so the whole sheet is never scanned.
+    /// </summary>
+    internal CellPosition? FindFirstUnlockedCell()
     {
-        if (!IsEnforced)
-            return true;
-        return !ContainsLocked(region) && _sheet.Cells.GetMerges(region).All(x => !ContainsLocked(x));
+        if (_sheet.Area == 0)
+            return null;
+
+        var candidates = _sheet.Cells.GetFormatData(_sheet.Region)
+            .Where(x => x.Data.IsLocked == false)
+            .Select(x => (IRegion)x.Region)
+            .Concat(_sheet.Columns.Formats.GetIntervals(0, _sheet.NumCols - 1)
+                .Where(x => x.Data.IsLocked == false)
+                .Select(x => (IRegion)new ColumnRegion(x.Start, x.End)))
+            .Concat(_sheet.Rows.Formats.GetIntervals(0, _sheet.NumRows - 1)
+                .Where(x => x.Data.IsLocked == false)
+                .Select(x => (IRegion)new RowRegion(x.Start, x.End)));
+
+        CellPosition? first = null;
+        foreach (var candidate in candidates)
+        {
+            // A candidate starting higher up the sheet may have its early rows overridden back to
+            // locked, so every candidate is scanned and the minimum position taken.
+            var found = FindFirstUnlockedCellIn(candidate.GetIntersection(_sheet.Region));
+            if (found == null)
+                continue;
+            if (first == null || found.Value.row < first.Value.row ||
+                (found.Value.row == first.Value.row && found.Value.col < first.Value.col))
+                first = found;
+        }
+
+        return first;
+    }
+
+    private CellPosition? FindFirstUnlockedCellIn(IRegion? region)
+    {
+        if (region == null)
+            return null;
+        for (var row = region.Top; row <= region.Bottom; row++)
+        for (var col = region.Left; col <= region.Right; col++)
+        {
+            if (!IsLocked(row, col) && CanSelect(new Region(row, col)))
+                return new CellPosition(row, col);
+        }
+
+        return null;
+    }
+
+    private void ConstrainSelectionToUnlocked()
+    {
+        if (!RestrictsSelection)
+            return;
+        if (_sheet.Selection.IsSelecting)
+            _sheet.Selection.CancelSelecting();
+        if (_sheet.Selection.Regions.All(CanSelect))
+            return;
+        if (FindFirstUnlockedCell() is { } position)
+            _sheet.Selection.Set(position.row, position.col);
+        else
+            _sheet.Selection.ClearSelections();
     }
 
     /// <summary>Queries protection only; bounds, validation and legacy read-only checks remain separate.</summary>
@@ -99,6 +167,7 @@ public sealed class SheetProtection
             SheetOperation.DeleteColumns => Options.AllowDeleteColumns && region != null && CanEdit(region),
             SheetOperation.Sort => Options.AllowSort && region != null && CanEdit(region),
             SheetOperation.Filter => Options.AllowFilter,
+            SheetOperation.SelectLockedCells => Options.AllowSelectLockedCells,
             SheetOperation.Freeze => true,
             _ => false
         };

--- a/src/BlazorDatasheet.Core/Protection/SheetProtectionOptions.cs
+++ b/src/BlazorDatasheet.Core/Protection/SheetProtectionOptions.cs
@@ -1,0 +1,32 @@
+namespace BlazorDatasheet.Core.Protection;
+
+/// <summary>Operations allowed while a sheet is protected. All are denied by default.</summary>
+public sealed record SheetProtectionOptions
+{
+    public bool AllowFormatCells { get; init; }
+    public bool AllowFormatRows { get; init; }
+    public bool AllowFormatColumns { get; init; }
+    public bool AllowInsertRows { get; init; }
+    public bool AllowInsertColumns { get; init; }
+    public bool AllowDeleteRows { get; init; }
+    public bool AllowDeleteColumns { get; init; }
+    public bool AllowSort { get; init; }
+    public bool AllowFilter { get; init; }
+}
+
+/// <summary>An operation governed by sheet protection.</summary>
+public enum SheetOperation
+{
+    EditCells,
+    FormatCells,
+    FormatRows,
+    FormatColumns,
+    InsertRows,
+    InsertColumns,
+    DeleteRows,
+    DeleteColumns,
+    Sort,
+    Filter,
+    Configure,
+    Freeze
+}

--- a/src/BlazorDatasheet.Core/Protection/SheetProtectionOptions.cs
+++ b/src/BlazorDatasheet.Core/Protection/SheetProtectionOptions.cs
@@ -12,6 +12,12 @@ public sealed record SheetProtectionOptions
     public bool AllowDeleteColumns { get; init; }
     public bool AllowSort { get; init; }
     public bool AllowFilter { get; init; }
+
+    /// <summary>
+    /// Whether locked cells can be selected with the mouse or keyboard. Unlike every other option,
+    /// this is allowed by default, matching spreadsheet convention.
+    /// </summary>
+    public bool AllowSelectLockedCells { get; init; } = true;
 }
 
 /// <summary>An operation governed by sheet protection.</summary>
@@ -27,6 +33,7 @@ public enum SheetOperation
     DeleteColumns,
     Sort,
     Filter,
+    SelectLockedCells,
     Configure,
     Freeze
 }

--- a/src/BlazorDatasheet.Core/Selecting/Selection.Input.cs
+++ b/src/BlazorDatasheet.Core/Selecting/Selection.Input.cs
@@ -16,7 +16,8 @@ public partial class Selection
     internal void HandleInput(SelectionInputKind kind, Action<Selection> operation)
     {
         if (!ReferenceEquals(this, _sheet.Selection) ||
-            (!_sheet.HasSelectionInputHandlers && _inputPreviewSnapshot == null))
+            (!_sheet.HasSelectionInputHandlers && _inputPreviewSnapshot == null &&
+             !_sheet.Protection.RestrictsSelection))
         {
             operation(this);
             return;
@@ -33,6 +34,9 @@ public partial class Selection
         };
         proposal._regions.AddRange(CloneRegions());
         operation(proposal);
+
+        if (!SkipLockedCellsDuringNavigation(kind, operation, proposal))
+            return;
 
         var isPreview = proposal.IsSelecting;
         // Commit only on the detached instance to obtain the complete proposed selection.
@@ -75,6 +79,40 @@ public partial class Selection
             ApplyInputSnapshot(snapshot, proposal._inputSetsActiveCellPosition ||
                 snapshot.ActiveCellPosition != ActiveCellPosition);
         }
+    }
+
+    /// <summary>
+    /// Repeats a navigation while it lands on a cell that protection excludes from selection, so
+    /// that runs of locked cells are skipped over rather than blocking the keyboard. Returns false
+    /// when there is nowhere left to move and the input should be cancelled.
+    /// </summary>
+    private bool SkipLockedCellsDuringNavigation(SelectionInputKind kind, Action<Selection> operation,
+        Selection proposal)
+    {
+        if (!_sheet.Protection.RestrictsSelection ||
+            kind is not (SelectionInputKind.ArrowNavigation or SelectionInputKind.TabEnterNavigation))
+            return true;
+
+        var visited = new HashSet<(CellPosition Position, int RegionIndex)>();
+        while (!CanSelectActiveCell(proposal))
+        {
+            // Repeating the same operation is safe: after the first move the active region is a
+            // single cell or merge, so navigation only moves the position. At a sheet edge the
+            // position stops changing, which the visited set detects.
+            if (!visited.Add((proposal.ActiveCellPosition, proposal._activeRegionIndex)) ||
+                visited.Count > _sheet.Area)
+                return false;
+            operation(proposal);
+        }
+
+        return true;
+    }
+
+    private bool CanSelectActiveCell(Selection proposal)
+    {
+        var position = proposal.ActiveCellPosition;
+        var region = ExpandRegionOverMerges(new Region(position.row, position.col));
+        return region != null && _sheet.Protection.CanSelect(region);
     }
 
     private bool ConstrainInputProposal()
@@ -124,7 +162,24 @@ public partial class Selection
                 return false;
         }
 
+        if (_sheet.Protection.RestrictsSelection && !IsAllowedByProtection(args))
+            return false;
+
         return args.ProposedRegions[args.ProposedActiveRegionIndex].Contains(args.ProposedActiveCellPosition);
+    }
+
+    private bool IsAllowedByProtection(BeforeSelectionInputEventArgs args)
+    {
+        // Navigation only ever moves the active cell; other regions may legitimately contain locked
+        // cells when they were set programmatically, and tab cycling simply skips over them.
+        if (args.InputKind is SelectionInputKind.ArrowNavigation or SelectionInputKind.TabEnterNavigation)
+        {
+            var position = args.ProposedActiveCellPosition;
+            var active = ExpandRegionOverMerges(new Region(position.row, position.col));
+            return active != null && _sheet.Protection.CanSelect(active);
+        }
+
+        return args.ProposedRegions.All(x => _sheet.Protection.CanSelect(x));
     }
 
     private void ApplyInputPreview(SelectionSnapshot snapshot, SelectionMode mode, CellPosition start)

--- a/src/BlazorDatasheet.Core/Serialization/Json/Converters/CellFormatJsonConverter.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Json/Converters/CellFormatJsonConverter.cs
@@ -17,6 +17,7 @@ internal class CellFormatJsonConverter : JsonConverter<CellFormat>
             Property<string?>(nameof(CellFormat.NumberFormat), (format, value) => format.NumberFormat = value),
             Property<string?>(nameof(CellFormat.Icon), (format, value) => format.Icon = value),
             Property<string?>(nameof(CellFormat.IconColor), (format, value) => format.IconColor = value),
+            Property<bool?>(nameof(CellFormat.IsLocked), (format, value) => format.IsLocked = value),
             Property<bool?>(nameof(CellFormat.IsReadOnly), (format, value) => format.IsReadOnly = value),
             Property<TextAlign?>(nameof(CellFormat.HorizontalTextAlign),
                 (format, value) => format.HorizontalTextAlign = value),

--- a/src/BlazorDatasheet.Core/Serialization/Mappers/SheetMapper.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Mappers/SheetMapper.cs
@@ -15,6 +15,7 @@ internal class SheetMapper
 	{
 		var sheetModel = new SheetModel();
 
+		sheetModel.Protection = sheet.Protection.IsProtected ? sheet.Protection.Options : null;
 		sheetModel.NumRows = sheet.NumRows;
 		sheetModel.NumCols = sheet.NumCols;
 		sheetModel.Name = sheet.Name;
@@ -216,6 +217,8 @@ internal class SheetMapper
 		sheet.EndBatchUpdates();
 		sheet.ScreenUpdating = true;
 		sheet.Commands.ResumeHistory();
+		if (sheetModel.Protection != null)
+			sheet.Protection.Protect(sheetModel.Protection);
 	}
 
 	private static void BulkLoadCellValues(SheetModel sheetModel, Sheet sheet)

--- a/src/BlazorDatasheet.Core/Serialization/Models/SheetModel.cs
+++ b/src/BlazorDatasheet.Core/Serialization/Models/SheetModel.cs
@@ -1,10 +1,11 @@
-﻿using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Interfaces;
 
 namespace BlazorDatasheet.Core.Serialization.Models;
 
 internal class SheetModel
 {
+    public BlazorDatasheet.Core.Protection.SheetProtectionOptions? Protection { get; set; }
     public string Name { get; set; }
     public List<RowModel> Rows { get; set; } = new();
     public FreezeStateModel FreezeState { get; set; } = new();

--- a/src/BlazorDatasheet.Core/Validation/ValidationManager.cs
+++ b/src/BlazorDatasheet.Core/Validation/ValidationManager.cs
@@ -1,7 +1,8 @@
-﻿using BlazorDatasheet.Core.Commands.Formatting;
+using BlazorDatasheet.Core.Commands.Formatting;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Events.Validation;
 using BlazorDatasheet.Core.Interfaces;
+using BlazorDatasheet.Core.Protection;
 using BlazorDatasheet.DataStructures.Geometry;
 using BlazorDatasheet.DataStructures.Store;
 using BlazorDatasheet.Formula.Core;
@@ -103,11 +104,18 @@ public class ValidationManager
 
 
     /// <summary>
-    /// Clears the data validator from the region
+    /// Clears the data validator from the region. This is a direct, non-undoable update and is
+    /// denied while the sheet is protected.
     /// </summary>
-    /// <param name="validator"></param>
-    /// <param name="region"></param>
     public void Clear(IDataValidator validator, IRegion region)
+    {
+        if (!_sheet.Protection.Can(SheetOperation.Configure))
+            return;
+
+        ClearImpl(validator, region);
+    }
+
+    internal void ClearImpl(IDataValidator validator, IRegion region)
     {
         var index = GetValidatorIndex(validator);
         if (index == null)

--- a/src/BlazorDatasheet.SharedPages/Components/Examples/Protection/SheetProtectionExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Examples/Protection/SheetProtectionExample.razor
@@ -1,0 +1,55 @@
+@using BlazorDatasheet.Core.Data
+@using BlazorDatasheet.Core.Formats
+@using BlazorDatasheet.Core.Protection
+@using BlazorDatasheet.DataStructures.Geometry
+<button class="button"
+        @onclick="ToggleProtection">@(_sheet.Protection.IsProtected ? "Unprotect sheet" : "Protect sheet")</button>
+<button class="button" @onclick="ResetInputs">Reset inputs using trusted code</button>
+<p>Status: @(_sheet.Protection.IsProtected ? "Protected" : "Unprotected")</p>
+<label>
+    <input type="checkbox" checked="@_allowSelectLocked" @onchange="OnAllowSelectLockedChanged"/>
+    Allow selecting locked cells
+</label>
+<Datasheet Sheet="_sheet"/>
+
+
+@code {
+    private readonly Sheet _sheet = new(6, 3);
+    private bool _allowSelectLocked = true;
+
+    private SheetProtectionOptions Options => new() { AllowSelectLockedCells = _allowSelectLocked };
+
+    protected override void OnInitialized()
+    {
+        _sheet.Cells.SetValue(0, 0, "Order");
+        _sheet.Cells.SetValue(1, 0, "Quantity");
+        _sheet.Cells.SetValue(2, 0, "Unit price");
+        _sheet.Cells.SetValue(3, 0, "Total");
+        ResetInputs();
+        _sheet.Cells.SetFormula(3, 1, "=B2*B3");
+        _sheet.SetFormat(new Region(1, 2, 1, 1), new CellFormat { IsLocked = false, BackgroundColor = "#dbeafe" });
+        _sheet.Protection.Protect(Options);
+    }
+
+    private void ToggleProtection()
+    {
+        if (_sheet.Protection.IsProtected)
+            _sheet.Protection.Unprotect();
+        else
+            _sheet.Protection.Protect(Options);
+    }
+
+    private void OnAllowSelectLockedChanged(ChangeEventArgs args)
+    {
+        _allowSelectLocked = args.Value is true;
+        if (_sheet.Protection.IsProtected)
+            _sheet.Protection.Protect(Options);
+    }
+
+    private void ResetInputs() => _sheet.Protection.RunUnprotected(() =>
+    {
+        _sheet.Cells.SetValue(1, 1, 2);
+        _sheet.Cells.SetValue(2, 1, 15);
+    });
+
+}

--- a/src/BlazorDatasheet.SharedPages/Components/Layout/NavMenu.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Layout/NavMenu.razor
@@ -1,4 +1,4 @@
-﻿@inject NavigationManager NavigationManager
+@inject NavigationManager NavigationManager
 @implements IDisposable
 
 <div
@@ -33,6 +33,7 @@
     <ul class="menu-list">
         <MenuLink Href="CellsAndCellValues" Text="Cells and cell values"/>
         <MenuLink Href="DataValidation" Text="Data validation"/>
+        <MenuLink Href="SheetProtection" Text="Sheet protection"/>
         <MenuLink Href="Sorting" Text="Sorting"/>
         <MenuLink Href="ColumnFilters" Text="Column filters"/>
         <MenuLink Href="Commands" Text="Commands"/>

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/SheetProtectionExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/SheetProtectionExample.razor
@@ -1,0 +1,51 @@
+@page "/SheetProtection"
+@using BlazorDatasheet.Core.Data
+@using BlazorDatasheet.Core.Formats
+@using BlazorDatasheet.Core.Protection
+@using BlazorDatasheet.DataStructures.Geometry
+
+<h3>Sheet protection</h3>
+<p>Edit the blue input cells. The total is a locked formula that recalculates when inputs change.
+    Protection also prevents formatting and structural changes.</p>
+<button class="button" @onclick="ToggleProtection">@(_sheet.Protection.IsProtected ? "Unprotect sheet" : "Protect sheet")</button>
+<button class="button" @onclick="ResetInputs">Reset inputs using trusted code</button>
+<p>Status: @(_sheet.Protection.IsProtected ? "Protected" : "Unprotected")</p>
+<Datasheet Sheet="_sheet"/>
+
+<pre><code>sheet.SetFormat(new Region(1, 2, 1, 1), new CellFormat { IsLocked = false });
+sheet.Protection.Protect();
+sheet.Protection.RunUnprotected(() =&gt; sheet.Cells.SetValue(1, 1, 2));</code></pre>
+<p>Cells are locked by default; locking takes effect only while protected. Use
+    <code>SheetProtectionOptions</code> to allow formatting, inserting or deleting rows and columns,
+    sorting, or filtering. Changing protection or completing a trusted update clears undo and redo history.
+    The trusted callback is synchronous; application code controls access to it.</p>
+
+@code {
+    private readonly Sheet _sheet = new(6, 3);
+
+    protected override void OnInitialized()
+    {
+        _sheet.Cells.SetValue(0, 0, "Order");
+        _sheet.Cells.SetValue(1, 0, "Quantity");
+        _sheet.Cells.SetValue(2, 0, "Unit price");
+        _sheet.Cells.SetValue(3, 0, "Total");
+        ResetInputs();
+        _sheet.Cells.SetFormula(3, 1, "=B2*B3");
+        _sheet.SetFormat(new Region(1, 2, 1, 1), new CellFormat { IsLocked = false, BackgroundColor = "#dbeafe" });
+        _sheet.Protection.Protect();
+    }
+
+    private void ToggleProtection()
+    {
+        if (_sheet.Protection.IsProtected)
+            _sheet.Protection.Unprotect();
+        else
+            _sheet.Protection.Protect();
+    }
+
+    private void ResetInputs() => _sheet.Protection.RunUnprotected(() =>
+    {
+        _sheet.Cells.SetValue(1, 1, 2);
+        _sheet.Cells.SetValue(2, 1, 15);
+    });
+}

--- a/src/BlazorDatasheet.SharedPages/Components/Pages/SheetProtectionExample.razor
+++ b/src/BlazorDatasheet.SharedPages/Components/Pages/SheetProtectionExample.razor
@@ -1,51 +1,19 @@
 @page "/SheetProtection"
-@using BlazorDatasheet.Core.Data
-@using BlazorDatasheet.Core.Formats
-@using BlazorDatasheet.Core.Protection
-@using BlazorDatasheet.DataStructures.Geometry
 
 <h3>Sheet protection</h3>
+
+
 <p>Edit the blue input cells. The total is a locked formula that recalculates when inputs change.
     Protection also prevents formatting and structural changes.</p>
-<button class="button" @onclick="ToggleProtection">@(_sheet.Protection.IsProtected ? "Unprotect sheet" : "Protect sheet")</button>
-<button class="button" @onclick="ResetInputs">Reset inputs using trusted code</button>
-<p>Status: @(_sheet.Protection.IsProtected ? "Protected" : "Unprotected")</p>
-<Datasheet Sheet="_sheet"/>
 
-<pre><code>sheet.SetFormat(new Region(1, 2, 1, 1), new CellFormat { IsLocked = false });
-sheet.Protection.Protect();
-sheet.Protection.RunUnprotected(() =&gt; sheet.Cells.SetValue(1, 1, 2));</code></pre>
-<p>Cells are locked by default; locking takes effect only while protected. Use
+<CodeExample ComponentType="typeof(BlazorDatasheet.SharedPages.Components.Examples.Protection.SheetProtectionExample)"/>
+
+<div class="block"><code>AllowSelectLockedCells</code> is allowed by default: turn it off and
+    locked cells can no longer be clicked or dragged over, while the arrow, tab and enter keys skip
+    straight past them to the next unlocked cell.
+</div>
+<div class="block">
+    Cells are locked by default; locking takes effect only while protected. Use
     <code>SheetProtectionOptions</code> to allow formatting, inserting or deleting rows and columns,
     sorting, or filtering. Changing protection or completing a trusted update clears undo and redo history.
-    The trusted callback is synchronous; application code controls access to it.</p>
-
-@code {
-    private readonly Sheet _sheet = new(6, 3);
-
-    protected override void OnInitialized()
-    {
-        _sheet.Cells.SetValue(0, 0, "Order");
-        _sheet.Cells.SetValue(1, 0, "Quantity");
-        _sheet.Cells.SetValue(2, 0, "Unit price");
-        _sheet.Cells.SetValue(3, 0, "Total");
-        ResetInputs();
-        _sheet.Cells.SetFormula(3, 1, "=B2*B3");
-        _sheet.SetFormat(new Region(1, 2, 1, 1), new CellFormat { IsLocked = false, BackgroundColor = "#dbeafe" });
-        _sheet.Protection.Protect();
-    }
-
-    private void ToggleProtection()
-    {
-        if (_sheet.Protection.IsProtected)
-            _sheet.Protection.Unprotect();
-        else
-            _sheet.Protection.Protect();
-    }
-
-    private void ResetInputs() => _sheet.Protection.RunUnprotected(() =>
-    {
-        _sheet.Cells.SetValue(1, 1, 2);
-        _sheet.Cells.SetValue(2, 1, 15);
-    });
-}
+</div>

--- a/src/BlazorDatasheet/Datasheet.razor.cs
+++ b/src/BlazorDatasheet/Datasheet.razor.cs
@@ -433,6 +433,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
     private void RemoveEvents(Sheet sheet)
     {
+        sheet.Protection.Changed -= ProtectionChanged;
         sheet.Editor.EditBegin -= EditorOnEditBegin;
         sheet.Editor.EditFinished -= EditorOnEditFinished;
         sheet.ScreenUpdatingChanged -= ScreenUpdatingChanged;
@@ -450,6 +451,7 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
     private void AddEvents(Sheet sheet)
     {
+        sheet.Protection.Changed += ProtectionChanged;
         sheet.Editor.EditBegin += EditorOnEditBegin;
         sheet.Editor.EditFinished += EditorOnEditFinished;
         sheet.ScreenUpdatingChanged += ScreenUpdatingChanged;
@@ -465,6 +467,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
         sheet.SetDialogService(new SimpleDialogService(Js));
         _autoScrollState.SetSheetSelectionActive(sheet.Selection.IsSelecting);
     }
+
+    private void ProtectionChanged(object? sender, EventArgs args) => _ = InvokeAsync(StateHasChanged);
 
     private void SelectingChanged(object? sender, IRegion? selectingRegion)
     {
@@ -620,7 +624,8 @@ public partial class Datasheet : SheetComponentBase, IAsyncDisposable, IScrollSe
 
         ShortcutManager.Register(["Delete", "Backspace"], KeyboardModifiers.Any,
             _ => _sheet.Commands.ExecuteCommand(new ClearCellsCommand(_sheet.Selection.Regions)),
-            _ => _sheet.Selection.Regions.Any() && !_sheet.Editor.IsEditing && !IsReadOnly);
+            _ => _sheet.Selection.Regions.Any() && !_sheet.Editor.IsEditing && !IsReadOnly &&
+                 new ClearCellsCommand(_sheet.Selection.Regions).CanExecute(_sheet));
     }
 
     private void HandleCellMouseDown(object? sender, SheetPointerEventArgs args)

--- a/src/BlazorDatasheet/Menu/SheetMenuItem.razor
+++ b/src/BlazorDatasheet/Menu/SheetMenuItem.razor
@@ -2,7 +2,7 @@
 @inject IMenuService MenuService
 @inherits SheetComponentBase
 
-<div class="bds-sheet-menu-item @(Disabled && DisabledOnReadOnly ? "bds-sheet-menu-item-disabled" : "")"
+<div class="bds-sheet-menu-item @(!IsEnabled || (Disabled && DisabledOnReadOnly) ? "bds-sheet-menu-item-disabled" : "")"
      @onmouseup="HandleMouseUp"
      @onmouseover="HandleMouseOver">
     @ChildContent
@@ -51,15 +51,16 @@
 
     [CascadingParameter] public bool Disabled { get; set; }
     
-    /// <summary>
-    /// Whether the menu item can be disabled. Default is true.
-    /// </summary>
+    /// <summary>Whether the operation is available, independently of read-only state.</summary>
+    [Parameter] public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Whether read-only state disables this item. Default is true.</summary>
     [Parameter]
     public bool DisabledOnReadOnly { get; set; } = true;
 
     private async Task HandleMouseUp(MouseEventArgs args)
     {
-        if (Disabled)
+        if (!IsEnabled || (Disabled && DisabledOnReadOnly))
             return;
 
         if (OnClick.HasDelegate)

--- a/src/BlazorDatasheet/Menu/SheetSubMenu.razor
+++ b/src/BlazorDatasheet/Menu/SheetSubMenu.razor
@@ -1,11 +1,11 @@
 @inherits SheetComponentBase
 
-<SheetMenuTarget DisableMenuTarget="@(Disabled && DisabledOnReadOnly)" 
+<SheetMenuTarget DisableMenuTarget="@(!IsEnabled || (Disabled && DisabledOnReadOnly))"
                  MenuId="@SubMenuId" 
                  MenuData="@CurrentContext"
                  Placement="@MenuPlacement.Right"
                  Trigger="@MenuTrigger.OnHover" Margin="0">
-    <SheetMenuItem SubmenuId="@SubMenuId" DisabledOnReadOnly="DisabledOnReadOnly">
+    <SheetMenuItem IsEnabled="IsEnabled" SubmenuId="@SubMenuId" DisabledOnReadOnly="DisabledOnReadOnly">
         <div class="bds-sheet-submenu-label">
             <span class="bds-sheet-submenu-text">@Label</span>
             <span class="bds-sheet-submenu-chevron">
@@ -46,7 +46,7 @@
     }
 </style>
 
-<SheetMenu MenuId="@SubMenuId" Disabled="@(Disabled && DisabledOnReadOnly)" ParentMenuId="@MenuId">
+<SheetMenu MenuId="@SubMenuId" Disabled="@(!IsEnabled || (Disabled && DisabledOnReadOnly))" ParentMenuId="@MenuId">
     @ChildContent
 </SheetMenu>
 
@@ -64,9 +64,10 @@
 
     [CascadingParameter] public bool Disabled { get; set; }
 
-    /// <summary>
-    /// Whether the menu item can be disabled. Default is true.
-    /// </summary>
+    /// <summary>Whether the operation is available, independently of read-only state.</summary>
+    [Parameter] public bool IsEnabled { get; set; } = true;
+
+    /// <summary>Whether read-only state disables this item. Default is true.</summary>
     [Parameter]
     public bool DisabledOnReadOnly { get; set; } = true;
 

--- a/src/BlazorDatasheet/Render/DefaultComponents/BoolRenderer.razor
+++ b/src/BlazorDatasheet/Render/DefaultComponents/BoolRenderer.razor
@@ -2,21 +2,32 @@
 @inherits BaseRenderer
 
 <div style="margin-top:auto;margin-bottom: auto; @(IsReadonly ? "pointer-events:none;" : "")">
-    <input type="checkbox" disabled="@(Cell.Format?.IsReadOnly == true || IsReadonly)" @bind="Checked"/>
+    @* the key forces the input to be re-created when a change is rejected, so the checkbox
+       always shows the model value rather than what the user clicked. *@
+    <input @key="_renderKey"
+           type="checkbox"
+           disabled="@(!CanEdit)"
+           checked="@_checked"
+           @onchange="OnCheckedChanged"/>
 </div>
 
 @code {
 
     private bool _checked;
+    private int _renderKey;
 
-    public bool Checked
+    private bool CanEdit => !IsReadonly && Cell.Format?.IsReadOnly != true &&
+                            Sheet.Protection.CanEdit(Cell.Row, Cell.Col);
+
+    private void OnCheckedChanged(ChangeEventArgs args)
     {
-        get { return _checked; }
-        set
-        {
+        var value = args.Value as bool? ??
+                    (bool.TryParse(args.Value?.ToString(), out var parsedValue) && parsedValue);
+
+        if (CanEdit && Sheet.Cells.SetValue(Cell.Row, Cell.Col, value))
             _checked = value;
-            this.Sheet.Cells.SetValue(Cell.Row, Cell.Col, _checked);
-        }
+        else
+            _renderKey++; // rejected - re-render the checkbox from the model value
     }
 
     protected override void OnParametersSet()

--- a/src/BlazorDatasheet/Render/Headings/ColumnHeadingRenderer.razor
+++ b/src/BlazorDatasheet/Render/Headings/ColumnHeadingRenderer.razor
@@ -221,6 +221,8 @@
                 </div>
             </div>
 
+            @if (_sheet.Protection.Can(BlazorDatasheet.Core.Protection.SheetOperation.FormatColumns))
+            {
             <div class="bds-unselectable"
                  @onmousedown="GetResizerMouseDownHandler(col)"
                  style="position: absolute;
@@ -233,6 +235,7 @@
                  display: inline-block;
                  cursor: col-resize;">
             </div>
+            }
         </div>;
 
     [Parameter] public bool ShowColumnMenu { get; set; }
@@ -338,6 +341,8 @@
 
     private void HandleMouseDownOnResizer(int col)
     {
+        if (!_sheet.Protection.Can(BlazorDatasheet.Core.Protection.SheetOperation.FormatColumns))
+            return;
         MouseXStart = MouseX;
         ActiveResizerIndex = col;
         CurrentColResizeAmount = 0;

--- a/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
+++ b/src/BlazorDatasheet/Render/Headings/HeadingRenderer.razor.cs
@@ -75,6 +75,7 @@ public partial class HeadingRenderer : SheetComponentBase, IDisposable
         sheet.Columns.HeadingsModified -= HandleHeadingsModified;
         sheet.Rows.GroupsModified -= HandleGroupsModified;
         sheet.Columns.GroupsModified -= HandleGroupsModified;
+        sheet.Protection.Changed -= HandleProtectionChanged;
         sheet.FrozenRowCols -= HandleFrozenRowCols;
     }
 
@@ -92,6 +93,7 @@ public partial class HeadingRenderer : SheetComponentBase, IDisposable
         sheet.Columns.HeadingsModified += HandleHeadingsModified;
         sheet.Rows.GroupsModified += HandleGroupsModified;
         sheet.Columns.GroupsModified += HandleGroupsModified;
+        sheet.Protection.Changed += HandleProtectionChanged;
         sheet.FrozenRowCols += HandleFrozenRowCols;
     }
 
@@ -111,6 +113,12 @@ public partial class HeadingRenderer : SheetComponentBase, IDisposable
 
         _dirty = true;
         StateHasChanged();
+    }
+
+    private void HandleProtectionChanged(object? sender, EventArgs e)
+    {
+        _dirty = true;
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void HandleFrozenRowCols(object? sender, SheetFrozenRowColsEventArgs e)

--- a/src/BlazorDatasheet/Render/Layers/AutofillLayer.razor
+++ b/src/BlazorDatasheet/Render/Layers/AutofillLayer.razor
@@ -19,7 +19,7 @@
 <div @ref="_originElement"
      style="position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;"></div>
 
-@if (!Sheet.Editor.IsEditing && Sheet.Selection.ActiveRegion != null && ViewRegion?.Contains(Sheet.Selection.ActiveRegion.BottomRight) == true)
+@if (!Sheet.Editor.IsEditing && Sheet.Selection.ActiveRegion != null && Sheet.Protection.CanEdit(Sheet.Selection.ActiveRegion) && ViewRegion?.Contains(Sheet.Selection.ActiveRegion.BottomRight) == true)
 {
     <!-- render dragger (bottom right corner) -->
     <div id="auto-filler"
@@ -48,9 +48,18 @@
 
     protected override void OnSheetChange(Sheet newSheet, Sheet oldSheet)
     {
+        oldSheet.Protection.Changed -= ProtectionChanged;
+        newSheet.Protection.Changed += ProtectionChanged;
         oldSheet.Selection.SelectionChanged -= OnSelectionChanged;
         newSheet.Selection.SelectionChanged += OnSelectionChanged;
         _cellLayoutProvider = new CellLayoutProvider(newSheet);
+    }
+
+    private void ProtectionChanged(object? sender, EventArgs args)
+    {
+        RemovePreviewItem();
+        _dragPreviewRegion = null;
+        _ = InvokeAsync(StateHasChanged);
     }
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs args)
@@ -258,6 +267,7 @@
     public async ValueTask DisposeAsync()
     {
         _isDisposed = true;
+        Sheet.Protection.Changed -= ProtectionChanged;
         RemovePreviewItem();
         Sheet.Selection.SelectionChanged -= OnSelectionChanged;
 

--- a/src/BlazorDatasheet/SelectionMenu.razor
+++ b/src/BlazorDatasheet/SelectionMenu.razor
@@ -1,3 +1,4 @@
+@using BlazorDatasheet.Core.Protection
 @using BlazorDatasheet.Core.Commands.Data
 @using BlazorDatasheet.Core.Data
 @using BlazorDatasheet.Core.Data.Filter
@@ -22,19 +23,19 @@
         <MenuSection SectionId="0">
             @if (MenuOptions.ClearEnabled)
             {
-                <SheetMenuItem OnClick="() => sheet.Cells.ClearCells(sheet.Selection.Regions)">Clear</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@(new ClearCellsCommand(sheet.Selection.Regions).CanExecute(sheet))" OnClick="() => sheet.Cells.ClearCells(sheet.Selection.Regions)">Clear</SheetMenuItem>
             }
             @if (MenuOptions.MergeEnabled && !sheet.Selection.ActiveRegion.IsSingleCell())
             {
-                <SheetMenuItem OnClick="() => sheet.Cells.Merge(sheet.Selection.Regions)">Merge</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.Configure)" OnClick="() => sheet.Cells.Merge(sheet.Selection.Regions)">Merge</SheetMenuItem>
             }
             @if (MenuOptions.MergeEnabled && sheet.Cells.AnyMerges(sheet.Selection.ActiveRegion))
             {
-                <SheetMenuItem OnClick="() => sheet.Cells.UnMerge(sheet.Selection.Regions)">Un-merge</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.Configure)" OnClick="() => sheet.Cells.UnMerge(sheet.Selection.Regions)">Un-merge</SheetMenuItem>
             }
             @if (MenuOptions.AlignmentEnabled)
             {
-                <SheetSubMenu Label="Horiz. Alignment ">
+                <SheetSubMenu IsEnabled="@sheet.Selection.Regions.All(sheet.Protection.CanFormat)" Label="Horiz. Alignment ">
                     <SheetMenuItem
                         OnClick="@(() => sheet.SetFormat(sheet.Selection.Regions, new CellFormat() { HorizontalTextAlign = TextAlign.Start }))">
                         Left
@@ -48,7 +49,7 @@
                         Right
                     </SheetMenuItem>
                 </SheetSubMenu>
-                <SheetSubMenu Label="Vert. Alignment">
+                <SheetSubMenu IsEnabled="@sheet.Selection.Regions.All(sheet.Protection.CanFormat)" Label="Vert. Alignment">
                     <SheetMenuItem
                         OnClick="@(() => sheet.SetFormat(sheet.Selection.Regions, new CellFormat() { VerticalTextAlign = TextAlign.Start }))">
                         Top
@@ -76,20 +77,20 @@
 
             @if (MenuOptions.InsertColsEnabled)
             {
-                <SheetMenuItem OnClick="() => sheet.Columns.InsertAt(c.Left, c.Width)">Insert column(s) left
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.InsertColumns)" OnClick="() => sheet.Columns.InsertAt(c.Left, c.Width)">Insert column(s) left
                 </SheetMenuItem>
             }
 
             @if (MenuOptions.DeleteColsEnabled)
             {
-                <SheetMenuItem OnClick="() => sheet.Columns.RemoveAt(c.Left, c.Width)">Delete column(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.DeleteColumns, c)" OnClick="() => sheet.Columns.RemoveAt(c.Left, c.Width)">Delete column(s)</SheetMenuItem>
             }
 
             @if (MenuOptions.HideColsEnabled)
             {
                 <SheetMenuDivider/>
-                <SheetMenuItem OnClick="() => sheet.Columns.Hide(c.Left, c.Width)">Hide column(s)</SheetMenuItem>
-                <SheetMenuItem OnClick="() => sheet.Columns.Unhide(c.Left, c.Width)">Un-hide column(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.FormatColumns)" OnClick="() => sheet.Columns.Hide(c.Left, c.Width)">Hide column(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.FormatColumns)" OnClick="() => sheet.Columns.Unhide(c.Left, c.Width)">Un-hide column(s)</SheetMenuItem>
             }
         }
 
@@ -102,26 +103,26 @@
 
             @if (MenuOptions.InsertRowsEnabled)
             {
-                <SheetMenuItem OnClick="() => sheet.Rows.InsertAt(r.Top, r.Height)">Insert row(s) above</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.InsertRows)" OnClick="() => sheet.Rows.InsertAt(r.Top, r.Height)">Insert row(s) above</SheetMenuItem>
             }
 
             @if (MenuOptions.DeleteRowsEnabled)
             {
-                <SheetMenuItem OnClick="() => sheet.Rows.RemoveAt(r.Top, r.Height)">Delete row(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.DeleteRows, r)" OnClick="() => sheet.Rows.RemoveAt(r.Top, r.Height)">Delete row(s)</SheetMenuItem>
             }
 
             @if (MenuOptions.HideRowsEnabled)
             {
                 <SheetMenuDivider/>
-                <SheetMenuItem OnClick="() => sheet.Rows.Hide(r.Top, r.Height)">Hide row(s)</SheetMenuItem>
-                <SheetMenuItem OnClick="() => sheet.Rows.Unhide(r.Top, r.Height)">Un-hide row(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.FormatRows)" OnClick="() => sheet.Rows.Hide(r.Top, r.Height)">Hide row(s)</SheetMenuItem>
+                <SheetMenuItem IsEnabled="@sheet.Protection.Can(SheetOperation.FormatRows)" OnClick="() => sheet.Rows.Unhide(r.Top, r.Height)">Un-hide row(s)</SheetMenuItem>
             }
         }
 
         @if (MenuOptions.SortRangeEnabled && sheet.Selection.ActiveRegion!.Height > 1)
         {
             <SheetMenuDivider/>
-            <SheetSubMenu Label="Sort">
+            <SheetSubMenu IsEnabled="@sheet.Protection.Can(SheetOperation.Sort, sheet.Selection.ActiveRegion)" Label="Sort">
                 <SheetMenuItem OnClick="() => sheet.SortRange(sheet.Selection.ActiveRegion)">Sort Ascending
                 </SheetMenuItem>
                 <SheetMenuItem
@@ -136,7 +137,7 @@
              sheet.Selection.ActiveRegion is ColumnRegion colRegion &&
              colRegion.Width == 1)
         {
-            <SheetSubMenu Label="Filter" @ref="_filterSubMenu" DisabledOnReadOnly="false">
+            <SheetSubMenu IsEnabled="@sheet.Protection.Can(SheetOperation.Filter)" Label="Filter" @ref="_filterSubMenu" DisabledOnReadOnly="false">
                 <div class="bds-sheet-menu-panel bds-filter-panel">
                     <div class="bds-filter-panel-head">
                         <span class="bds-filter-panel-title">Filters</span>

--- a/test/BlazorDatasheet.Test/Commands/AutofillCommandTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/AutofillCommandTests.cs
@@ -1,3 +1,4 @@
+using BlazorDatasheet.Core.Commands;
 using BlazorDatasheet.Core.Commands.Data;
 using BlazorDatasheet.Core.Data;
 using BlazorDatasheet.Core.Events.Data;
@@ -174,5 +175,19 @@ public class AutofillCommandTests
         sheet.Cells["B2"]!.Format = new CellFormat() { IsReadOnly = true };
         sheet.Commands.ExecuteCommand(new AutoFillCommand(new Region(0, 5, 1, 1), new Region(0, 1)));
         sheet.Cells["B2"]!.Value.Should().Be("Not Empty");
+    }
+
+    [Test]
+    public void Autofill_In_A_Group_Fills_From_Values_Written_Earlier_In_The_Group()
+    {
+        var sheet = new Sheet(10, 10);
+        var group = new CommandGroup(
+            new SetCellValueCommand(0, 0, new CellValue(1)),
+            new SetCellValueCommand(1, 0, new CellValue(2)),
+            new AutoFillCommand(new Region(0, 1, 0, 0), new Region(0, 3, 0, 0)));
+
+        sheet.Commands.ExecuteCommand(group).Should().BeTrue();
+        sheet.Cells[2, 0].Value.Should().Be(3);
+        sheet.Cells[3, 0].Value.Should().Be(4);
     }
 }

--- a/test/BlazorDatasheet.Test/Commands/CommandManagerTests.cs
+++ b/test/BlazorDatasheet.Test/Commands/CommandManagerTests.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BlazorDatasheet.Core.Commands;
 using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Events.Commands;
 using BlazorDatasheet.DataStructures.Geometry;
 using FluentAssertions;
 using NUnit.Framework;
@@ -217,6 +219,44 @@ public class CommandManagerTests
     }
 
     [Test]
+    public void New_Command_Run_From_A_Handler_During_Redo_Clears_The_Redo_Stack()
+    {
+        _sheet.Cells.SetValue(0, 0, 1);
+        _sheet.Cells.SetValue(1, 0, 2);
+        _sheet.Commands.Undo();
+        _sheet.Commands.Undo();
+        _sheet.Commands.GetRedoCommands().Should().HaveCount(2);
+
+        EventHandler<CommandRunEventArgs>? handler = null;
+        handler = (_, _) =>
+        {
+            _sheet.Commands.CommandRun -= handler;
+            _sheet.Cells.SetValue(4, 4, "a new change");
+        };
+        _sheet.Commands.CommandRun += handler;
+
+        _sheet.Commands.Redo();
+        // the change made from the handler invalidates anything left on the redo stack
+        _sheet.Commands.GetRedoCommands().Should().BeEmpty();
+    }
+
+    [Test]
+    public void Redo_That_Cannot_Run_Is_Removed_From_The_Redo_Stack()
+    {
+        _sheet.Cells.SetValue(0, 0, 1);
+        _sheet.Commands.Undo();
+        _sheet.Commands.GetRedoCommands().Should().HaveCount(1);
+
+        void Cancel(object? sender, BeforeCommandRunEventArgs args) => args.Cancel = true;
+        _sheet.Commands.BeforeCommandRun += Cancel;
+        _sheet.Commands.Redo().Should().BeFalse();
+        _sheet.Commands.BeforeCommandRun -= Cancel;
+
+        _sheet.Commands.GetRedoCommands().Should().BeEmpty();
+        _sheet.Commands.Redo().Should().BeFalse();
+    }
+
+    [Test]
     public void Command_Not_Executed_Fires_Event()
     {
         var notExecutedCount = 0;
@@ -239,13 +279,13 @@ public class FakeCommand : BaseCommand, IUndoableCommand
         _canExecute = canExecute;
     }
 
-    public override bool Execute(Sheet sheet)
+    protected override bool ExecuteCore(Sheet sheet)
     {
         _cmdExecutions.Add(Id);
         return true;
     }
 
-    public override bool CanExecute(Sheet sheet) => _canExecute;
+    protected override bool CanExecuteCore(Sheet sheet) => _canExecute;
 
     public bool Undo(Sheet sheet)
     {

--- a/test/BlazorDatasheet.Test/Edit/EditTests.cs
+++ b/test/BlazorDatasheet.Test/Edit/EditTests.cs
@@ -113,4 +113,21 @@ public class EditTests
         sheet.Editor.AcceptEdit();
         sheet.Cells.GetCell(1, 1).CellValue.ValueType.Should().Be(CellValueType.Empty);
     }
+
+    [Test]
+    public void Accept_Edit_Closes_Edit_When_The_Value_Command_Is_Rejected()
+    {
+        var sheet = new Sheet(10, 10);
+        sheet.Commands.BeforeCommandRun += (_, args) => args.Cancel = true;
+        var editFinishedCount = 0;
+        sheet.Editor.EditFinished += (_, _) => editFinishedCount++;
+
+        sheet.Editor.BeginEdit(1, 1);
+        sheet.Editor.EditValue = "new value";
+        sheet.Editor.AcceptEdit().Should().BeFalse();
+
+        sheet.Editor.IsEditing.Should().BeFalse();
+        editFinishedCount.Should().Be(1);
+        sheet.Cells[1, 1].Value.Should().BeNull();
+    }
 }

--- a/test/BlazorDatasheet.Test/Render/SimpleRenderTests.razor
+++ b/test/BlazorDatasheet.Test/Render/SimpleRenderTests.razor
@@ -1,4 +1,4 @@
-﻿@using AngleSharp.Css.Dom
+@using AngleSharp.Css.Dom
 @using BlazorDatasheet.Core.Data
 @using BlazorDatasheet.Core.Events.Selection
 @using BlazorDatasheet.KeyboardInput
@@ -69,6 +69,51 @@
 
         calls.Should().Be(1);
         sheet.Selection.ActiveRegion.Should().BeEquivalentTo(cancel ? (IRegion)new Region(0, 0) : new ColumnRegion(2));
+    }
+
+    [Test]
+    public async Task Protection_Changes_Refresh_Boolean_And_Autofill_Controls()
+    {
+        var sheet = new Sheet(4, 4);
+        sheet.Cells.SetValue(0, 0, true);
+        sheet.Cells[0, 0].Type = "boolean";
+        sheet.Selection.Set(new Region(0, 0));
+        var cut = RenderComponent<Datasheet>(parameters => parameters
+            .Add(p => p.Sheet, sheet).Add(p => p.UseAutoFill, true));
+        await cut.InvokeAsync(() =>
+        {
+            cut.Instance.ForceReRender();
+            sheet.Cells.SetValue(0, 0, true);
+        });
+        cut.Find("input[type=checkbox]").HasAttribute("disabled").Should().BeFalse();
+        cut.FindAll("#auto-filler").Should().NotBeEmpty();
+        await cut.InvokeAsync(() => sheet.Protection.Protect());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("input[type=checkbox]").HasAttribute("disabled").Should().BeTrue();
+            cut.FindAll("#auto-filler").Should().BeEmpty();
+        });
+        await cut.InvokeAsync(() => sheet.Protection.Unprotect());
+        cut.WaitForAssertion(() =>
+        {
+            cut.Find("input[type=checkbox]").HasAttribute("disabled").Should().BeFalse();
+            cut.FindAll("#auto-filler").Should().NotBeEmpty();
+        });
+    }
+
+    [Test]
+    public async Task Protection_Cancels_An_Open_Locked_Editor_And_Blocks_Delete()
+    {
+        var sheet = new Sheet(4, 4);
+        sheet.Cells.SetValue(0, 0, "original");
+        sheet.Selection.Set(new Region(0, 0));
+        var cut = RenderComponent<Datasheet>(parameters => parameters.Add(p => p.Sheet, sheet));
+        await cut.InvokeAsync(() => sheet.Editor.BeginEdit(0, 0));
+        sheet.Editor.IsEditing.Should().BeTrue();
+        await cut.InvokeAsync(() => sheet.Protection.Protect());
+        sheet.Editor.IsEditing.Should().BeFalse();
+        await cut.InvokeAsync(() => cut.Instance.HandleShortcuts("Delete", KeyboardModifiers.None));
+        sheet.Cells[0, 0].Value.Should().Be("original");
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/SheetTests/DirtyRegionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/DirtyRegionTests.cs
@@ -113,15 +113,15 @@ public class DirtyRegionTests
 
     private sealed class ThrowingUndoCommand : BaseCommand, IUndoableCommand
     {
-        public override bool CanExecute(Sheet sheet) => true;
-        public override bool Execute(Sheet sheet) => true;
+        protected override bool CanExecuteCore(Sheet sheet) => true;
+        protected override bool ExecuteCore(Sheet sheet) => true;
         public bool Undo(Sheet sheet) => throw new InvalidOperationException();
     }
 
     private sealed class FailingCommand(bool throws) : BaseCommand
     {
-        public override bool CanExecute(Sheet sheet) => true;
-        public override bool Execute(Sheet sheet) => throws ? throw new InvalidOperationException() : false;
+        protected override bool CanExecuteCore(Sheet sheet) => true;
+        protected override bool ExecuteCore(Sheet sheet) => throws ? throw new InvalidOperationException() : false;
     }
 
     [Test]

--- a/test/BlazorDatasheet.Test/SheetTests/SelectionProtectionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SelectionProtectionTests.cs
@@ -1,0 +1,278 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Formats;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Render;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.SheetTests;
+
+public class SelectionProtectionTests
+{
+    private Sheet _sheet = null!;
+    private SelectionInputManager _manager = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _sheet = new Sheet(10, 10);
+        _manager = new SelectionInputManager(_sheet.Selection);
+    }
+
+    private void Unlock(IRegion region) => _sheet.SetFormat(region, new CellFormat { IsLocked = false });
+
+    private void Lock(IRegion region) => _sheet.SetFormat(region, new CellFormat { IsLocked = true });
+
+    private void ProtectRestricted() =>
+        _sheet.Protection.Protect(new SheetProtectionOptions { AllowSelectLockedCells = false });
+
+    private void Click(int row, int col, bool ctrl = false, bool shift = false)
+    {
+        _manager.HandlePointerDown(row, col, shift, ctrl, false, 0);
+        _manager.HandleWindowMouseUp();
+    }
+
+    [Test]
+    public void Locked_Cells_Are_Selectable_By_Default()
+    {
+        new SheetProtectionOptions().AllowSelectLockedCells.Should().BeTrue();
+        _sheet.Protection.Protect();
+        _sheet.Protection.Can(SheetOperation.SelectLockedCells).Should().BeTrue();
+        _sheet.Protection.CanSelect(new Region(3, 3)).Should().BeTrue();
+
+        Click(3, 3);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(3, 3));
+
+        ProtectRestricted();
+        _sheet.Protection.Can(SheetOperation.SelectLockedCells).Should().BeFalse();
+        _sheet.Protection.CanSelect(new Region(3, 3)).Should().BeFalse();
+    }
+
+    [Test]
+    public void Click_On_Locked_Cell_Is_Rejected_Without_Notifications()
+    {
+        Unlock(new Region(0, 0));
+        ProtectRestricted();
+        _sheet.Selection.Set(0, 0);
+
+        var notifications = 0;
+        _sheet.Selection.SelectionChanged += (_, _) => notifications++;
+        _sheet.Selection.SelectingChanged += (_, _) => notifications++;
+        _sheet.Selection.ActiveCellPositionChanged += (_, _) => notifications++;
+        _sheet.Selection.ActiveRegionChanged += (_, _) => notifications++;
+
+        Click(3, 3);
+        Click(3, 3, ctrl: true);
+
+        notifications.Should().Be(0);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(0, 0));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(0, 0));
+        _sheet.Selection.IsSelecting.Should().BeFalse();
+    }
+
+    [Test]
+    public void Drag_Stops_At_Locked_Cells_And_Resumes_From_Last_Accepted_Preview()
+    {
+        Unlock(new Region(0, 3, 0, 3));
+        ProtectRestricted();
+
+        _manager.HandlePointerDown(1, 1, false, false, false, 0);
+        _manager.HandlePointerOver(2, 2);
+        _sheet.Selection.SelectingRegion.Should().BeEquivalentTo(new Region(1, 2, 1, 2));
+
+        _manager.HandlePointerOver(2, 5);
+        _sheet.Selection.SelectingRegion.Should().BeEquivalentTo(new Region(1, 2, 1, 2));
+
+        _manager.HandlePointerOver(3, 3);
+        _manager.HandleWindowMouseUp();
+
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(1, 3, 1, 3));
+        _sheet.Selection.IsSelecting.Should().BeFalse();
+    }
+
+    [Test]
+    public void Shift_Extension_Into_Locked_Cells_Is_Rejected()
+    {
+        Unlock(new Region(0, 3, 0, 3));
+        ProtectRestricted();
+        _sheet.Selection.Set(1, 1);
+
+        _manager.HandleArrowKeyDown(true, new Offset(0, 1));
+        _manager.HandleArrowKeyDown(true, new Offset(0, 1));
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(1, 1, 1, 3));
+
+        _manager.HandleArrowKeyDown(true, new Offset(0, 1));
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(1, 1, 1, 3));
+
+        Click(5, 5, shift: true);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(1, 1, 1, 3));
+    }
+
+    [Test]
+    public void Arrow_Navigation_Skips_Over_Locked_Cells()
+    {
+        Unlock(new Region(0, 0));
+        Unlock(new Region(0, 3));
+        ProtectRestricted();
+        _sheet.Selection.Set(0, 0);
+
+        _manager.HandleArrowKeyDown(false, new Offset(0, 1));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(0, 3));
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(0, 3));
+
+        // nothing unlocked remains to the right, so the selection stays put
+        _manager.HandleArrowKeyDown(false, new Offset(0, 1));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(0, 3));
+
+        _manager.HandleArrowKeyDown(false, new Offset(0, -1));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(0, 0));
+    }
+
+    [Test]
+    public void Tab_Navigation_Skips_Locked_Cells_And_Cycles_Regions()
+    {
+        Unlock(new Region(0, 0));
+        Unlock(new Region(2, 2));
+        ProtectRestricted();
+        _sheet.Selection.Set(new List<IRegion> { new Region(0, 0, 0, 1), new Region(2, 2) });
+        _sheet.Selection.Activate(0, 0);
+
+        _manager.HandleTabEnterNavigation(Axis.Col, 1);
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(2, 2));
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(2, 2));
+    }
+
+    [Test]
+    public void Navigation_Over_Entirely_Locked_Regions_Is_A_No_Op()
+    {
+        Unlock(new Region(9, 9));
+        ProtectRestricted();
+        _sheet.Selection.Set(new List<IRegion> { new Region(5, 5), new Region(6, 6) });
+        _sheet.Selection.Activate(5, 5);
+
+        var notifications = 0;
+        _sheet.Selection.SelectionChanged += (_, _) => notifications++;
+        _sheet.Selection.ActiveCellPositionChanged += (_, _) => notifications++;
+        _sheet.Selection.ActiveRegionChanged += (_, _) => notifications++;
+
+        _manager.HandleTabEnterNavigation(Axis.Col, 1);
+        _manager.HandleTabEnterNavigation(Axis.Row, 1);
+
+        notifications.Should().Be(0);
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(5, 5));
+        _sheet.Selection.Regions.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void Header_Selection_Requires_The_Whole_Row_Or_Column_To_Be_Unlocked()
+    {
+        Unlock(new ColumnRegion(2));
+        Unlock(new Region(4, 4, 0, 9));
+        ProtectRestricted();
+        _sheet.Selection.Set(new ColumnRegion(2));
+
+        Click(-1, 3);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new ColumnRegion(2, 2));
+
+        Click(3, -1);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new ColumnRegion(2, 2));
+
+        Click(4, -1);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new RowRegion(4, 4));
+
+        Click(-1, 2);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new ColumnRegion(2, 2));
+    }
+
+    [Test]
+    public void Consumer_Replacement_Containing_Locked_Cells_Is_Rejected()
+    {
+        Unlock(new Region(0, 0));
+        ProtectRestricted();
+        _sheet.Selection.Set(0, 0);
+        _sheet.BeforeSelectionInput += (_, e) =>
+        {
+            e.ProposedRegions = new IRegion[] { new Region(7, 8, 7, 8) };
+            e.ProposedActiveRegionIndex = 0;
+            e.ProposedActiveCellPosition = new CellPosition(7, 7);
+        };
+
+        Click(0, 0);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(0, 0));
+    }
+
+    [Test]
+    public void Protecting_Moves_The_Selection_To_The_First_Unlocked_Cell()
+    {
+        Unlock(new Region(4, 4));
+        _sheet.Selection.Set(0, 0);
+        ProtectRestricted();
+
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(4, 4));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(4, 4));
+
+        _sheet.Protection.Unprotect();
+        Click(1, 1);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(1, 1));
+    }
+
+    [Test]
+    public void Protecting_Clears_The_Selection_When_Nothing_Is_Unlocked()
+    {
+        _sheet.Selection.Set(0, 0);
+        _sheet.Selection.BeginSelectingCell(1, 1);
+        ProtectRestricted();
+
+        _sheet.Selection.IsEmpty().Should().BeTrue();
+        _sheet.Selection.IsSelecting.Should().BeFalse();
+    }
+
+    [Test]
+    public void First_Unlocked_Cell_Is_Row_Major_Across_Cell_Column_And_Row_Formats()
+    {
+        _sheet.SetFormat(new RowRegion(1), new CellFormat { IsLocked = false });
+        Lock(new Region(1, 1, 0, 4));
+        Unlock(new Region(3, 3, 2, 2));
+        _sheet.Selection.Set(0, 0);
+        ProtectRestricted();
+
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(1, 5));
+    }
+
+    [Test]
+    public void Locks_Changed_In_A_Trusted_Update_Relocate_The_Selection()
+    {
+        Unlock(new Region(0, 0));
+        Unlock(new Region(5, 5));
+        _sheet.Selection.Set(0, 0);
+        ProtectRestricted();
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(0, 0));
+
+        _sheet.Protection.RunUnprotected(() => Lock(new Region(0, 0)));
+
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(5, 5));
+        _sheet.Selection.ActiveCellPosition.Should().Be(new CellPosition(5, 5));
+    }
+
+    [Test]
+    public void Merged_Cells_Must_Be_Entirely_Unlocked_To_Be_Selected()
+    {
+        _sheet.Cells.Merge(new Region(2, 3, 2, 3));
+        Unlock(new Region(2, 2));
+        Unlock(new Region(8, 8));
+        ProtectRestricted();
+        _sheet.Selection.Set(8, 8);
+
+        Click(2, 2);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(8, 8));
+
+        _sheet.Protection.RunUnprotected(() => Unlock(new Region(2, 3, 2, 3)));
+        _sheet.Selection.Set(8, 8);
+
+        Click(2, 2);
+        _sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(2, 3, 2, 3));
+    }
+}

--- a/test/BlazorDatasheet.Test/SheetTests/SheetProtectionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SheetProtectionTests.cs
@@ -305,11 +305,12 @@ public class SheetProtectionTests
     {
         var sheet = UnlockedSheet();
         sheet.Cells.SetValue(0, 0, 3);
-        sheet.Protection.Protect(new() { AllowFilter = true });
+        sheet.Protection.Protect(new() { AllowFilter = true, AllowSelectLockedCells = false });
         var json = new BlazorDatasheet.Core.Serialization.Json.SheetJsonSerializer().Serialize(sheet.Workbook);
         var restored = new BlazorDatasheet.Core.Serialization.Json.SheetJsonDeserializer().Deserialize(json).Sheets.First();
         restored.Protection.IsProtected.Should().BeTrue();
         restored.Protection.Options.AllowFilter.Should().BeTrue();
+        restored.Protection.Options.AllowSelectLockedCells.Should().BeFalse();
         restored.Protection.CanEdit(0, 0).Should().BeTrue();
         restored.Cells[0, 0].Value.Should().Be(3);
     }

--- a/test/BlazorDatasheet.Test/SheetTests/SheetProtectionTests.cs
+++ b/test/BlazorDatasheet.Test/SheetTests/SheetProtectionTests.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Linq;
+using BlazorDatasheet.Core.Commands;
+using BlazorDatasheet.Core.Commands.Data;
+using BlazorDatasheet.Core.Commands.Formatting;
+using BlazorDatasheet.Core.Commands.RowCols;
+using BlazorDatasheet.Core.Data;
+using BlazorDatasheet.Core.Data.Filter;
+using BlazorDatasheet.Core.Events.Commands;
+using BlazorDatasheet.Core.Formats;
+using BlazorDatasheet.Core.Protection;
+using BlazorDatasheet.DataStructures.Geometry;
+using BlazorDatasheet.Formula.Core;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BlazorDatasheet.Test.SheetTests;
+
+public class SheetProtectionTests
+{
+    private static Sheet UnlockedSheet()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.SetFormat(sheet.Region, new CellFormat { IsLocked = false });
+        return sheet;
+    }
+
+    [Test]
+    public void Default_Locks_Only_Apply_When_Protected()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Protection.IsLocked(0, 0).Should().BeTrue();
+        sheet.Cells.SetValue(0, 0, 1).Should().BeTrue();
+        sheet.Protection.Protect();
+        var rejected = 0;
+        sheet.Commands.CommandNotExecuted += (_, _) => rejected++;
+        sheet.Cells.SetValue(0, 0, 2).Should().BeFalse();
+        new SetCellValueCommand(0, 0, new CellValue(2)).CanExecute(sheet).Should().BeFalse();
+        sheet.Cells.SetFormula(0, 0, "=2+3");
+        sheet.Cells[0, 0].Value.Should().Be(1);
+        rejected.Should().Be(2);
+        sheet.Protection.Unprotect();
+        sheet.Cells.SetValue(0, 0, 3).Should().BeTrue();
+    }
+
+    [Test]
+    public void Sparse_Lock_Resolution_Uses_Cell_Column_Row_Precedence()
+    {
+        var sheet = new Sheet(1_000_000, 1000);
+        sheet.SetFormat(new RowRegion(0, 999_999), new CellFormat { IsLocked = false });
+        sheet.SetFormat(new ColumnRegion(2), new CellFormat { IsLocked = true });
+        sheet.SetFormat(new ColumnRegion(2), new CellFormat { IsLocked = false });
+        sheet.SetFormat(new Region(42, 2), new CellFormat { IsLocked = true });
+        sheet.Protection.Protect();
+        sheet.Protection.CanEdit(new Region(0, 999_999, 3, 999)).Should().BeTrue();
+        sheet.Protection.CanEdit(sheet.Region).Should().BeFalse();
+        sheet.Protection.IsLocked(42, 2).Should().BeTrue();
+        sheet.Protection.IsLocked(43, 2).Should().BeFalse();
+    }
+
+    [Test]
+    public void Merged_Cell_Requires_Entire_Merge_To_Be_Unlocked()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Cells.Merge(new Region(0, 1, 0, 1));
+        sheet.SetFormat(new Region(0, 0), new CellFormat { IsLocked = false });
+        sheet.Protection.Protect();
+        sheet.Protection.CanEdit(0, 0).Should().BeFalse();
+        sheet.Protection.RunUnprotected(() => sheet.SetFormat(new Region(0, 1, 0, 1), new CellFormat { IsLocked = false }));
+        sheet.Cells.SetValue(0, 0, "merged").Should().BeTrue();
+    }
+
+    [Test]
+    public void Bulk_Paste_Clear_And_Command_Chains_Reject_Before_Mutation()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.SetFormat(new Region(0, 0), new CellFormat { IsLocked = false });
+        sheet.Cells.SetValue(0, 0, "original");
+        sheet.Selection.Set(new Region(2, 2));
+        sheet.Protection.Protect();
+        sheet.Cells.SetValues(0, 0, new object[][] { new object[] { 1, 2 } }).Should().BeFalse();
+        sheet.InsertDelimitedText("1\t2", new CellPosition(0, 0)).Should().BeNull();
+        var denied = new SetCellValueCommand(0, 1, new CellValue(9));
+        denied.AttachBefore(new ClearCellsCommand(new Region(0, 0)));
+        sheet.Commands.ExecuteCommand(denied).Should().BeFalse();
+        sheet.Commands.ExecuteCommand(new ClearCellsCommand(new Region(0, 0, 0, 1))).Should().BeFalse();
+        sheet.Commands.ExecuteCommand(new CommandGroup(new ClearCellsCommand(new Region(0, 0)), denied)).Should().BeFalse();
+        sheet.Cells[0, 0].Value.Should().Be("original");
+        sheet.Selection.ActiveRegion.Should().BeEquivalentTo(new Region(2, 2));
+        sheet.Commands.GetUndoCommands().Should().BeEmpty();
+    }
+
+    [Test]
+    public void Jagged_Writes_Check_Only_Cells_Actually_Written()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.SetFormat(new Region(0, 0, 0, 1), new CellFormat { IsLocked = false });
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = false });
+        sheet.Protection.Protect();
+        sheet.Cells.SetValues(0, 0, new object[][] { new object[] { 1, 2 }, new object[] { 3 } }).Should().BeTrue();
+        sheet.Cells[1, 1].Value.Should().BeNull();
+    }
+
+    [Test]
+    public void Appearance_Changes_And_Copy_Preserve_Destination_Locks()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Cells.SetValue(0, 0, "source");
+        sheet.SetFormat(new Region(0, 0), new CellFormat { IsLocked = true, BackgroundColor = "red" });
+        sheet.SetFormat(new Region(0, 1), new CellFormat { IsLocked = false });
+        sheet.Protection.Protect(new() { AllowFormatCells = true });
+        sheet.Commands.ExecuteCommand(new CopyRangeCommand(sheet.Range(0, 0), sheet.Range(0, 1), new())).Should().BeTrue();
+        sheet.Cells[0, 1].Value.Should().Be("source");
+        sheet.Protection.IsLocked(0, 1).Should().BeFalse();
+        sheet.GetFormat(0, 1).BackgroundColor.Should().Be("red");
+        sheet.Commands.ExecuteCommand(new ClearFormatCommand(new Region(0, 1))).Should().BeTrue();
+        sheet.Protection.IsLocked(0, 1).Should().BeFalse();
+        sheet.GetFormat(0, 1).BackgroundColor.Should().BeNull();
+        sheet.Commands.ExecuteCommand(new SetFormatCommand(new Region(0, 1), new() { IsLocked = true })).Should().BeFalse();
+        sheet.Commands.ExecuteCommand(new SetFormatCommand(new Region(0, 1), new() { IsLocked = null })).Should().BeFalse();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.GetFormat(0, 1).BackgroundColor.Should().Be("red");
+        sheet.Protection.IsLocked(0, 1).Should().BeFalse();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Cells[0, 1].Value.Should().BeNull();
+        sheet.Protection.IsLocked(0, 1).Should().BeFalse();
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Cells[0, 1].Value.Should().Be("source");
+    }
+
+    [Test]
+    public void Copy_Checks_Source_Sized_Footprint_And_All_Destinations()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Cells.SetValues(0, 0, new object[][] { new object[] { 1, 2 } });
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = false });
+        sheet.Protection.Protect();
+        sheet.Commands.ExecuteCommand(new CopyRangeCommand(sheet.Range(new Region(0, 0, 0, 1)), sheet.Range(1, 0),
+            new CopyOptions { CopyFormat = false })).Should().BeFalse();
+        sheet.Commands.ExecuteCommand(new CopyRangeCommand(sheet.Range(0, 0), new[] { sheet.Range(1, 0), sheet.Range(2, 0) },
+            new CopyOptions { CopyFormat = false })).Should().BeFalse();
+        sheet.Cells[1, 0].Value.Should().BeNull();
+    }
+
+    [Test]
+    public void Autofill_Expansion_Shrink_And_Dynamic_Formatting_Are_Atomic()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Cells.SetValue(0, 0, "text");
+        sheet.Cells.SetValue(1, 0, "original");
+        sheet.SetFormat(new Region(0, 0), new CellFormat { BackgroundColor = "red" });
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = false });
+        sheet.Protection.Protect();
+        var fill = new AutoFillCommand(new Region(0, 0), new Region(0, 1, 0, 0));
+        // Text autofill copies formatting by default. Formatting isn't permitted here, so the
+        // fill degrades to a values-only copy rather than doing nothing.
+        sheet.Commands.ExecuteCommand(fill).Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("text");
+        sheet.GetFormat(1, 0).BackgroundColor.Should().BeNull();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("original");
+        sheet.Protection.Protect(new() { AllowFormatCells = true });
+        sheet.Commands.ExecuteCommand(fill).Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("text");
+        sheet.GetFormat(1, 0).BackgroundColor.Should().Be("red");
+        sheet.Protection.IsLocked(1, 0).Should().BeFalse();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("original");
+        // shrinking the fill clears the locked source cell, which is never permitted
+        sheet.Commands.ExecuteCommand(new AutoFillCommand(new Region(0, 1, 0, 0), new Region(1, 0))).Should().BeFalse();
+        sheet.Cells[0, 0].Value.Should().Be("text");
+    }
+
+    [Test]
+    public void Sorting_Requires_Permission_And_Unlocked_Data()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValues(0, 0, new object[][] { new object[] { 2 }, new object[] { 1 } });
+        var sort = new SortRangeCommand(new Region(0, 1, 0, 0));
+        sheet.Protection.Protect();
+        sheet.Commands.ExecuteCommand(sort).Should().BeFalse();
+        sheet.Protection.Protect(new() { AllowSort = true });
+        sheet.Commands.ExecuteCommand(sort).Should().BeTrue();
+        sheet.Cells[0, 0].Value.Should().Be(1);
+        sheet.Protection.RunUnprotected(() => sheet.SetFormat(new Region(1, 0), new() { IsLocked = true }));
+        sheet.Commands.ExecuteCommand(sort).Should().BeFalse();
+    }
+
+    [Test]
+    public void Row_Operations_Use_Independent_Permissions()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Protection.Protect(new() { AllowInsertRows = true, AllowDeleteRows = true, AllowFormatRows = true });
+        sheet.Rows.InsertAt(1);
+        sheet.NumRows.Should().Be(6);
+        sheet.Columns.InsertAt(1);
+        sheet.NumCols.Should().Be(5);
+        sheet.Commands.ExecuteCommand(new SetSizeCommand(0, 0, 40, Axis.Row)).Should().BeTrue();
+        sheet.Commands.ExecuteCommand(new HideCommand(0, 0, Axis.Col)).Should().BeFalse();
+        sheet.Rows.RemoveAt(0).Should().BeTrue();
+        sheet.Protection.RunUnprotected(() => sheet.SetFormat(new Region(0, 0), new() { IsLocked = true }));
+        sheet.Rows.RemoveAt(0).Should().BeFalse();
+        sheet.Columns.RemoveAt(0).Should().BeFalse();
+    }
+
+    [Test]
+    public void Protected_Formulas_Recalculate_And_Conditional_Formats_Cannot_Unlock()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.SetFormat(new Region(0, 0), new() { IsLocked = false });
+        sheet.Cells.SetValue(0, 0, 2);
+        sheet.Cells.SetFormula(0, 1, "=A1*2");
+        sheet.ConditionalFormats.Apply(new Region(0, 1), new ConditionalFormat((_, _) => true,
+            _ => new CellFormat { IsLocked = false }));
+        sheet.Protection.Protect();
+        sheet.Cells.SetValue(0, 0, 3).Should().BeTrue();
+        sheet.Cells[0, 1].Value.Should().Be(6);
+        sheet.Protection.CanEdit(0, 1).Should().BeFalse();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Cells[0, 1].Value.Should().Be(4);
+    }
+
+    [Test]
+    public void Protection_Changes_Clear_Both_Histories_And_Cancel_Locked_Edit()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Cells.SetValue(0, 0, 1);
+        sheet.Commands.Undo();
+        sheet.Editor.BeginEdit(0, 0);
+        sheet.Editor.IsEditing.Should().BeTrue();
+        sheet.Protection.Protect();
+        sheet.Editor.IsEditing.Should().BeFalse();
+        sheet.Commands.GetRedoCommands().Should().BeEmpty();
+        sheet.Commands.GetUndoCommands().Should().BeEmpty();
+        sheet.Protection.Unprotect();
+        sheet.Commands.Redo().Should().BeFalse();
+    }
+
+    [Test]
+    public void Nested_Trusted_Updates_Restore_Protection_After_Exception()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Protection.Protect();
+        Action update = () => sheet.Protection.RunUnprotected(() =>
+        {
+            sheet.Cells.SetValue(0, 0, 1).Should().BeTrue();
+            sheet.Protection.RunUnprotected(() => sheet.Cells.SetValue(0, 1, 2)).Should().BeTrue();
+            throw new InvalidOperationException("test");
+        });
+        update.Should().Throw<InvalidOperationException>();
+        sheet.Protection.IsProtected.Should().BeTrue();
+        sheet.Cells.SetValue(0, 0, 3).Should().BeFalse();
+        sheet.Commands.GetUndoCommands().Should().BeEmpty();
+        sheet.Commands.GetRedoCommands().Should().BeEmpty();
+    }
+
+    [Test]
+    public void Legacy_ReadOnly_Behavior_Is_Preserved()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.SetFormat(new Region(0, 0), new() { IsReadOnly = true, IsLocked = false });
+        sheet.Protection.Protect();
+        sheet.Cells.SetValue(0, 0, 1).Should().BeTrue();
+        sheet.Editor.BeginEdit(0, 0);
+        sheet.Editor.IsEditing.Should().BeFalse();
+        sheet.Protection.RunUnprotected(() => sheet.Commands.ExecuteCommand(new ClearCellsCommand(new Region(0, 0))))
+            .Should().BeFalse();
+    }
+
+    [Test]
+    public void Undeclared_Custom_Commands_Are_Rejected_While_Protected()
+    {
+        var sheet = new Sheet(5, 5);
+        var command = new CustomCommand();
+        sheet.Commands.ExecuteCommand(command).Should().BeTrue();
+        sheet.Protection.Protect();
+        sheet.Commands.ExecuteCommand(command).Should().BeFalse();
+        sheet.Protection.RunUnprotected(() => sheet.Commands.ExecuteCommand(command)).Should().BeTrue();
+    }
+
+    [Test]
+    public void Filtering_Locked_Data_Does_Not_Require_Row_Formatting()
+    {
+        var sheet = new Sheet(3, 1);
+        sheet.Cells.SetValue(0, 0, "apple");
+        sheet.Cells.SetValue(1, 0, "pear");
+        var filter = new PatternFilter(PatternFilterType.StartsWith, "a");
+        sheet.Protection.Protect();
+        sheet.Columns.Filters.Set(0, filter);
+        sheet.Rows.IsVisible(1).Should().BeTrue();
+        sheet.Protection.Protect(new() { AllowFilter = true });
+        sheet.Columns.Filters.Set(0, filter);
+        sheet.Rows.IsVisible(0).Should().BeTrue();
+        sheet.Rows.IsVisible(1).Should().BeFalse();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Rows.IsVisible(1).Should().BeTrue();
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Rows.IsVisible(1).Should().BeFalse();
+        sheet.Columns.Filters.Clear(0);
+        sheet.Rows.IsVisible(1).Should().BeTrue();
+    }
+
+    [Test]
+    public void Protection_And_Locks_Round_Trip_Through_Json()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, 3);
+        sheet.Protection.Protect(new() { AllowFilter = true });
+        var json = new BlazorDatasheet.Core.Serialization.Json.SheetJsonSerializer().Serialize(sheet.Workbook);
+        var restored = new BlazorDatasheet.Core.Serialization.Json.SheetJsonDeserializer().Deserialize(json).Sheets.First();
+        restored.Protection.IsProtected.Should().BeTrue();
+        restored.Protection.Options.AllowFilter.Should().BeTrue();
+        restored.Protection.CanEdit(0, 0).Should().BeTrue();
+        restored.Cells[0, 0].Value.Should().Be(3);
+    }
+
+    [Test]
+    public void Rejected_Dynamic_Autofill_Preserves_Redo_History()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, "text");
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = true });
+        sheet.Protection.Protect();
+        sheet.Cells.SetValue(2, 0, "later");
+        sheet.Commands.Undo();
+        var history = sheet.Commands.GetRedoCommands().ToArray();
+        sheet.Commands.ExecuteCommand(new AutoFillCommand(new Region(0, 0), new Region(0, 1, 0, 0))).Should().BeFalse();
+        sheet.Commands.GetRedoCommands().Should().Equal(history);
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Cells[2, 0].Value.Should().Be("later");
+    }
+
+    [Test]
+    public void Composite_Redo_Does_Not_Discard_Later_Redo_Entries()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Protection.Protect();
+        sheet.Commands.ExecuteCommand(new CommandGroup(
+            new SetCellValueCommand(0, 0, new CellValue(1)),
+            new SetCellValueCommand(0, 1, new CellValue(2))));
+        sheet.Cells.SetValue(0, 2, 3);
+        sheet.Commands.Undo();
+        sheet.Commands.Undo();
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Cells[0, 2].Value.Should().Be(3);
+    }
+
+    [Test]
+    public void All_Configuration_Changes_Are_Denied_While_Protected()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Range(0, 0).SetMetaData("key", "value");
+        var validator = new BlazorDatasheet.Core.Validation.NumberValidator(false);
+        sheet.Range(0, 0).AddValidator(validator);
+        sheet.Protection.Protect(new() { AllowFormatCells = true, AllowFormatRows = true, AllowFormatColumns = true });
+        sheet.Range(0, 0).ClearMetaData();
+        sheet.Cells.GetMetaData(0, 0, "key").Should().Be("value");
+        sheet.Validators.Clear(validator, new Region(0, 0));
+        sheet.Validators.Get(0, 0).Should().Contain(validator);
+        sheet.Range(1, 0).AddValidator(validator);
+        sheet.Validators.Get(1, 0).Should().BeEmpty();
+        sheet.Cells.Merge(new Region(0, 1, 0, 1));
+        sheet.Cells.AnyMerges().Should().BeFalse();
+        sheet.Cells.SetType(0, 0, "boolean");
+        sheet.Cells.GetCellType(0, 0).Should().NotBe("boolean");
+        sheet.Columns.SetGroup(0, 1, "blocked");
+        sheet.Commands.GetUndoCommands().Should().BeEmpty();
+        sheet.FreezeTopRows(1);
+        sheet.FreezeState.Top.Should().Be(1);
+    }
+
+    [Test]
+    public void Edit_Commit_Rechecks_Protection_After_User_Callback()
+    {
+        var sheet = new Sheet(5, 5);
+        sheet.Editor.BeginEdit(0, 0);
+        sheet.Editor.EditValue = "new";
+        sheet.Editor.BeforeEditAccepted += (_, _) => sheet.Protection.Protect();
+        sheet.Editor.AcceptEdit().Should().BeFalse();
+        sheet.Editor.IsEditing.Should().BeFalse();
+        sheet.Cells[0, 0].Value.Should().BeNull();
+    }
+
+    [Test]
+    public void Multiple_Copy_Destinations_Restore_Independently()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, "source");
+        sheet.Cells.SetValue(1, 0, "first");
+        sheet.Cells.SetValue(2, 0, "second");
+        sheet.Protection.Protect(new() { AllowFormatCells = true });
+        sheet.Commands.ExecuteCommand(new CopyRangeCommand(sheet.Range(0, 0),
+            new[] { sheet.Range(1, 0), sheet.Range(2, 0) }, new())).Should().BeTrue();
+        sheet.Commands.Undo().Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("first");
+        sheet.Cells[2, 0].Value.Should().Be("second");
+        sheet.Commands.Redo().Should().BeTrue();
+        sheet.Cells[1, 0].Value.Should().Be("source");
+        sheet.Cells[2, 0].Value.Should().Be("source");
+    }
+
+    [Test]
+    public void Dynamic_Autofill_In_A_Group_Is_Checked_Before_Any_Child_Mutates()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, "source");
+        sheet.Cells.SetValue(4, 0, "keep");
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = true });
+        sheet.Protection.Protect();
+        var changes = 0;
+        sheet.Cells.CellsChanged += (_, _) => changes++;
+        var group = new CommandGroup(new ClearCellsCommand(new Region(4, 0)),
+            new AutoFillCommand(new Region(0, 0), new Region(0, 1, 0, 0)));
+        sheet.Commands.ExecuteCommand(group).Should().BeFalse();
+        changes.Should().Be(0);
+        sheet.Cells[4, 0].Value.Should().Be("keep");
+    }
+
+    [Test]
+    public void Dynamic_Autofill_In_A_Group_Fills_From_The_Values_The_Group_Wrote()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Protection.Protect(new() { AllowFormatCells = true });
+        sheet.Commands.ExecuteCommand(new CommandGroup(
+            new SetCellValueCommand(0, 0, new CellValue(1)),
+            new SetCellValueCommand(1, 0, new CellValue(2)),
+            new AutoFillCommand(new Region(0, 1, 0, 0), new Region(0, 3, 0, 0)))).Should().BeTrue();
+        sheet.Cells[2, 0].Value.Should().Be(3);
+        sheet.Cells[3, 0].Value.Should().Be(4);
+    }
+
+    [Test]
+    public void Rejected_Autofill_Does_Not_Replay_Stale_Commands_Later()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, 1);
+        sheet.Cells.SetValue(1, 0, 2);
+        sheet.SetFormat(new Region(2, 3, 0, 0), new CellFormat { IsLocked = true });
+        sheet.Protection.Protect();
+
+        var fill = new AutoFillCommand(new Region(0, 1, 0, 0), new Region(0, 3, 0, 0));
+        sheet.Commands.ExecuteCommand(fill).Should().BeFalse();
+
+        sheet.Protection.Unprotect();
+        sheet.Cells.SetValue(0, 0, 10);
+        sheet.Cells.SetValue(1, 0, 20);
+        sheet.Commands.ExecuteCommand(fill).Should().BeTrue();
+        sheet.Cells[2, 0].Value.Should().Be(30);
+        sheet.Cells[3, 0].Value.Should().Be(40);
+    }
+
+    [Test]
+    public void Dynamic_Autofill_In_A_Group_Run_From_A_Handler_Is_Checked_Before_Any_Child_Mutates()
+    {
+        var sheet = UnlockedSheet();
+        sheet.Cells.SetValue(0, 0, "source");
+        sheet.Cells.SetValue(4, 0, "keep");
+        sheet.SetFormat(new Region(1, 0), new CellFormat { IsLocked = true });
+        sheet.Protection.Protect();
+
+        var changes = 0;
+        sheet.Cells.CellsChanged += (_, _) => changes++;
+
+        bool? groupResult = null;
+        var changesDuringGroup = 0;
+        EventHandler<CommandRunEventArgs>? handler = null;
+        handler = (_, _) =>
+        {
+            // run the group re-entrantly, from inside another command's execution
+            sheet.Commands.CommandRun -= handler;
+            var changesBefore = changes;
+            groupResult = sheet.Commands.ExecuteCommand(new CommandGroup(
+                new ClearCellsCommand(new Region(4, 0)),
+                new AutoFillCommand(new Region(0, 0), new Region(0, 1, 0, 0))));
+            changesDuringGroup = changes - changesBefore;
+        };
+        sheet.Commands.CommandRun += handler;
+
+        sheet.Cells.SetValue(3, 0, "trigger").Should().BeTrue();
+
+        groupResult.Should().BeFalse();
+        changesDuringGroup.Should().Be(0);
+        sheet.Cells[4, 0].Value.Should().Be("keep");
+    }
+
+    private sealed class CustomCommand : BaseCommand
+    {
+        protected override bool CanExecuteCore(Sheet sheet) => true;
+        protected override bool ExecuteCore(Sheet sheet) => true;
+    }
+}


### PR DESCRIPTION
#### Sheet Protection Management (Sheet.Protection) ####
- Added SheetProtection.cs API: Protect(options), Unprotect(), and RunUnprotected(action) for trusted
      programmatic updates.
- Added SheetProtectionOptions.cs to allow specific operations while protected (insert/delete rows and
      columns, formatting, sorting, filtering, and selecting locked cells).

#### Cell Locking (IsLocked) ####
- Added IsLocked property to CellFormat.cs (and row/column formats). Defaults to true, matching standard spreadsheet convention.
- Implemented sparse region checking (ContainsLocked) for efficient permission resolution without
      scanning cell-by-cell.
- Added serialization support for IsLocked in sheet models and JSON converters.

#### Selection Restrictions (AllowSelectLockedCells) ####

- Added ability to disallow selecting locked cells (AllowSelectLockedCells = false).
- Keyboard navigation (arrows, Tab, Enter) and mouse selections automatically skip over locked cells.
- Constrains or moves active selection to the first unlocked cell when protection is applied.